### PR TITLE
Make the results and announcement links work on signup and report.

### DIFF
--- a/decksite/data/competition.py
+++ b/decksite/data/competition.py
@@ -31,7 +31,7 @@ def load_competition(competition_id):
 
 def load_competitions(where_clause='1 = 1'):
     sql = """
-        SELECT c.id, c.name, c.start_date, c.end_date,
+        SELECT c.id, c.name, c.start_date, c.end_date, c.url,
         COUNT(d.id) AS num_decks
         FROM competition AS c
         INNER JOIN deck AS d ON c.id = d.competition_id

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -6,7 +6,7 @@ from magic import legality
 from shared import dtutil
 from shared.pd_exception import InvalidDataException
 
-from decksite.data import deck, guarantee
+from decksite.data import competition, deck, guarantee
 from decksite.database import db
 from decksite.scrapers import decklist
 
@@ -111,12 +111,8 @@ def active_competition_id_query():
     return "SELECT id FROM competition WHERE start_date < {now} AND end_date > {now} AND competition_type_id = (SELECT id FROM competition_type WHERE name = 'League')".format(now=dtutil.dt2ts(dtutil.now()))
 
 def active_league():
-    sql = """
-        SELECT id, name, start_date, end_date
-        FROM competition
-        WHERE id = ({active_competition_id_query})
-    """.format(active_competition_id_query=active_competition_id_query())
-    return guarantee.exactly_one(db().execute(sql))
+    where_clause = 'c.id = ({id_query})'.format(id_query=active_competition_id_query())
+    return guarantee.exactly_one(competition.load_competitions(where_clause))
 
 def insert_match(params):
     match_id = db().insert("INSERT INTO match (`date`) VALUES (strftime('%s', 'now'))")

--- a/decksite/templates/competitions.mustache
+++ b/decksite/templates/competitions.mustache
@@ -10,9 +10,9 @@
         <tbody>
                 {{#competitions}}
                 <tr>
-                    <td><a href="{{url}}">{{{name}}}</a></td>
-                    <td class="n"><a href="{{url}}">{{{num_decks}}}</a></td>
-                    <td class="n" data-text="{{date_sort}}"><a href="{{url}}">{{{display_date}}}</a></td>
+                    <td><a href="{{competition_url}}">{{{name}}}</a></td>
+                    <td class="n"><a href="{{competition_url}}">{{{num_decks}}}</a></td>
+                    <td class="n" data-text="{{date_sort}}"><a href="{{competition_url}}">{{{display_date}}}</a></td>
                 </tr>
             {{/competitions}}
         </tbody>

--- a/decksite/templates/league_header.mustache
+++ b/decksite/templates/league_header.mustache
@@ -1,3 +1,3 @@
 <p><a href="{{league.url}}">League Announcement</a></p>
-<p><a href="{{competition_url}}">League Results</a></p>
+<p><a href="{{league.competition_url}}">League Results</a></p>
 

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -98,7 +98,7 @@ class View:
 
     def prepare_competitions(self):
         for c in getattr(self, 'competitions', []):
-            c.url = url_for('competition', competition_id=c.id)
+            c.competition_url = url_for('competition', competition_id=c.id)
             c.display_date = dtutil.display_date(c.start_date)
             c.date_sort = dtutil.dt2ts(c.start_date)
 

--- a/decksite/views/__init__.py
+++ b/decksite/views/__init__.py
@@ -7,6 +7,7 @@ from .competitions import Competitions
 from .deck import Deck
 from .home import Home
 from .internal_server_error import InternalServerError
+from .league_form import LeagueForm
 from .not_found import NotFound
 from .people import People
 from .person import Person

--- a/decksite/views/league_form.py
+++ b/decksite/views/league_form.py
@@ -1,0 +1,9 @@
+from decksite import league
+from decksite.view import View
+
+# pylint: disable=no-self-use
+class LeagueForm(View):
+    def __init__(self, form):
+        self.form = form
+        self.league = league.active_league()
+        self.competitions = [self.league]

--- a/decksite/views/report.py
+++ b/decksite/views/report.py
@@ -1,11 +1,6 @@
-from decksite import league
-from decksite.view import View
+from decksite.views import LeagueForm
 
 # pylint: disable=no-self-use
-class Report(View):
-    def __init__(self, form):
-        self.form = form
-        self.league = league.active_league()
-
+class Report(LeagueForm):
     def subtitle(self):
         return '{league} Result Report'.format(league=self.league['name'])

--- a/decksite/views/signup.py
+++ b/decksite/views/signup.py
@@ -1,11 +1,6 @@
-from decksite import league
-from decksite.view import View
+from decksite.views import LeagueForm
 
 # pylint: disable=no-self-use
-class SignUp(View):
-    def __init__(self, form):
-        self.form = form
-        self.league = league.active_league()
-
+class SignUp(LeagueForm):
     def subtitle(self):
         return '{league} Sign Up'.format(league=self.league['name'])


### PR DESCRIPTION
Fixes #568.

Standardize on 'competition_url' for our page and 'url' for the source.