### PR TITLE
Download and store set and printing information in db.

### DIFF
--- a/card.py
+++ b/card.py
@@ -9,22 +9,40 @@ def properties():
         'cmc': 'REAL',
         'type': 'TEXT',
         'text': 'TEXT',
-        'flavor': 'TEXT',
-        'artist': 'TEXT',
-        'number': 'TEXT',
         'power': 'TEXT',
         'toughness': 'TEXT',
         'loyalty': 'TEXT',
-        'multiverse_id': 'INTEGER',
         'image_name': 'TEXT',
-        'watermark': 'TEXT',
         'border': 'TEXT',
-        'timeshifted': 'INTEGER',
         'hand': 'INTEGER',
         'life': 'INTEGER',
+        'starter': 'INTEGER',
+    }
+
+def set_properties():
+    return {
+        'name': 'TEXT',
+        'code': 'TEXT',
+        'gatherer_code': 'TEXT',
+        'old_code': 'TEXT',
+        'magiccardsinfo_code': 'TEXT',
+        'release_date': 'INT',
+        'border': 'TEXT',
+        'type': 'TEXT',
+        'online_only': 'INT'
+    }
+
+def printing_properties():
+    return {
+        'rarity': 'TEXT',
+        'flavor': 'TEXT',
+        'artist': 'TEXT',
+        'number': 'TEXT',
+        'multiverseid': 'INTEGER',
+        'watermark': 'TEXT',
+        'timeshifted': 'INTEGER',
         'reserved': 'INTEGER',
         'release_date': 'INTEGER',
-        'starter': 'INTEGER',
         'mci_number': 'TEXT'
     }
 

--- a/database.py
+++ b/database.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 
 import pkg_resources
@@ -7,7 +8,7 @@ import configuration
 
 class Database:
     # Bump this if you modify the schema.
-    schema_version = 2
+    schema_version = 16
 
     @staticmethod
     def escape(s):
@@ -19,16 +20,19 @@ class Database:
         return "'{escaped}'".format(escaped=encodable.replace("'", "''"))
 
     def __init__(self):
-        db = configuration.get('database')
-        self.database = sqlite3.connect(db)
-        self.database.row_factory = sqlite3.Row
+        self.open()
         try:
             self.version()
             if self.db_version() < self.schema_version:
-                self.droptables()
+                self.delete()
                 self.setup()
         except sqlite3.OperationalError:
             self.setup()
+
+    def open(self):
+        db = configuration.get('database')
+        self.database = sqlite3.connect(db)
+        self.database.row_factory = sqlite3.Row
 
     def version(self):
         return pkg_resources.parse_version(self.value('SELECT version FROM version', [], '0'))
@@ -58,8 +62,8 @@ class Database:
         self.execute('CREATE TABLE IF NOT EXISTS db_version (version INTEGER)')
         self.execute('INSERT INTO db_version (version) VALUES ({0})'.format(self.schema_version))
         self.execute('CREATE TABLE IF NOT EXISTS version (version TEXT)')
-        sql = 'CREATE TABLE card (id INTEGER PRIMARY KEY, pd_legal INTEGER, '
-        sql += ', '.join(name + ' ' + type for name, type in card.properties().items())
+        sql = 'CREATE TABLE IF NOT EXISTS card (id INTEGER PRIMARY KEY, pd_legal INTEGER, '
+        sql += ', '.join('{name} {type}'.format(name=name, type=type) for name, type in card.properties().items())
         sql += ')'
         self.execute(sql)
         self.execute("""CREATE TABLE IF NOT EXISTS card_name (
@@ -68,6 +72,18 @@ class Database:
             name TEXT NOT NULL,
             FOREIGN KEY(card_id) REFERENCES card(id)
         )""")
