### PR TITLE
Some simple response caching.

### DIFF
--- a/decksite/cache.py
+++ b/decksite/cache.py
@@ -1,0 +1,78 @@
+import binascii
+import datetime
+import functools
+import os
+
+from flask import request, make_response
+from werkzeug.contrib.cache import SimpleCache
+
+CACHE = SimpleCache()
+
+def cached():
+    return cached_impl(cacheable=True, must_revalidate=True, client_only=False, client_timeout=1 * 60 * 60, server_timeout=5 * 60)
+
+# pylint: disable=too-many-arguments
+def cached_impl(cacheable=False, must_revalidate=True, client_only=True, client_timeout=0, server_timeout=5 * 60, key='view%s'):
+    """
+
+    @see https://jakearchibald.com/2016/caching-best-practices/
+        https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching
+    """
+    def decorator(f):
+        @functools.wraps(f)
+        def decorated_function(*args, **kwargs):
+            cache_key = key % request.full_path # include querystring
+            cache_policy = ''
+            if not cacheable:
+                cache_policy += ', no-store' # tells the browser not to cache at all
+            else:
+                if must_revalidate: # this looks contradicting if you haven't read the article.
+                    # no-cache doesn't mean "don't cache", it means it must check
+                    # (or "revalidate" as it calls it) with the server before
+                    # using the cached resource
+                    cache_policy += ', no-cache'
+                else:
+                    # Also must-revalidate doesn't mean "must revalidate", it
+                    # means the local resource can be used if it's younger than
+                    # the provided max-age, otherwise it must revalidate
+                    cache_policy += ', must-revalidate'
+
+                if client_only:
+                    cache_policy += ', private'
+                else:
+                    cache_policy += ', public'
+
+                cache_policy += ', max-age=%d' % (client_timeout)
+
+            headers = {}
+            cache_policy = cache_policy.strip(',')
+            headers['Cache-Control'] = cache_policy
+            now = datetime.datetime.utcnow()
+
+            client_etag = request.headers.get('If-None-Match')
+
+            response = CACHE.get(cache_key)
+            # respect the hard-refresh
+            if response is not None and request.headers.get('Cache-Control', '') != 'no-cache':
+                headers['X-Cache'] = 'HIT from Server'
+                cached_etag = response.headers.get('ETag')
+                if client_etag and cached_etag and client_etag == cached_etag:
+                    headers['X-Cache'] = 'HIT from Client'
+                    headers['X-Last-Modified'] = response.headers.get('X-LastModified')
+                    response = make_response('', 304)
+            else:
+                response = make_response(f(*args, **kwargs))
+                if response.status_code == 200 and request.method in ['GET', 'HEAD']:
+                    headers['X-Cache'] = 'MISS'
+                    # - Added the headers to the response object instead of the
+                    # headers dict so they get cached too
+                    # - If you can find any faster random algorithm go for it.
+                    response.headers.add('ETag', binascii.hexlify(os.urandom(4)))
+                    response.headers.add('X-Last-Modified', str(now))
+                    print(cache_key)
+                    CACHE.set(cache_key, response, timeout=server_timeout)
+
+            response.headers.extend(headers)
+            return response
+        return decorated_function
+    return decorator

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -9,6 +9,7 @@ from shared.pd_exception import DoesNotExistException, InvalidDataException
 
 from decksite import league as lg
 from decksite import APP
+from decksite.cache import cached
 from decksite.data import card as cs, competition as comp, deck, person as ps
 from decksite.charts import chart
 from decksite.league import ReportForm, SignUpForm
@@ -17,21 +18,25 @@ from decksite.views import About, AddForm, Card, Cards, Competition, Competition
 # Decks
 
 @APP.route('/')
+@cached()
 def home():
     view = Home(deck.latest_decks())
     return view.page()
 
 @APP.route('/decks/<deck_id>/')
+@cached()
 def decks(deck_id):
     view = Deck(deck.load_deck(deck_id))
     return view.page()
 
 @APP.route('/people/')
+@cached()
 def people():
     view = People(ps.load_people())
     return view.page()
 
 @APP.route('/people/<person_id>/')
+@cached()
 def person(person_id):
     try:
         p = ps.load_person(person_id)
@@ -41,21 +46,25 @@ def person(person_id):
     return view.page()
 
 @APP.route('/cards/')
+@cached()
 def cards():
     view = Cards(cs.played_cards())
     return view.page()
 
 @APP.route('/cards/<name>/')
+@cached()
 def card(name):
     view = Card(cs.load_card(name))
     return view.page()
 
 @APP.route('/competitions/')
+@cached()
 def competitions():
     view = Competitions(comp.load_competitions())
     return view.page()
 
 @APP.route('/competitions/<competition_id>/')
+@cached()
 def competition(competition_id):
     view = Competition(comp.load_competition(competition_id))
     return view.page()
@@ -66,6 +75,7 @@ def add_form():
     return view.page()
 
 @APP.route('/add/', methods=['POST'])
+@cached()
 def add_deck():
     url = request.form['url']
     print(url)
@@ -85,6 +95,7 @@ def add_deck():
     return redirect(url_for('decks', deck_id=deck_id))
 
 @APP.route('/about/')
+@cached()
 def about():
     view = About()
     return view.page()
@@ -96,6 +107,7 @@ def export(deck_id):
     return (str(d), 200, {'Content-type': 'text/plain; charset=utf-8', 'Content-Disposition': 'attachment; filename={name}.txt'.format(name=safe_name)})
 
 @APP.route('/resources/')
+@cached()
 def resources():
     view = Resources()
     return view.page()
@@ -115,6 +127,7 @@ def signup(form=None):
     return view.page()
 
 @APP.route('/signup/', methods=['POST'])
+@cached()
 def add_signup():
     form = SignUpForm(request.form)
     if form.validate():


### PR DESCRIPTION
This makes subsequent request for the same path+querystring very fast.

But it does nothing for the first request.

Fairly conservative with times for now - we can maybe cache more aggressively.

A client hard-refresh will always be respected.

Not caching some things either because they are inexpensive, binary objects,
or need to be very up-to-date.