### PR TITLE
Make ci: work the same as ci! as it does on magidex and magiccards.

### DIFF
--- a/find/find_test.py
+++ b/find/find_test.py
@@ -13,16 +13,19 @@ def test_multicolored():
     do_test('c:bm', '((id IN (SELECT card_id FROM card_color WHERE color_id = 3)) AND (id IN (SELECT card_id FROM card_color GROUP BY card_id HAVING COUNT(card_id) > 1)))')
 
 def test_multicolored_coloridentity():
-    do_test('ci:bm', '((id IN (SELECT card_id FROM card_color_identity WHERE color_id = 3)) AND (id IN (SELECT card_id FROM card_color_identity GROUP BY card_id HAVING COUNT(card_id) > 1)))')
+    do_test('ci:bm', '(((id IN (SELECT card_id FROM card_color_identity WHERE color_id = 3)) AND (id NOT IN (SELECT card_id FROM card_color_identity WHERE color_id <> 3))) AND (id IN (SELECT card_id FROM card_color_identity GROUP BY card_id HAVING COUNT(card_id) > 1)))')
+
+def test_exclusivemulitcolored_same():
+    do_test('ci!bm', '(((id IN (SELECT card_id FROM card_color_identity WHERE color_id = 3)) AND (id NOT IN (SELECT card_id FROM card_color_identity WHERE color_id <> 3))) AND (id IN (SELECT card_id FROM card_color_identity GROUP BY card_id HAVING COUNT(card_id) > 1)))')
 
 def test_mulitcolored_multiple():
-    do_test('c:brm', '(((id IN (SELECT card_id FROM card_color WHERE color_id = 3)) OR (id IN (SELECT card_id FROM card_color WHERE color_id = 4))) AND (id IN (SELECT card_id FROM card_color GROUP BY card_id HAVING COUNT(card_id) > 1)))')
+    do_test('c:brm', "(((id IN (SELECT card_id FROM card_color WHERE color_id = 3)) OR (id IN (SELECT card_id FROM card_color WHERE color_id = 4))) AND (id IN (SELECT card_id FROM card_color GROUP BY card_id HAVING COUNT(card_id) > 1)))")
 
 def test_multicolored_exclusive():
     do_test('c!brm', "((((id IN (SELECT card_id FROM card_color WHERE color_id = 3)) OR (id IN (SELECT card_id FROM card_color WHERE color_id = 4))) AND (id NOT IN (SELECT card_id FROM card_color WHERE color_id <> 3 AND color_id <> 4))) AND (id IN (SELECT card_id FROM card_color GROUP BY card_id HAVING COUNT(card_id) > 1)))")
 
 def test_color_identity():
-    do_test('ci:u', '(id IN (SELECT card_id FROM card_color_identity WHERE color_id = 2))')
+    do_test('ci:u', '((id IN (SELECT card_id FROM card_color_identity WHERE color_id = 2)) AND (id NOT IN (SELECT card_id FROM card_color_identity WHERE color_id <> 2)))')
 
 def test_color_identity_colorless():
     do_test('ci:c', '(id NOT IN (SELECT card_id FROM card_color_identity))')

--- a/find/search.py
+++ b/find/search.py
@@ -191,6 +191,8 @@ def math_where(column, operator, term):
     return "({column} IS NOT NULL AND {column} <> '' AND CAST({column} AS REAL) {operator} {term})".format(column=column, operator=operator, term=database.escape(term))
 
 def color_where(subtable, operator, term):
+    if operator == ':' and subtable == 'color_identity':
+        operator = '!' # "includes color x" doesn't really make sense in a color identity query and this matches magidex/magiccards behavior.
     colors = list(term)
     try:
         colors.remove('m')


### PR DESCRIPTION
This is inconsistent with the behavior of c: but it's more useful and matches
the card sites.