+        sql = 'CREATE TABLE IF NOT EXISTS `set` (id INTEGER PRIMARY KEY, '
+        sql += ', '.join('{name} {type}'.format(name=name, type=type) for name, type in card.set_properties().items())
+        sql += ')'
+        self.execute(sql)
+        sql = 'CREATE TABLE IF NOT EXISTS printing ('
+        sql += 'id INTEGER PRIMARY KEY,'
+        sql += 'card_id INTEGER NOT NULL, '
+        sql += 'set_id INTEGER NOT NULL, '
+        sql += ', '.join('{name} {type}'.format(name=name, type=type) for name, type in card.printing_properties().items())
+        sql += ', FOREIGN KEY(card_id) REFERENCES card(id), '
+        sql += 'FOREIGN KEY(set_id) REFERENCES `set`(id))'
+        self.execute(sql)
         self.execute('CREATE TABLE IF NOT EXISTS color (id INTEGER PRIMARY KEY, name TEXT, symbol TEXT)')
         self.execute("""CREATE TABLE IF NOT EXISTS card_color (
             id INTEGER PRIMARY KEY,
@@ -119,26 +135,8 @@ class Database:
             ('Red', 'R'),
             ('Green', 'G')
         """)
-        self.execute('DELETE FROM rarity')
-        self.execute("""INSERT INTO rarity (name) VALUES
-            ('Common'),
-            ('Uncommon'),
-            ('Rare'),
-            ('Mythic Rare'),
-            ('Special')
-        """)
 
-    # Drop All Tables, so we can reinit
-    def droptables(self):
-        self.execute('DROP TABLE IF EXISTS card')
-        self.execute('DROP TABLE IF EXISTS card_alias')
-        self.execute('DROP TABLE IF EXISTS card_color')
-        self.execute('DROP TABLE IF EXISTS card_color_identity')
-        self.execute('DROP TABLE IF EXISTS card_name')
-        self.execute('DROP TABLE IF EXISTS card_subtype')
-        self.execute('DROP TABLE IF EXISTS card_supertype')
-        self.execute('DROP TABLE IF EXISTS card_type')
-        self.execute('DROP TABLE IF EXISTS color')
-        self.execute('DROP TABLE IF EXISTS rarity')
-        self.execute('DROP TABLE IF EXISTS version')
-        self.execute('DROP TABLE IF EXISTS db_version')
+    # Drop the database so we can recreate it.
+    def delete(self):
+        os.remove(configuration.get('database'))
+        self.open()

--- a/fetcher.py
+++ b/fetcher.py
@@ -22,21 +22,29 @@ def mtgo_status():
         return 'UNKNOWN'
 
 def all_cards():
+    s = unzip('https://mtgjson.com/json/AllCards.json.zip', 'AllCards.json')
+    return json.load(s)
+
+def all_sets():
+    s = unzip('https://mtgjson.com/json/AllSets.json.zip', 'AllSets.json')
+    return json.load(s)
+
+def unzip(url, path):
     if os.path.isdir('./ziptemp'):
         shutil.rmtree('./ziptemp')
     os.mkdir('./ziptemp')
-    store('https://mtgjson.com/json/AllCards.json.zip', './ziptemp/AllCards.json.zip')
-    allcards_zip = zipfile.ZipFile('./ziptemp/AllCards.json.zip', 'r')
-    allcards_zip.extractall('./ziptemp/unzip')
-    allcards_zip.close()
-    allcards_json = json.load(open('./ziptemp/unzip/AllCards.json', encoding='utf-8'))
+    store(url, './ziptemp/zip.zip')
+    f = zipfile.ZipFile('./ziptemp/zip.zip', 'r')
+    f.extractall('./ziptemp/unzip')
+    f.close()
+    s = open('./ziptemp/unzip/{path}'.format(path=path), encoding='utf-8')
     shutil.rmtree('./ziptemp')
-    return allcards_json
+    return s
 
 def card_aliases():
     with open(configuration.get('card_alias_file'), newline='', encoding='utf-8') as f:
         return list(csv.reader(f, dialect='excel-tab'))
-      
+
 def fetch(url, character_encoding='utf-8'):
     print('Fetching {url}'.format(url=url))
     try:

--- a/oracle.py
+++ b/oracle.py
@@ -11,6 +11,7 @@ class Oracle:
         return ['normal', 'meld', 'split', 'phenomenon', 'token', 'vanguard', 'double-faced', 'plane', 'flip', 'scheme', 'leveler']
 
     def __init__(self):
+        self.card_ids = {}
         self.database = database.Database()
         current_version = fetcher.version()
         if current_version > self.database.version():
