### PR TITLE
Card aliases

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -109,7 +109,7 @@ def cards_from_query(query):
     cards = [card for card in cards if card.type != 'Vanguard' and card.layout != 'token']
     # First look for an exact match.
     for card in cards:
-        if card.name.lower() == query:
+        if (card.name.lower() == query) or ((card.alias is not None) and (card.alias.lower() == query)):
             return [card]
     # If not found, use cards that start with the query and a punctuation char.
     results = [card for card in cards if card.name.lower().startswith('{query} '.format(query=query)) or card.name.lower().startswith('{query},'.format(query=query))]

--- a/card_aliases.tsv
+++ b/card_aliases.tsv
@@ -1,0 +1,28 @@
+﻿dandan	Dandân
+ghazban ogre	Ghazbán Ogre
+ifh-biff efreet	Ifh-Bíff Efreet
+ifh biff efreet	Ifh-Bíff Efreet
+junun efreet	Junún Efreet
+khabal ghoul	Khabál Ghoul
+legions of lim-dul	Legions of Lim-Dûl
+lim-dul the necromancer	Lim-Dûl the Necromancer
+lim-dul's vault	Lim-Dûl the Necromancer
+lim-dul's cohort	Lim-Dûl's Cohort
+lim-dul's hex	Lim-Dûl's Hex
+lim-dul's high guard	Lim-Dûl's High Guard
+lim-dul's paladin	Lim-Dûl's Paladin
+lim-dul's vault	Lim-Dûl's Vault
+oath of lim-dul	Oath of Lim-Dûl
+seance	Séance
+ring of ma'ruf	Ring of Ma'rûf
+ring of maruf	Ring of Ma'rûf
+bob	Dark Confidant
+jens	Solemn Simulacrum
+solum simulacrim	Solemn Simulacrum
+sad robot	Solemn Simulacrum
+mom	Mother of Runes
+tim	Prodigal Sorcerer
+gary	Gray Merchant of Asphodel
+finkel	Shadowmage Infiltrator
+kai	Voidmage Prodigy
+tiago	Snapcaster Mage

--- a/configuration.py
+++ b/configuration.py
@@ -2,7 +2,8 @@ import json
 
 DEFAULTS = {
     'database': './db',
-    'image_dir': '.'
+    'image_dir': '.',
+    'card_alias_file': './card_aliases.tsv'
 }
 
 def get(key):

--- a/database.py
+++ b/database.py
@@ -101,6 +101,12 @@ class Database:
             subtype TEXT NOT NULL,
             FOREIGN KEY(card_id) REFERENCES card(id)
         )""")
+        self.execute("""CREATE TABLE card_alias (
+            id INTEGER PRIMARY KEY,
+            card_id INTEGER NOT NULL,
+            alias TEXT NOT NULL,
+            FOREIGN KEY(card_id) REFERENCES card(id)
+        )""")
         self.execute("""CREATE TABLE IF NOT EXISTS rarity (
             id INTEGER PRIMARY KEY,
             name TEXT NOT NULL

--- a/emoji.py
+++ b/emoji.py
@@ -12,6 +12,8 @@ def find_emoji(emoji, channel):
 def replace_emoji(text, channel):
     if channel.is_private:
         return text
+    elif text is None:
+        return ''
     output = text
     symbols = re.findall(r'\{([A-Z0-9/]{1,3})\}', text)
     for symbol in symbols:

--- a/fetcher.py
+++ b/fetcher.py
@@ -1,3 +1,4 @@
+import csv
 import json
 import os
 import shutil
@@ -5,6 +6,8 @@ import urllib.request
 import zipfile
 
 import pkg_resources
+
+import configuration
 
 def legal_cards():
     return [s.lower() for s in fetch('http://pdmtgo.com/legal_cards.txt', 'latin-1').split('\n')]
@@ -30,6 +33,10 @@ def all_cards():
     shutil.rmtree('./ziptemp')
     return allcards_json
 
+def card_aliases():
+    with open(configuration.get('card_alias_file'), newline='', encoding='utf-8') as f:
+        return list(csv.reader(f, dialect='excel-tab'))
+      
 def fetch(url, character_encoding='utf-8'):
     print('Fetching {url}'.format(url=url))
     try:


### PR DESCRIPTION
Added support for card aliases, defined in card_aliases.tsv and inserted
into table card_alias.

Selecting with LEFT OUTER JOIN on card_alias is the easiest way to get the whole list of cards + aliases at once to subsequently filter in cards_from_query(). But if you'd prefer to keep oracle.search results as close to the original card records as possible, I can look into moving that part of the filtering code into oracle.search.
