### PR TITLE
Hash decklists

### DIFF
--- a/card_aliases.tsv
+++ b/card_aliases.tsv
@@ -22,3 +22,4 @@ skittles	Skithiryx, the Blight Dragon
 goyf	Tarmogoyf
 hot potato	Measure of Wickedness
 superman	Morphling
+prime time	Primeval Titan

--- a/decksite/data/query.py
+++ b/decksite/data/query.py
@@ -1,2 +1,2 @@
 def person_query(table='p'):
-    return 'IFNULL(IFNULL({table}.name, LOWER({table}.mtgo_username)), LOWER({table}.tappedout_username))'.format(table=table)
+    return 'LOWER(IFNULL(IFNULL({table}.name, {table}.mtgo_username), {table}.tappedout_username))'.format(table=table)

--- a/decksite/database.py
+++ b/decksite/database.py
@@ -9,7 +9,9 @@ def db():
 def setup():
     db().execute('CREATE TABLE IF NOT EXISTS db_version (version INTEGER UNIQUE ON CONFLICT REPLACE NOT NULL)')
     version = db_version()
-    for fn in os.listdir('decksite/sql'):
+    patches = os.listdir('decksite/sql')
+    patches.sort(key=lambda n: int(n.split('.')[0]))
+    for fn in patches:
         path = os.path.join('decksite/sql', fn)
         n = int(fn.split('.')[0])
         if version < n:

--- a/decksite/maintenance/deck_hash.py
+++ b/decksite/maintenance/deck_hash.py
@@ -1,0 +1,13 @@
+import hashlib
+
+from decksite.data import deck
+from decksite.database import db
+
+
+def run():
+    all_decks = deck.load_decks()
+    for d in all_decks:
+        # Recalculate all hashes, in case they've changed.  Or we've changed the default sort order.
+        cards = {'maindeck': d['maindeck'], 'sideboard': d['sideboard']}
+        deckhash = hashlib.sha1(repr(cards).encode('utf-8')).hexdigest()
+        db().execute("UPDATE deck SET decklist_hash = ? WHERE id = ?", [deckhash, d['id']])

--- a/decksite/sql/6.sql
+++ b/decksite/sql/6.sql
@@ -1,0 +1,3 @@
+ALTER TABLE deck ADD COLUMN decklist_hash TEXT;
+CREATE INDEX deck_hash ON deck (decklist_hash);
+CREATE INDEX generate_name ON person (IFNULL(IFNULL(name, mtgo_username), tappedout_username));

--- a/decksite/templates/deck.mustache
+++ b/decksite/templates/deck.mustache
@@ -4,18 +4,31 @@
         {{> section}}
     {{/sections}}
 </section>
