### PR TITLE
Don't update bugged cards every time we load multiverse

### DIFF
--- a/decksite/scrapers/bugged_cards.py
+++ b/decksite/scrapers/bugged_cards.py
@@ -1,0 +1,4 @@
+from magic import multiverse
+
+def scrape():
+    multiverse.update_bugged_cards()

--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -12,6 +12,7 @@ class Bot:
 
     def init(self):
         multiverse.set_legal_cards()
+        multiverse.update_bugged_cards()
         self.client.run(configuration.get('token'))
 
     async def on_ready(self):

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -14,7 +14,6 @@ def init():
         print('Database update required')
         update_database(str(current_version))
         set_legal_cards()
-    update_bugged_cards()
 
 def layouts():
     return ['normal', 'meld', 'split', 'phenomenon', 'token', 'vanguard', 'double-faced', 'plane', 'flip', 'scheme', 'leveler', 'aftermath']


### PR DESCRIPTION
This should prevent the database lock we observed earlier by switching the buglist scraper from running every time the class is loaded to being a scraper task.