@@ -32,11 +33,12 @@ class Oracle:
 
     def update_database(self, new_version):
         self.database.execute('DELETE FROM version')
-        self.database.execute('DELETE FROM card')
         cards = fetcher.all_cards()
         for name, c in cards.items():
-            self.insert_card(name, c)
-
+            self.insert_card(c)
+        sets = fetcher.all_sets()
+        for name, s in sets.items():
+            self.insert_set(s)
         self.database.database.commit()
         # mtgjson thinks that lands have a CMC of NULL so we'll work around that here.
         self.check_layouts() # Check that the hardcoded list of layouts we're about to use is still valid.
@@ -48,20 +50,21 @@ class Oracle:
                 self.database.execute('INSERT INTO card_alias (card_id, alias) VALUES (?, ?)', [card_id, alias])
             else:
                 print("no match for " + name)
-        
+
         self.database.execute('INSERT INTO version (version) VALUES (?)', [new_version])
 
-    def insert_card(self, name, c):
+    def insert_card(self, c):
         sql = 'INSERT INTO card ('
-        sql += ', '.join(property for property in card.properties())
+        sql += ', '.join(prop for prop in card.properties())
         sql += ') VALUES ('
         sql += ', '.join('?' for prop in card.properties())
         sql += ')'
-        values = [c.get(underscore2camel(property)) for property in card.properties()]
+        values = [c.get(underscore2camel(prop)) for prop in card.properties()]
         # self.database.execute commits after each statement, which we want to
         # avoid while inserting cards
         self.database.database.execute(sql, values)
         card_id = self.database.value('SELECT last_insert_rowid()')
+        self.card_ids[c.get('name')] = card_id
         for name in c.get('names', []):
             self.database.database.execute('INSERT INTO card_name (card_id, name) VALUES (?, ?)', [card_id, name])
         for color in c.get('colors', []):
@@ -74,6 +77,27 @@ class Oracle:
             self.database.database.execute('INSERT INTO card_supertype (card_id, supertype) VALUES (?, ?)', [card_id, supertype])
         for subtype in c.get('subtypes', []):
             self.database.database.execute('INSERT INTO card_subtype (card_id, subtype) VALUES (?, ?)', [card_id, subtype])
+
+    def insert_set(self, s):
+        sql = 'INSERT INTO `set` ('
+        sql += ', '.join(prop for prop in card.set_properties())
+        sql += ') VALUES ('
+        sql += ', '.join('?' for prop in card.set_properties())
+        sql += ')'
+        values = [s.get(underscore2camel(prop)) for prop in card.set_properties()]
+        # self.database.execute commits after each statement, which we want to
+        # avoid while inserting sets
+        self.database.database.execute(sql, values)
+        set_id = self.database.value('SELECT last_insert_rowid()')
+        for c in s.get('cards', []):
+            card_id = self.card_ids[c.get('name')]
+            sql = 'INSERT INTO printing (card_id, set_id, '
+            sql += ', '.join(prop for prop in card.printing_properties())
+            sql += ') VALUES (?, ?, '
+            sql += ', '.join('?' for prop in card.printing_properties())
+            sql += ')'
+            values = [card_id, set_id] + [c.get(underscore2camel(prop)) for prop in card.printing_properties()]
+            self.database.database.execute(sql, values)
 
     def check_layouts(self):
         rs = self.database.execute('SELECT DISTINCT layout FROM card')


### PR DESCRIPTION
Sets are MtG sets. Pretty straightforward. They go in the table `set`.
You'll always want backticks on that because SET is an SQL keyword but
they are so very definitely called sets that I used it anyway.

Printings are individual printings of cards. Effectively card+set.

I moved the properties that are not populated in AllCards.json (on a 'card')
but are populated in AllSets.json (on a 'printing') to printing.

I changed the teardown of the database from a bunch of DROP statements to
a simple delete of the file. That way you don't have to remember to add
a table to the list. That said if we ever want persistent data we'll either
have to use another sqlite db or reverse this decision.

Schema version bumped (a lot!)

I meddled with unzipping to make it generic as we now do it for two
different files.

We can now add search on the new fields like rarity and artist and fallback
images with multiverseid can now be made to work. That's upcoming.