-{{#competition_id}}
+{{#has_record}}
     <section>
         <h2>Competition</h2>
-        <a href="{{competition_url}}">
-            {{stars}}
-            {{competition_name}}
-            {{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}
-            {{#finish}}{{finish}}/{{players}}{{/finish}}
-            {{top8}}
-        </a>
+        {{#competition_id}}
+            <ul><a href="{{competition_url}}">
+                {{stars}}
+                {{competition_name}}
+                (Piloted by {{person}})
+                {{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}
+                {{top8}}
+            </a></ul>
+        {{/competition_id}}
+        {{#twins}}
+            {{#competition_id}}
+                <ul><a href="{{competition_url}}">
+                    {{stars}}
+                    {{competition_name}}
+                    (Piloted by {{person}})
+                    {{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}
+                    {{top8}}
+                </a></ul>
+            {{/competition_id}}
+        {{/twins}}
     </section>
-{{/competition_id}}
+{{/has_record}}
 <section>
     <h2>Notes</h2>
     <p>Source: <a href="{{source_url}}">{{source_name}}</a></p>

--- a/decksite/templates/deck.mustache
+++ b/decksite/templates/deck.mustache
@@ -7,26 +7,28 @@
 {{#has_record}}
     <section>
         <h2>Competition</h2>
-        {{#competition_id}}
-            <ul><a href="{{competition_url}}">
-                {{stars}}
-                {{competition_name}}
-                (Piloted by {{person}})
-                {{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}
-                {{top8}}
-            </a></ul>
-        {{/competition_id}}
-        {{#twins}}
+        <table style="width: 40em">
             {{#competition_id}}
-                <ul><a href="{{competition_url}}">
-                    {{stars}}
+                <tr><td class="marginalia">{{stars}}</td>
+                <td style="width: {{row_len}};"><a href="{{competition_url}}">
                     {{competition_name}}
                     (Piloted by {{person}})
                     {{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}
                     {{top8}}
-                </a></ul>
+                </a></td></tr>
             {{/competition_id}}
-        {{/twins}}
+            {{#twins}}
+                {{#competition_id}}
+                    <tr><td class="marginalia">{{stars}}</td>
+                    <td><a href="{{competition_url}}">
+                        {{competition_name}}
+                        (Piloted by {{person}})
+                        {{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}
+                        {{top8}}
+                    </a></td></tr>
+                {{/competition_id}}
+            {{/twins}}
+        </table>
     </section>
 {{/has_record}}
 <section>

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -65,27 +65,36 @@ class View:
 
     def prepare_decks(self):
         for d in getattr(self, 'decks', []):
-            set_stars_and_top8(d)
+            self.prepare_deck(d)
+
+    def prepare_deck(self, d):
+        set_stars_and_top8(d)
+        if d.get('colors', None):
+            # This is a twin - There's probably a neater way to do this.
             d.colors_safe = colors_html(d.colors, d.colored_symbols)
             d.name = deck_name.normalize(d)
-            d.person_url = url_for('person', person_id=d.person_id)
-            d.date_sort = dtutil.dt2ts(d.date)
-            d.display_date = dtutil.display_date(d.date)
-            d.show_record = d.wins or d.losses or d.draws
-            d.players = d.players if d.players > 0 else ''
-            if d.competition_id:
-                d.competition_url = url_for('competition', competition_id=d.competition_id)
-            d.url = url_for('decks', deck_id=d.id)
-            d.export_url = url_for('export', deck_id=d.id)
-            if d.source_name == 'League':
-                d.source_indicator = 'League'
-                if d.wins + d.losses < 5 and d.competition_end_date > dtutil.now():
-                    d.stars = '⊕ {stars}'.format(stars=d.stars).strip()
-                    d.source_sort = '1'
-            elif d.source_name == 'Gatherling':
-                d.source_indicator = 'Gatherling'
-            elif d.source_name == 'Tapped Out':
-                d.source_indicator = 'Tapped Out'
+        d.person_url = url_for('person', person_id=d.person_id)
+        d.date_sort = dtutil.dt2ts(d.date)
+        d.display_date = dtutil.display_date(d.date)
+        d.show_record = d.wins or d.losses or d.draws
+        d.players = d.players if d.players > 0 else ''
+        if d.competition_id:
+            d.competition_url = url_for('competition', competition_id=d.competition_id)
+        d.url = url_for('decks', deck_id=d.id)
+        d.export_url = url_for('export', deck_id=d.id)
+        if d.source_name == 'League':
+            d.source_indicator = 'League'
+            if d.wins + d.losses < 5 and d.competition_end_date > dtutil.now():
+                d.stars = '⊕ {stars}'.format(stars=d.stars).strip()
+                d.source_sort = '1'
+        elif d.source_name == 'Gatherling':
+            d.source_indicator = 'Gatherling'
+        elif d.source_name == 'Tapped Out':
+            d.source_indicator = 'Tapped Out'
+        d.comp_row_len = len("{comp_name} (Piloted by {person}".format(comp_name=d.competition_name, person=d.person))
+        if d.get('twins', None):
+            for t in d.twins:
+                self.prepare_deck(t)
 
     def prepare_cards(self):
         cards = getattr(self, 'cards', [])

--- a/shared/dtutil.py
+++ b/shared/dtutil.py
@@ -35,9 +35,9 @@ def now():
 def display_date(dt, granularity=1):
     start = now()
     if (start - dt) > datetime.timedelta(365):
-        return '{:%b %-d, %Y}'.format(dt.astimezone(WOTC_TZ))
+        return '{:%b %d, %Y}'.format(dt.astimezone(WOTC_TZ))
     if (start - dt) > datetime.timedelta(28):
-        return '{:%b %-d}'.format(dt.astimezone(WOTC_TZ))
+        return '{:%b %d}'.format(dt.astimezone(WOTC_TZ))
     else:
         diff = start - dt
         return '{duration} ago'.format(duration=display_time(diff.total_seconds(), granularity))


### PR DESCRIPTION
We now:
- hash decklists
- can update the contents of a tappedout decklist.  (It turns out that we were previously just dropping them. Fixes #293)