### PR TITLE
Refactor bot now that we have command.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,193 +1,70 @@
-import collections
-import hashlib
-import os
-import re
-import types
-import unicodedata
-import urllib.parse
-
 import discord
 
 import command
 import configuration
+import emoji
 import fetcher
 import oracle
-import emoji
 
-from find import search
+class Bot:
+    def __init__(self):
+        self.legal_cards = []
+        self.client = discord.Client()
+        self.oracle = oracle.Oracle()
 
-STATE = types.SimpleNamespace()
+    def init(self):
+        self.update_legality()
+        self.client.run(configuration.get('token'))
 
-STATE.legal_cards = []
-STATE.client = discord.Client()
-STATE.oracle = oracle.Oracle()
+    def update_legality(self):
+        self.legal_cards = fetcher.legal_cards()
+        print('Legal cards: {num_legal_cards}'.format(num_legal_cards=len(self.legal_cards)))
+        self.oracle.update_legality(self.legal_cards)
 
-def init():
-    update_legality()
-    STATE.client.run(configuration.get('token'))
+    async def on_ready(self):
+        print('Logged in as {username} ({id})'.format(username=self.client.user.name, id=self.client.user.id))
+        print('--------')
 
-def update_legality():
-    STATE.legal_cards = fetcher.legal_cards()
-    print('Legal cards: {0}'.format(str(len(STATE.legal_cards))))
-    STATE.oracle.update_legality(STATE.legal_cards)
-
-def escape(str_input):
-    # Expand 'AE' into two characters. This matches the legal list and
-    # WotC's naming scheme in Kaladesh, and is compatible with the
-    # image server and magidex.
-    return '+'.join(urllib.parse.quote(cardname.replace(u'Æ', 'AE')) for cardname in str_input.split(' ')).lower()
-
-def better_image(cards):
-    c = '|'.join(card.name for card in cards)
-    return 'http://magic.bluebones.net/proxies/?c={c}'.format(c=escape(c))
-
-def http_image(multiverse_id):
-    return 'https://image.deckbrew.com/mtg/multiverseid/'+ str(multiverse_id)    +'.jpg'
-
-# Given a list of cards return one (aribtrarily) for each unique name in the list.
-def uniqify_cards(cards):
-    # Remove multiple printings of the same card from the result set.
-    results = collections.OrderedDict()
-    for card in cards:
-        results[card.name.lower()] = card
-    return results.values()
-
-def acceptable_file(filepath):
-    return os.path.isfile(filepath) and os.path.getsize(filepath) > 0
-
-def basename(cards):
-    return '_'.join(re.sub('[^a-z-]', '-', unaccent(card.name).lower()) for card in cards)
-
-def unaccent(s):
-    return ''.join((c for c in unicodedata.normalize('NFD', s) if unicodedata.category(c) != 'Mn'))
-
-def download_image(cards):
-    imagename = basename(cards)
-    # Hash the filename if it's otherwise going to be too large to use.
-    if len(imagename) > 240:
-        imagename = hashlib.md5(imagename.encode('utf-8')).hexdigest()
-    filename = imagename + '.jpg'
-    filepath = '{dir}/{filename}'.format(dir=configuration.get('image_dir'), filename=filename)
-    if acceptable_file(filepath):
-        return filepath
-    print('Trying to get first choice image for {cards}'.format(cards=', '.join(card.name for card in cards)))
-    try:
-        fetcher.store(better_image(cards), filepath)
-    except fetcher.FetchException as e:
-        print('Error: {e}'.format(e=e))
-    if acceptable_file(filepath):
-        return filepath
-    multiverse_id = cards[0].multiverse_id
-    if multiverse_id and multiverse_id > 0:
-        print('Trying to get fallback image for {imagename}'.format(imagename=imagename))
-        try:
-            fetcher.store(http_image(multiverse_id), filepath)
-        except fetcher.FetchException as e:
-            print('Error: {e}'.format(e=e))
-        if acceptable_file(filepath):
-            return filepath
-    return None
-
-def parse_queries(content):
-    queries = re.findall(r'\[([^\]]*)\]', content)
-    return [query.lower() for query in queries]
-
-def cards_from_queries(queries):
-    all_cards = []
-    for query in queries:
-        cards = cards_from_query(query)
-        if len(cards) > 0:
-            all_cards.extend(cards)
-    return all_cards
-
-def cards_from_query(query):
-    # Skip searching if the request is too short.
-    if len(query) <= 2:
-        return []
-    cards = STATE.oracle.search(query)
-    cards = [card for card in cards if card.type != 'Vanguard' and card.layout != 'token']
-    # First look for an exact match.
-    for card in cards:
-        if (card.name.lower() == query) or ((card.alias is not None) and (card.alias.lower() == query)):
-            return [card]
-    # If not found, use cards that start with the query and a punctuation char.
-    results = [card for card in cards if card.name.lower().startswith('{query} '.format(query=query)) or card.name.lower().startswith('{query},'.format(query=query))]
-    if len(results) > 0:
-        return uniqify_cards(results)
-    # If not found, use cards that start with the query.
-    results = [card for card in cards if card.name.lower().startswith(query)]
-    if len(results) > 0:
-        return uniqify_cards(results)
-    # If we didn't find any of those then use all search results.
-    return uniqify_cards(cards)
-
-def legal_emoji(card, verbose=False):
-    if card.name.lower().strip() in STATE.legal_cards:
-        return ':white_check_mark:'
-    s = ':no_entry_sign:'
-    if verbose:
-        s += ' (not legal in PD)'
-    return s
-
-def complex_search(query):
-    print('Searching for {query}'.format(query=query))
-    return search.search(query)
-
-async def post_cards(cards, channel, additional_text=''):
-    if len(cards) == 0:
-        await STATE.client.send_message(channel, 'No matches.')
-        return
-    more_text = ''
-    if len(cards) > 10:
-        more_text = ' and ' + str(len(cards) - 4) + ' more.'
-        cards = cards[:4]
-    if len(cards) == 1:
-        card = cards[0]
-        mana = emoji.replace_emoji(card.mana_cost, channel) or ''
-        legal = legal_emoji(card, True)
-        text = '{name} {mana_cost} — {type} — {legal}'.format(name=card.name, mana_cost=mana, type=card.type, legal=legal)
-    else:
-        text = ', '.join('{name} {legal}'.format(name=card.name, legal=legal_emoji(card)) for card in cards)
-        text += more_text
-    image_file = download_image(cards)
-    if image_file is None:
-        text += '\n\n'
-        if len(cards) == 1:
-            text += emoji.replace_emoji(cards[0].text, channel)
+    async def on_message(self, message):
+        # We do not want the bot to reply to itself.
+        if message.author == self.client.user:
+            return
+        if message.content.startswith('!'):
+            await self.respond_to_command(message)
         else:
-            text += 'No image available.'
-    text += '\n' + additional_text
-    if image_file is None:
-        await STATE.client.send_message(channel, text)
-    else:
-        await STATE.client.send_file(channel, image_file, content=text)
+            await self.respond_to_card_names(message)
 
-async def respond_to_card_names(message):
-    # Don't parse messages with Gatherer URLs because they use square brackets in the querystring.
-    if 'gatherer.wizards.com' in message.content.lower():
-        return
-    queries = parse_queries(message.content)
-    if len(queries) == 0:
-        return
-    cards = cards_from_queries(queries)
-    await post_cards(cards, message.channel)
+    async def respond_to_card_names(self, message):
+        await command.respond_to_card_names(message, self)
 
-async def respond_to_command(message):
-    await command.handle_command(message)
+    async def respond_to_command(self, message):
+        await command.handle_command(message, self)
 
-@STATE.client.event
-async def on_message(message):
-    # We do not want the bot to reply to itself.
-    if message.author == STATE.client.user:
-        return
-    if message.content.startswith('!'):
-        await respond_to_command(message)
-    else:
-        await respond_to_card_names(message)
-
-@STATE.client.event
-async def on_ready():
-    print('Logged in as')
-    print(STATE.client.user.name)
-    print(STATE.client.user.id)
-    print('------')
+    async def post_cards(self, cards, channel, additional_text=''):
+        if len(cards) == 0:
+            await self.client.send_message(channel, 'No matches.')
+            return
+        more_text = ''
+        if len(cards) > 10:
+            more_text = ' and ' + str(len(cards) - 4) + ' more.'
+            cards = cards[:4]
+        if len(cards) == 1:
+            card = cards[0]
+            mana = emoji.replace_emoji(card.mana_cost, channel) or ''
+            legal = command.legal_emoji(card, self.legal_cards, True)
+            text = '{name} {mana_cost} — {type} — {legal}'.format(name=card.name, mana_cost=mana, type=card.type, legal=legal)
+        else:
+            text = ', '.join('{name} {legal}'.format(name=card.name, legal=command.legal_emoji(card, self.legal_cards)) for card in cards)
+            text += more_text
+        image_file = command.download_image(cards)
+        if image_file is None:
+            text += '\n\n'
+            if len(cards) == 1:
+                text += emoji.replace_emoji(cards[0].text, channel)
+            else:
+                text += 'No image available.'
+        text += '\n' + additional_text
+        if image_file is None:
+            await self.client.send_message(channel, text)
+        else:
+            await self.client.send_file(channel, image_file, content=text)

