### PR TITLE
Add a name_ascii column to card for a diacritic-ignoring search.

### DIFF
--- a/command.py
+++ b/command.py
@@ -10,6 +10,7 @@ import urllib.parse
 from typing import List
 
 import configuration
+import database
 import emoji
 import fetcher
 from card import Card
@@ -221,10 +222,7 @@ def acceptable_file(filepath: str) -> bool:
     return os.path.isfile(filepath) and os.path.getsize(filepath) > 0
 
 def basename(cards):
-    return '_'.join(re.sub('[^a-z-]', '-', unaccent(card.name).lower()) for card in cards)
-
-def unaccent(s):
-    return ''.join((c for c in unicodedata.normalize('NFD', s) if unicodedata.category(c) != 'Mn'))
+    return '_'.join(re.sub('[^a-z-]', '-', database.unaccent(card.name).lower()) for card in cards)
 
 def download_image(cards: List[Card]) -> str:
     imagename = basename(cards)

--- a/find/find_test.py
+++ b/find/find_test.py
@@ -91,16 +91,16 @@ def test_color():
     do_test('c:g', '(id IN (SELECT card_id FROM card_color WHERE color_id = 5))')
 
 def test_or():
-    do_test('a OR b', "(name LIKE '%a%' OR type LIKE '%a%' OR text LIKE '%a%') OR (name LIKE '%b%' OR type LIKE '%b%' OR text LIKE '%b%')")
+    do_test('a OR b', "(name_ascii LIKE '%a%' OR type LIKE '%a%' OR text LIKE '%a%') OR (name_ascii LIKE '%b%' OR type LIKE '%b%' OR text LIKE '%b%')")
 
 def test_text():
     do_test('o:"target attacking"', "(text LIKE '%target attacking%')")
 
 def test_name():
-    do_test('tension turtle', "(name LIKE '%tension%' OR type LIKE '%tension%' OR text LIKE '%tension%') AND (name LIKE '%turtle%' OR type LIKE '%turtle%' OR text LIKE '%turtle%')")
+    do_test('tension turtle', "(name_ascii LIKE '%tension%' OR type LIKE '%tension%' OR text LIKE '%tension%') AND (name_ascii LIKE '%turtle%' OR type LIKE '%turtle%' OR text LIKE '%turtle%')")
 
 def test_parentheses():
-    do_test('x OR (a OR (b AND c))', "(name LIKE '%x%' OR type LIKE '%x%' OR text LIKE '%x%') OR ((name LIKE '%a%' OR type LIKE '%a%' OR text LIKE '%a%') OR ((name LIKE '%b%' OR type LIKE '%b%' OR text LIKE '%b%') AND (name LIKE '%c%' OR type LIKE '%c%' OR text LIKE '%c%')))")
+    do_test('x OR (a OR (b AND c))', "(name_ascii LIKE '%x%' OR type LIKE '%x%' OR text LIKE '%x%') OR ((name_ascii LIKE '%a%' OR type LIKE '%a%' OR text LIKE '%a%') OR ((name_ascii LIKE '%b%' OR type LIKE '%b%' OR text LIKE '%b%') AND (name_ascii LIKE '%c%' OR type LIKE '%c%' OR text LIKE '%c%')))")
 
 def test_toughness():
     do_test('c:r tou>2', "(id IN (SELECT card_id FROM card_color WHERE color_id = 4)) AND (toughness IS NOT NULL AND toughness <> '' AND CAST(toughness AS REAL) > 2)")

--- a/find/search.py
+++ b/find/search.py
@@ -161,6 +161,9 @@ def where(keys, term, exact_match=False):
     subsequent = False
     s = '('
     for column in keys:
+        if column == 'name':
+            column = 'name_ascii'
+            q = database.unaccent(q)
         if subsequent:
             s += ' OR '
         s += '{column} LIKE {q}'.format(column=column, q=database.escape(q))
@@ -220,7 +223,7 @@ def set_where(name):
 def format_where(term):
     if term in ['pennydreadful', 'pd']:
         return '(pd_legal = 1)'
-    format_id = database.DATABASE.value('SELECT id FROM format WHERE name LIKE ?', ['{term}%'.format(term=term)])
+    format_id = database.DATABASE.value('SELECT id FROM format WHERE name LIKE ?', ['{term}%'.format(term=database.unaccent(term))])
     return "(id IN (SELECT card_id FROM card_legality WHERE format_id = {format_id} AND legality <> 'Banned'))".format(format_id=format_id)
 
 def rarity_where(operator, term):

--- a/oracle.py
+++ b/oracle.py
@@ -83,10 +83,12 @@ def update_fuzzy_matching():
 def insert_card(c):
     sql = 'INSERT INTO card ('
     sql += ', '.join(prop for prop in card.properties())
+    sql += ', name_ascii'
     sql += ') VALUES ('
     sql += ', '.join('?' for prop in card.properties())
+    sql += ', ?'
     sql += ')'
-    values = [c.get(database2json(prop)) for prop in card.properties()]
+    values = [c.get(database2json(prop)) for prop in card.properties()] + [command.unaccent(c.get('name'))]
     # database.execute commits after each statement, which we want to
     # avoid while inserting cards
     DATABASE.database.execute(sql, values)


### PR DESCRIPTION
We can't use COLLATE NOACCENT because LIKE clauses ignore collation.

Fixes #175.
