### PR TITLE
Handle colorless when ordering mana symbols (by ignoring it).

### DIFF
--- a/discordbot/README.md
+++ b/discordbot/README.md
@@ -40,8 +40,6 @@ The bot will search for any quoted cards, and respond with the card details.
 
            `!resources {section} {link}` Link to Penny Dreadful resource.
 
-
-
 `!rhinos` Anything can be a rhino if you try hard enough
 
 `!rotation` Give the date of the next Penny Dreadful rotation.

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -284,8 +284,7 @@ class Commands:
     async def resources(self, bot, channel, args):
         """`!resources` Link to page of all Penny Dreadful resources.
            `!resources {section}` Link to Penny Dreadful resources section.
-           `!resources {section} {link}` Link to Penny Dreadful resource.
-        """
+           `!resources {section} {link}` Link to Penny Dreadful resource."""
         args = args.split()
         results = {}
         if len(args) > 0:

--- a/magic/mana.py
+++ b/magic/mana.py
@@ -115,6 +115,7 @@ def order(symbols):
     return list(sorted(permutations, key=order_score)[0])
 
 def order_score(symbols):
+    symbols = [symbol for symbol in symbols if symbol != 'C']
     if not symbols:
         return 0
     score = 0

--- a/magic/mana_test.py
+++ b/magic/mana_test.py
@@ -77,6 +77,9 @@ def test_order():
     assert mana.order(['G', 'R', 'B']) == ['B', 'R', 'G']
     assert mana.order(['W', 'G', 'R', 'B']) == ['B', 'R', 'G', 'W']
 
+def test_colorless():
+    assert mana.colored_symbols(['C']) == {'required': ['C'], 'also': []}
+
 def do_test(s, expected):
     symbols = mana.parse(s)
     assert symbols == expected or print('\nInput: {s}\nExpected: {expected}\n  Actual: {actual}'.format(s=s, expected=expected, actual=symbols))


### PR DESCRIPTION
It might be better to give it a high value so it sorts last.