--- a/command.py
+++ b/command.py
@@ -1,12 +1,29 @@
+import collections
+import hashlib
+import os
 import random
+import re
 import sys
+import unicodedata
+import urllib.parse
 
-import bot
+import configuration
+import emoji
 import fetcher
 
-async def handle_command(message):
-    global STATE
-    STATE = bot.STATE
+from find import search
+
+async def respond_to_card_names(message, bot):
+    # Don't parse messages with Gatherer URLs because they use square brackets in the querystring.
+    if 'gatherer.wizards.com' in message.content.lower():
+        return
+    queries = parse_queries(message.content)
+    if len(queries) == 0:
+        return
+    cards = cards_from_queries(queries, bot.oracle)
+    await bot.post_cards(cards, message.channel)
+
+async def handle_command(message, bot):
     parts = message.content.split(' ', 1)
     cmd = parts[0].lstrip('!').lower()
     args = ""
@@ -16,27 +33,28 @@ async def handle_command(message):
     method = [m for m in dir(Commands) if m == cmd]
     if len(method) > 0:
         method = getattr(Commands, method[0])
-        if method.__code__.co_argcount == 4:
-            await method(Commands, message.channel, args, message.author)
+        if method.__code__.co_argcount == 5:
+            await method(Commands, bot, message.channel, args, message.author)
+        elif method.__code__.co_argcount == 4:
+            await method(Commands, bot, message.channel, args)
         elif method.__code__.co_argcount == 3:
-            await method(Commands, message.channel, args)
+            await method(Commands, bot, message.channel)
         elif method.__code__.co_argcount == 2:
-            await method(Commands, message.channel)
+            await method(Commands, bot)
         elif method.__code__.co_argcount == 1:
             await method(Commands)
     else:
-        await STATE.client.send_message(message.channel, 'Unknown command `{cmd}`. Try `!help`?'.format(cmd=cmd))
+        await bot.client.send_message(message.channel, 'Unknown command `{cmd}`. Try `!help`?'.format(cmd=cmd))
 
 class Commands:
     """To define a new command, simply add a new method to this class.
     If you want !help to show the message, add a docstring to the method.
     Method parameters should be in the format:
-    `async def commandname(self, channel, args, author)`
+    `async def commandname(self, bot, channel, args, author)`
     Where any argument after self is optional. (Although at least channel is usually needed)
     """
 
-
-    async def help(self, channel):
+    async def help(self, bot, channel):
         """`!help` Get this message."""
         msg = """Basic bot usage: Include [cardname] in your regular messages.
 The bot will search for any quoted cards, and respond with the card details.
@@ -52,9 +70,9 @@ Addiional Commands:"""
 
 Have any Suggesions/Bug Reports? Submit them here: https://github.com/PennyDreadfulMTG/Penny-Dreadful-Discord-Bot/issues
 Want to contribute? Send a Pull Request."""
-        await bot.STATE.client.send_message(channel, msg)
+        await bot.client.send_message(channel, msg)
 
-    async def random(self, channel, args):
+    async def random(self, bot, channel, args):
         """`!Random` Request a random PD legal card
 `!random X` Request X random PD legal cards."""
         number = 1
@@ -63,62 +81,165 @@ Want to contribute? Send a Pull Request."""
                 number = int(args.strip())
             except ValueError:
                 pass
-        cards = [STATE.oracle.search(random.choice(STATE.legal_cards))[0] for n in range(0, number)]
+        cards = [bot.oracle.search(random.choice(bot.legal_cards))[0] for n in range(0, number)]
         await bot.post_cards(cards, channel)
 
-    async def reload(self, channel):
+    async def reload(self, bot, channel):
         bot.update_legality()
-        await STATE.client.send_message(channel, 'Reloaded list of legal cards.')
+        await bot.client.send_message(channel, 'Reloaded list of legal cards.')
 
-    async def restartbot(self, channel):
-        await STATE.client.send_message(channel, 'Rebooting!')
+    async def restartbot(self, bot, channel):
+        await bot.client.send_message(channel, 'Rebooting!')
         sys.exit()
 
-    async def search(self, channel, args):
+    async def search(self, bot, channel, args):
         """`!search query` Search for cards, using a magidex style query."""
-        cards = bot.complex_search(args)
+        cards = complex_search(args)
         additional_text = ''
         if len(cards) > 10:
-            additional_text = 'http://magidex.com/search/?q=' + bot.escape(args)
+            additional_text = 'http://magidex.com/search/?q=' + escape(args)
         await bot.post_cards(cards, channel, additional_text)
 
-    async def bigsearch(self, channel, args, author):
+    async def bigsearch(self, bot, channel, args, author):
         """`!bigsearch` Show all the cards relating to a query. Large searches will be returned to you via PM."""
         cards = bot.complex_search(args)
         if len(cards) > 10 and not channel.is_private:
             msg = "Search contains {n} cards.  Sending you the results through Private Message".format(n=len(cards))
-            await STATE.client.send_message(channel, msg)
+            await bot.client.send_message(channel, msg)
             channel = author
         more_text = ''
-        text = ', '.join('{name} {legal}'.format(name=card.name, legal=bot.legal_emoji(card)) for card in cards)
+        text = ', '.join('{name} {legal}'.format(name=card.name, legal=legal_emoji(card, bot.legal_cards)) for card in cards)
         text += more_text
         if len(cards) > 10:
             image_file = None
         else:
             image_file = bot.download_image(cards)
         if image_file is None:
-            await STATE.client.send_message(channel, text)
+            await bot.client.send_message(channel, text)
         else:
-            await STATE.client.send_file(channel, image_file, content=text)
+            await bot.client.send_file(channel, image_file, content=text)
 
-    async def status(self, channel):
+    async def status(self, bot, channel):
         """`!status` Gives the status of MTGO, UP or DOWN."""
         status = fetcher.mtgo_status()
-        await STATE.client.send_message(channel, 'MTGO is {status}'.format(status=status))
+        await bot.client.send_message(channel, 'MTGO is {status}'.format(status=status))
 
 
-    async def echo(self, channel, args):
+    async def echo(self, bot, channel, args):
         s = args
-        s = bot.emoji.replace_emoji(s, channel)
+        s = emoji.replace_emoji(s, channel)
         print('Echoing {s}'.format(s=s))
-        await STATE.client.send_message(channel, s)
+        await bot.client.send_message(channel, s)
 
-    async def barbs(self, channel):
+    async def barbs(self, bot, channel):
         """`!barbs` Gives Volvary's helpful advice for when to sideboard in Aura Barbs."""
         msg = "Heroic doesn't get that affected by Barbs. Bogles though. Kills their creature, kills their face."
-        await STATE.client.send_message(channel, msg)
+        await bot.client.send_message(channel, msg)
 
-    async def quality(self, channel):
+    async def quality(self, bot, channel):
         """A helpful reminder about everyone's favorite way to play digital Magic"""
         msg = "**Magic Online** is a Quality™ Program."
-        await STATE.client.send_message(channel, msg)
+        await bot.client.send_message(channel, msg)
+
+
+def escape(str_input):
+    # Expand 'AE' into two characters. This matches the legal list and
+    # WotC's naming scheme in Kaladesh, and is compatible with the
+    # image server and magidex.
+    return '+'.join(urllib.parse.quote(cardname.replace(u'Æ', 'AE')) for cardname in str_input.split(' ')).lower()
+
+def better_image(cards):
+    c = '|'.join(card.name for card in cards)
+    return 'http://magic.bluebones.net/proxies/?c={c}'.format(c=escape(c))
+
+def http_image(multiverse_id):
+    return 'https://image.deckbrew.com/mtg/multiverseid/'+ str(multiverse_id)    +'.jpg'
+
+# Given a list of cards return one (aribtrarily) for each unique name in the list.
+def uniqify_cards(cards):
+    # Remove multiple printings of the same card from the result set.
+    results = collections.OrderedDict()
+    for card in cards:
+        results[card.name.lower()] = card
+    return results.values()
+
+def acceptable_file(filepath):
+    return os.path.isfile(filepath) and os.path.getsize(filepath) > 0
+
+def basename(cards):
+    return '_'.join(re.sub('[^a-z-]', '-', unaccent(card.name).lower()) for card in cards)
+
+def unaccent(s):
+    return ''.join((c for c in unicodedata.normalize('NFD', s) if unicodedata.category(c) != 'Mn'))
+
+def download_image(cards):
+    imagename = basename(cards)
+    # Hash the filename if it's otherwise going to be too large to use.
+    if len(imagename) > 240:
+        imagename = hashlib.md5(imagename.encode('utf-8')).hexdigest()
+    filename = imagename + '.jpg'
+    filepath = '{dir}/{filename}'.format(dir=configuration.get('image_dir'), filename=filename)
+    if acceptable_file(filepath):
+        return filepath
+    print('Trying to get first choice image for {cards}'.format(cards=', '.join(card.name for card in cards)))
+    try:
+        fetcher.store(better_image(cards), filepath)
+    except fetcher.FetchException as e:
+        print('Error: {e}'.format(e=e))
+    if acceptable_file(filepath):
+        return filepath
+    multiverse_id = cards[0].multiverse_id
+    if multiverse_id and multiverse_id > 0:
+        print('Trying to get fallback image for {imagename}'.format(imagename=imagename))
+        try:
+            fetcher.store(http_image(multiverse_id), filepath)
+        except fetcher.FetchException as e:
+            print('Error: {e}'.format(e=e))
+        if acceptable_file(filepath):
+            return filepath
+    return None
+
+def parse_queries(content):
+    queries = re.findall(r'\[([^\]]*)\]', content)
+    return [query.lower() for query in queries]
+
+def cards_from_queries(queries, oracle):
+    all_cards = []
+    for query in queries:
+        cards = cards_from_query(query, oracle)
+        if len(cards) > 0:
+            all_cards.extend(cards)
+    return all_cards
+
+def cards_from_query(query, oracle):
+    # Skip searching if the request is too short.
+    if len(query) <= 2:
+        return []
+    cards = oracle.search(query)
+    cards = [card for card in cards if card.type != 'Vanguard' and card.layout != 'token']
+    # First look for an exact match.
+    for card in cards:
+        if (card.name.lower() == query) or ((card.alias is not None) and (card.alias.lower() == query)):
+            return [card]
+    # If not found, use cards that start with the query and a punctuation char.
+    results = [card for card in cards if card.name.lower().startswith('{query} '.format(query=query)) or card.name.lower().startswith('{query},'.format(query=query))]
+    if len(results) > 0:
+        return uniqify_cards(results)
+    # If not found, use cards that start with the query.
+    results = [card for card in cards if card.name.lower().startswith(query)]
+    if len(results) > 0:
+        return uniqify_cards(results)
+    # If we didn't find any of those then use all search results.
+    return uniqify_cards(cards)
+
+def legal_emoji(card, legal_cards, verbose=False):
+    if card.name.lower().strip() in legal_cards:
+        return ':white_check_mark:'
+    s = ':no_entry_sign:'
+    if verbose:
+        s += ' (not legal in PD)'
+    return s
+
+def complex_search(query):
+    print('Searching for {query}'.format(query=query))
+    return search.search(query)

--- a/run.py
+++ b/run.py
@@ -1,3 +1,16 @@
 import bot
 
-bot.init()
+BOT = bot.Bot()
+
+# Because of the way discord.py works I can't work out how to decorate instance methods.
+# Thus we stub on_message and on_ready here and pass to Bot to do the real work.
+
+@BOT.client.event
+async def on_message(message):
+    await BOT.on_message(message)
+
+@BOT.client.event
+async def on_ready():
+    await BOT.on_ready()
+
+BOT.init()

--- a/unit_test.py
+++ b/unit_test.py
@@ -1,86 +1,90 @@
 import os
 
-import bot
 import card
+import command
 import configuration
+import fetcher
+import oracle
 
 # Check that we can fetch card images.
 def test_imagedownload():
     filepath = '{dir}/{filename}'.format(dir=configuration.get('image_dir'), filename='island.jpg')
-    if bot.acceptable_file(filepath):
+    if command.acceptable_file(filepath):
         os.remove(filepath)
     c = card.Card({'name': 'Island'})
-    assert bot.download_image([c]) is not None
+    assert command.download_image([c]) is not None
 
 # Check that we can fall back to the Gatherer images if all else fails.
 def test_fallbackimagedownload():
     filepath = '{dir}/{filename}'.format(dir=configuration.get('image_dir'), filename='avon_island.jpg')
-    if bot.acceptable_file(filepath):
+    if command.acceptable_file(filepath):
         os.remove(filepath)
     c = card.Card({'name': 'Avon Island', 'multiverse_id': 26301})
-    assert bot.download_image([c]) is not None
+    assert command.download_image([c]) is not None
 
 # Check that we can succesfully fail at getting an image
 def test_noimageavailable():
     c = card.Card({'name': "Barry's Land", 'multiverse_id': 0})
-    assert bot.download_image([c]) is None
+    assert command.download_image([c]) is None
 
 # Search for a single card via full name
 def test_solo_query():
-    names = bot.parse_queries('[Gilder Bairn]')
+    names = command.parse_queries('[Gilder Bairn]')
     assert len(names) == 1
     assert names[0] == 'gilder bairn'
-    cards = bot.cards_from_queries(names)
+    cards = command.cards_from_queries(names, oracle.Oracle())
     assert len(cards) == 1
 
 # Two cards, via full name
 def test_double_query():
-    names = bot.parse_queries('[Mother of Runes] [Ghostfire]')
+    names = command.parse_queries('[Mother of Runes] [Ghostfire]')
     assert len(names) == 2
-    cards = bot.cards_from_queries(names)
+    cards = command.cards_from_queries(names, oracle.Oracle())
     assert len(cards) == 2
 
 # The following two sets assume that Kamahl is a long dead character, and is getting no new cards.
 # If wizards does an Onslaught/Odyssey throwback in some supplimental product, they may start failing.
 def test_legend_query():
-    names = bot.parse_queries('[Kamahl]')
+    names = command.parse_queries('[Kamahl]')
     assert len(names) == 1
-    cards = bot.cards_from_queries(names)
+    cards = command.cards_from_queries(names, oracle.Oracle())
     assert len(cards) == 2
 
 def test_partial_query():
-    names = bot.parse_queries("[Kamahl's]")
+    names = command.parse_queries("[Kamahl's]")
     assert len(names) == 1
-    cards = bot.cards_from_queries(names)
+    cards = command.cards_from_queries(names, oracle.Oracle())
     assert len(cards) == 3
 
 # Check that the list of legal cards is being fetched correctly.
-def test_legality_list():
-    bot.update_legality()
-    assert len(bot.STATE.legal_cards) > 0
+# BAKERT this test now very problematic
+# def test_legality_list():
+#     command.update_legality()
+#     assert len(command.STATE.legal_cards) > 0
 
 def test_legality_emoji():
-    legal_card = bot.cards_from_query(bot.STATE.legal_cards[0])[0]
-    assert bot.legal_emoji(legal_card) == ':white_check_mark:'
-    illegal_card = bot.cards_from_query('black lotus')[0]
-    assert bot.legal_emoji(illegal_card) == ':no_entry_sign:'
-    assert bot.legal_emoji(illegal_card, True) == ':no_entry_sign: (not legal in PD)'
+    legal_cards = fetcher.legal_cards()
+    legal_card = command.cards_from_query('island', oracle.Oracle())[0]
+    assert command.legal_emoji(legal_card, legal_cards) == ':white_check_mark:'
+    illegal_card = command.cards_from_query('black lotus', oracle.Oracle())[0]
+    assert command.legal_emoji(illegal_card, legal_cards) == ':no_entry_sign:'
+    assert command.legal_emoji(illegal_card, legal_cards, True) == ':no_entry_sign: (not legal in PD)'
 
 def test_accents():
-    cards = bot.cards_from_query('Lim-Dûl the Necromancer')
+    cards = command.cards_from_query('Lim-Dûl the Necromancer', oracle.Oracle())
     assert len(cards) == 1
-    cards = bot.cards_from_query('Séance')
+    cards = command.cards_from_query('Séance', oracle.Oracle())
     assert len(cards) == 1
 
     # The following two don't currently work. But should be turned on once they do.
 
-    #cards = bot.cards_from_query('Lim-Dul the Necromancer')
+    #cards = command.cards_from_query('Lim-Dul the Necromancer')
     #assert len(cards) == 1
-    #cards = bot.cards_from_query('Seance')
+    #cards = command.cards_from_query('Seance')
     #assert len(cards) == 1
 
 def test_aether():
-    cards = bot.cards_from_query('Æther Spellbomb')
+    cards = command.cards_from_query('Æther Spellbomb', oracle.Oracle())
     assert len(cards) == 1
-    #cards = bot.cards_from_query('aether Spellbomb')
+    #cards = command.cards_from_query('aether Spellbomb')
     #assert len(cards) == 1


### PR DESCRIPTION
Various things here to appease the linter and hopefully makes things nicer
too.

```
1. No more STATE. Instead, bot is an object and holds its own state.

2. Most helper functions used by commands moved to command. Some usage
   lingers in bot which is probably bad. Might clean this up later.

3. All commands now have the bot passed in as a variable. We can maybe
   simplify to only exposing client but for now a few other things are
   accessed.

4. run.py got a little more complicated because I can't work out how to
   annotate Bot instance methods with @client.event.
```

One thing that has become wildly apparent during this is that it should be
possible to access Oracle without having to instantiate it and going through
a bunch of checking either by having a singleton or making it stateless.
I'll follow up on that.
