### PR TITLE
Improve the handling and display of archetypes and archetype detail page.

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -44,7 +44,7 @@ def load_archetypes(where_clause='1 = 1', merge=False):
     archetypes = list(archetypes.values())
     return archetypes
 
-def load_archetypes_without_decks(where='1 = 1', order_by='`season.num_decks` DESC, `all.num_decks` DESC, `season.wins` DESC, `all.wins` DESC'):
+def load_archetypes_deckless(where='1 = 1', order_by='`season.num_decks` DESC, `all.num_decks` DESC, `season.wins` DESC, `all.wins` DESC'):
     sql = """
         SELECT
             a.id,
@@ -78,8 +78,8 @@ def load_archetypes_without_decks(where='1 = 1', order_by='`season.num_decks` DE
         a.parent = archetypes_by_id.get(a.parent_id, None)
     return archetypes
 
-def load_archetypes_without_decks_with_root(archetype_id):
-    archetypes = load_archetypes_without_decks()
+def load_archetypes_deckless_for(archetype_id):
+    archetypes = load_archetypes_deckless()
     for a in archetypes:
         if int(a.id) == int(archetype_id):
             return list(a.ancestors) + [a] + list(a.descendants)

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -1,3 +1,5 @@
+from anytree import NodeMixin
+
 from magic import rotation
 from shared.container import Container
 from shared.database import sqlescape
@@ -10,13 +12,12 @@ def load_archetype(archetype_id):
     archetypes = load_archetypes('d.archetype_id IN (SELECT descendant FROM archetype_closure WHERE ancestor = {archetype_id})'.format(archetype_id=sqlescape(archetype_id)), True)
     if len(archetypes) > 1:
         raise TooManyItemsException('Found {n} archetypes when expecting 1 at most'.format(n=len(archetypes)))
-    archetype = archetypes[0] if len(archetypes) == 1 else Container()
+    archetype = archetypes[0] if len(archetypes) == 1 else Archetype()
     # Because load_archetypes loads the root archetype and all below merged the id and name might not be those of the root archetype. Overwrite.
     archetype.id = int(archetype_id)
     archetype.name = db().value('SELECT name FROM archetype WHERE id = ?', [archetype_id])
     if len(archetypes) == 0:
         archetype.decks = []
-        archetype.tree = load_tree(archetype)
     return archetype
 
 def load_archetypes(where_clause='1 = 1', merge=False):
@@ -26,12 +27,12 @@ def load_archetypes(where_clause='1 = 1', merge=False):
         if d.archetype_id is None:
             continue
         key = 'merge' if merge else d.archetype_id
-        archetype = archetypes.get(key, Container())
+        archetype = archetypes.get(key, Archetype())
         archetype.id = d.archetype_id
         archetype.name = d.archetype_name
         archetype.decks = archetype.get('decks', []) + [d]
-        archetype.all = archetype.get('all', Container())
-        archetype.season = archetype.all.get('season', Container())
+        archetype.all = archetype.get('all', Archetype())
+        archetype.season = archetype.all.get('season', Archetype())
         archetype.all.wins = archetype.all.get('wins', 0) + (d.get('wins') or 0)
         archetype.all.losses = archetype.all.get('losses', 0) + (d.get('losses') or 0)
         archetype.all.draws = archetype.all.get('draws', 0) + (d.get('draws') or 0)
@@ -41,15 +42,14 @@ def load_archetypes(where_clause='1 = 1', merge=False):
             archetype.season.draws = archetype.season.get('draws', 0) + (d.get('draws') or 0)
         archetypes[key] = archetype
     archetypes = list(archetypes.values())
-    for a in archetypes:
-        a.tree = load_tree(a)
     return archetypes
 
-def load_archetypes_without_decks(where='1 = 1'):
+def load_archetypes_without_decks(where='1 = 1', order_by='`season.num_decks` DESC, `all.num_decks` DESC, `season.wins` DESC, `all.wins` DESC'):
     sql = """
         SELECT
             a.id,
             a.name,
+            aca.ancestor AS parent_id,
 
             COUNT(DISTINCT d.id) AS `all.num_decks`,
             SUM(d.wins) AS `all.wins`,
@@ -64,44 +64,25 @@ def load_archetypes_without_decks(where='1 = 1'):
             IFNULL(ROUND((SUM(CASE WHEN d.created_date >= %s THEN wins ELSE 0 END) / SUM(CASE WHEN d.created_date >= %s THEN wins ELSE 0 END + CASE WHEN d.created_date >= %s THEN losses ELSE 0 END)) * 100, 1), '') AS `season.win_percent`
 
         FROM archetype AS a
-        LEFT JOIN archetype_closure AS ac ON a.id = ac.ancestor
-        LEFT JOIN deck AS d ON ac.descendant = d.archetype_id
+        LEFT JOIN archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1
+        LEFT JOIN archetype_closure AS acd ON a.id = acd.ancestor
+        LEFT JOIN deck AS d ON acd.descendant = d.archetype_id
         WHERE {where}
         GROUP BY a.id
-        ORDER BY a.name
-    """.format(where=where)
-    archetypes = [Container(a) for a in db().execute(sql, [rotation.last_rotation().timestamp()] * 7)]
+        ORDER BY {order_by}
+    """.format(where=where, order_by=order_by)
+    archetypes = [Archetype(a) for a in db().execute(sql, [rotation.last_rotation().timestamp()] * 7)]
+    archetypes_by_id = {a.id: a for a in archetypes}
     for a in archetypes:
         a.decks = []
-        a.tree = load_tree(a)
+        a.parent = archetypes_by_id.get(a.parent_id, None)
     return archetypes
 
-def load_tree(archetype):
-    sql = """
-        SELECT a.id, a.name, -ac.depth AS pos, p.ancestor AS parent
-        FROM archetype AS a
-        LEFT JOIN archetype_closure AS ac ON a.id = ac.ancestor
-        LEFT JOIN archetype_closure AS p ON a.id = p.descendant AND p.depth = 1
-        WHERE ac.descendant = ?
-        UNION
-        SELECT a.id, a.name, ac.depth AS pos, p.ancestor AS parent
-        FROM archetype AS a
-        LEFT JOIN archetype_closure AS ac ON a.id = ac.descendant
-        LEFT JOIN archetype_closure AS p ON a.id = p.descendant AND p.depth = 1
-        WHERE ac.ancestor = ?
-        ORDER BY pos
-        """
-    rs = db().execute(sql, [archetype.id] * 2)
-    nodes = {}
-    for row in rs:
-        nodes[row['id']] = row
-    for row in rs:
-        if row.get('parent') is not None:
-            nodes[row['parent']]['children'] = nodes[row['parent']].get('children', []) + [row]
-        else:
-            root = nodes[row['id']]
-    archetype.is_root = nodes[archetype.id].get('parent') is None
-    return root
+def load_archetypes_without_decks_with_root(archetype_id):
+    archetypes = load_archetypes_without_decks()
+    for a in archetypes:
+        if int(a.id) == int(archetype_id):
+            return list(a.ancestors) + [a] + list(a.descendants)
 
 def add(name, parent):
     archetype_id = db().insert('INSERT INTO archetype (name) VALUES (?)', [name])
@@ -114,3 +95,6 @@ def add(name, parent):
 
 def assign(deck_id, archetype_id):
     return db().execute('UPDATE deck SET archetype_id = ? WHERE id = ?', [archetype_id, deck_id])
+
+class Archetype(Container, NodeMixin):
+    pass

--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -56,6 +56,12 @@ def normalize(d):
     name = ucase_trailing_roman_numerals(name)
     return titlecase.titlecase(name)
 
+def file_name(d):
+    safe_name = normalize(d).replace(' ', '-')
+    safe_name = re.sub('--+', '-', safe_name, flags=re.IGNORECASE)
+    safe_name = re.sub('[^0-9a-z-]', '', safe_name, flags=re.IGNORECASE)
+    return safe_name.strip('-')
+
 def remove_pd(name):
     name = re.sub(r'(^| )[\[\(]?pdh?[\]\)]?( |$)', '', name, flags=re.IGNORECASE).strip()
     name = re.sub(r'(^| )[\[\(]?penny ?dreadful[\[\(]?( |$)', '', name, flags=re.IGNORECASE).strip()

--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -53,6 +53,7 @@ def normalize(d):
         name = d.archetype
     if removed_colors or name == '':
         name = prepend_colors(name, d.colors)
+    name = ucase_trailing_roman_numerals(name)
     return titlecase.titlecase(name)
 
 def remove_pd(name):
@@ -88,3 +89,9 @@ def name_from_colors(colors, s=''):
                 return 'mono {name}'.format(name=name)
             return name
     return 'colorless'
+
+def ucase_trailing_roman_numerals(name):
+    last_word = name.split()[-1]
+    if re.search('^[ivx]+$', last_word):
+        name = re.sub('{last_word}$'.format(last_word=last_word), last_word.upper(), name)
+    return name

--- a/decksite/deck_name_test.py
+++ b/decksite/deck_name_test.py
@@ -66,6 +66,11 @@ def test_normalize():
     d.colors = ['R']
     d.name = 'RDW23'
     assert deck_name.normalize(d) == 'Red Deck Wins23'
+    d.colors = ['B']
+    d.name = 'Mono B Aristocrats III'
+    assert deck_name.normalize(d) == 'Mono Black Aristocrats III'
+    d.name = 'Mono B Aristocrats VI'
+    assert deck_name.normalize(d) == 'Mono Black Aristocrats VI'
 
     # Undefined cases
     # d.name = 'U/B Aggro' when d.archetype = 'Control'

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -1,5 +1,4 @@
 import os
-import re
 import traceback
 
 from flask import make_response, redirect, request, send_file, send_from_directory, url_for
@@ -7,7 +6,7 @@ from werkzeug import exceptions
 
 from shared.pd_exception import DoesNotExistException, InvalidDataException
 
-from decksite import league as lg
+from decksite import deck_name, league as lg
 from decksite import APP
 from decksite.cache import cached
 from decksite.data import archetype as archs, card as cs, competition as comp, deck, person as ps
@@ -126,7 +125,7 @@ def rotation():
 @APP.route('/export/<deck_id>/')
 def export(deck_id):
     d = deck.load_deck(deck_id)
-    safe_name = re.sub('[^0-9a-z-]', '-', d.name, flags=re.IGNORECASE)
+    safe_name = deck_name.file_name(d)
     return (str(d), 200, {'Content-type': 'text/plain; charset=utf-8', 'Content-Disposition': 'attachment; filename={name}.txt'.format(name=safe_name)})
 
 @APP.route('/resources/')

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -78,7 +78,7 @@ def archetypes():
 @APP.route('/archetypes/<archetype_id>/')
 @cached()
 def archetype(archetype_id):
-    view = Archetype(archs.load_archetype(archetype_id))
+    view = Archetype(archs.load_archetype(archetype_id), archs.load_archetypes_without_decks_with_root(archetype_id))
     return view.page()
 
 @APP.route('/tournaments/')
@@ -197,7 +197,7 @@ def deckcycle_tappedout():
 
 @APP.route('/admin/archetypes/')
 def edit_archetypes():
-    view = EditArchetypes(archs.load_archetypes_without_decks(), deck.load_decks())
+    view = EditArchetypes(archs.load_archetypes_without_decks(order_by='a.name'), deck.load_decks())
     return view.page()
 
 @APP.route('/admin/archetypes/', methods=['POST'])

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -72,13 +72,13 @@ def competition(competition_id):
 @APP.route('/archetypes/')
 @cached()
 def archetypes():
-    view = Archetypes(archs.load_archetypes_without_decks())
+    view = Archetypes(archs.load_archetypes_deckless())
     return view.page()
 
 @APP.route('/archetypes/<archetype_id>/')
 @cached()
 def archetype(archetype_id):
-    view = Archetype(archs.load_archetype(archetype_id), archs.load_archetypes_without_decks_with_root(archetype_id))
+    view = Archetype(archs.load_archetype(archetype_id), archs.load_archetypes_deckless_for(archetype_id))
     return view.page()
 
 @APP.route('/tournaments/')
@@ -197,7 +197,7 @@ def deckcycle_tappedout():
 
 @APP.route('/admin/archetypes/')
 def edit_archetypes():
-    view = EditArchetypes(archs.load_archetypes_without_decks(order_by='a.name'), deck.load_decks())
+    view = EditArchetypes(archs.load_archetypes_deckless(order_by='a.name'), deck.load_decks())
     return view.page()
 
 @APP.route('/admin/archetypes/', methods=['POST'])

--- a/decksite/smoke_test.py
+++ b/decksite/smoke_test.py
@@ -2,8 +2,6 @@ import unittest
 
 import pytest
 
-from flask import Flask
-
 from decksite.main import APP
 
 class SmokeTest(unittest.TestCase):

--- a/decksite/smoke_test.py
+++ b/decksite/smoke_test.py
@@ -1,0 +1,52 @@
+import pytest
+import unittest
+
+from flask import Flask
+
+from decksite.main import APP
+
+class SmokeTest(unittest.TestCase):
+    def setUp(self):
+        # creates a test client
+        self.app = APP.test_client()
+        # propagate the exceptions to the test client
+        self.app.testing = True
+
+    def test_home_status_code(self):
+        result = self.app.get('/')
+        self.assertEqual(result.status_code, 200)
+
+    def test_home_data(self):
+        result = self.app.get('/')
+        self.assertIn('Latest Decks', result.data.decode('utf-8'))
+
+    @pytest.mark.slowtest
+    def test_some_pages(self):
+        result = self.app.get('/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/archetypes/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/people/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/people/bakert99/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/cards/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/cards/Unsummon/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/cards/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/competitions/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/tournaments/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/resources/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/bugs/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/signup/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/report/')
+        self.assertEqual(result.status_code, 200)
+        result = self.app.get('/doesnotexist')
+        self.assertEqual(result.status_code, 404)

--- a/decksite/smoke_test.py
+++ b/decksite/smoke_test.py
@@ -1,5 +1,6 @@
-import pytest
 import unittest
+
+import pytest
 
 from flask import Flask
 

--- a/decksite/static/css/pd.css
+++ b/decksite/static/css/pd.css
@@ -347,7 +347,7 @@ ul.menu {
 /* Responsive tables */
 
 @media only screen and (max-width: 60rem) {
-    table, thead, tbody, th, td, tr {
+    table, tbody, th, td, tr {
         display: block;
     }
 
@@ -375,6 +375,21 @@ ul.menu {
     td.c, td.n {
         text-align: left;
     }
+
+    /* But don't screw up Google's HTML/CSS for the search box in the menu. */
+    .gsc-search-box table {
+        display: table;
+    }
+    .gsc-search-box tbody {
+        display: table-row-group;
+    }
+    .gsc-search-box tr {
+        display: table-row;
+    }
+    .gsc-search-box td, th {
+        display: table-cell;
+    }
+
 }
 
 /* Card */

--- a/decksite/static/css/pd.css
+++ b/decksite/static/css/pd.css
@@ -562,3 +562,7 @@ tr.archetype-3 > .primary.initial {
     font-size: 60%;
     padding-left: 3rem;
 }
+tr.current td:first-child a {
+    background-color: #eee;
+    padding: 0.5em;
+}

--- a/decksite/static/css/pd.css
+++ b/decksite/static/css/pd.css
@@ -515,7 +515,7 @@ form.inline, .inline input, .inline select, .inline textarea {
 }
 
 .gsc-wrapper div:after {
-  display: inherit;
+    display: inherit;
 }
 
 .gsc-control-cse {
@@ -528,10 +528,6 @@ form.inline, .inline input, .inline select, .inline textarea {
 
 .gsc-search-button {
     margin-top: 5px !important; /* csslint allow: important */
-}
-
-td.gsc-search-button {
-    width: inherit !important; /* csslint allow: important */
 }
 
 .search tr {

--- a/decksite/templates/archetype.mustache
+++ b/decksite/templates/archetype.mustache
@@ -1,5 +1,9 @@
 <h2>{{name}}</h2>
 <section>
+    <h3>Archetype Tree</h3>
+    {{> archetypetree}}
+</section>
+<section>
     <h3>Most Common Cards</h3>
     <ul>
         {{#most_common_cards}}<li>{{> singlecard}}</li>{{/most_common_cards}}

--- a/decksite/templates/archetypetree.mustache
+++ b/decksite/templates/archetypetree.mustache
@@ -18,8 +18,8 @@
     <tbody>
         {{#roots}}
             {{#archetype_tree}}
-                <tr class="archetype archetype-{{pos}}">
-                    <td data-sort="{{sort}}"class="primary initial"><a href="{{url}}">{{name}}</a></td>
+                <tr class="archetype archetype-{{depth}}{{#current}} current{{/current}}">
+                    <td data-sort="{{sort}}" class="primary initial"><a href="{{url}}">{{name}}</a></td>
                     {{#season}}
                         <td class="n">{{num_decks}}</td>
                         <td class="n">{{> record}}</td>

--- a/decksite/templates/card.mustache
+++ b/decksite/templates/card.mustache
@@ -35,10 +35,10 @@
         </table>
     </section>
 {{/played_competitively}}
+{{> legal}}
 {{#has_decks}}
     <section>
         <h2>Decks containing {{name}}</h2>
         {{> decks}}
     </section>
 {{/has_decks}}
-{{> legal}}

--- a/decksite/templates/deck.mustache
+++ b/decksite/templates/deck.mustache
@@ -6,7 +6,7 @@
 </section>
 <section>
     <h2>Mana Costs</h2>
-    <img src="{{cmc_chart_url}}" width="150" height="103">
+    <img src="{{cmc_chart_url}}" width="200">
 </section>
 {{#has_matches}}
     <section>

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -52,7 +52,7 @@
 <table>
     {{#roots}}
         {{#archetype_tree}}
-            <tr class="archetype archetype-{{pos}}">
+            <tr class="archetype archetype-{{depth}}">
                 <td class="initial primary"><a href="{{url}}">{{name}}</a></td>
                 <td>
                     <form method="post" class="inline">

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -2,6 +2,7 @@ import subprocess
 import urllib
 from collections import Counter
 
+from anytree.iterators import PreOrderIter
 from flask import url_for
 
 from magic import oracle, rotation
@@ -159,11 +160,9 @@ class View:
                 p.all.show_record = p.all.wins or p.all.losses or p.all.get('draws', None)
 
     def prepare_archetypes(self):
-        archetypes = getattr(self, 'archetypes', [])
-        if len(archetypes) == 0:
-            return
         num_most_common_cards_to_list = 10
-        for a in archetypes:
+        for a in getattr(self, 'archetypes', []):
+            a.current = a.id == getattr(self, 'archetype', {}).get('id', None)
             if a.get('all') and a.get('season'):
                 a.all.show_record = a.all.get('wins') or a.all.get('draws') or a.all.get('losses')
                 a.season.show_record = a.season.get('wins') or a.season.get('draws') or a.season.get('losses')
@@ -188,40 +187,18 @@ class View:
             for v in most_common_cards:
                 self.prepare_card(cs[v[0]])
                 a.most_common_cards.append(cs[v[0]])
-            a.archetype_tree = preorder(a.tree)
+            a.archetype_tree = PreOrderIter(a)
             for r in a.archetype_tree:
+                # Prune branches we don't want to show
+                if r.id not in [a.id for a in getattr(self, 'archetypes', [])]:
+                    r.parent = None
                 r['url'] = url_for('archetype', archetype_id=r['id'])
-        # Don't try and set up archetype trees if we're just on the archetype detail page, for now.
-        # We won't have loaded the other archetypes to make looking them up by id work.
-        archetypes_by_id = {a.id: a for a in archetypes}
-        if len(archetypes) > 1:
-            self.roots = [] # pylint: disable=attribute-defined-outside-init
-            for a in archetypes:
-                a.low = 10
-                for entry in a.archetype_tree:
-                    a.low = min(a.low, entry['pos'])
-                    entry.update(archetypes_by_id[entry['id']])
-                if a.is_root:
-                    self.roots.append(a)
-            for a in archetypes:
-                for entry in a.archetype_tree:
-                    entry['pos'] += abs(a.low)
-            sort = 0
-            for r in self.roots:
-                for a in r.archetype_tree:
-                    a['sort'] = sort
-                    sort += 1
+                # It perplexes me that this is necessary. It's something to do with the way NodeMixin magic works. Mustache doesn't like it.
+                r['depth'] = r.depth
 
     def commit_id(self):
         return subprocess.check_output(['git', 'rev-parse', 'HEAD'])
 
-
-def preorder(node):
-    result = []
-    result.append(node)
-    for child in node.get('children', []):
-        result += preorder(child)
-    return result
 
 def colors_html(colors, colored_symbols):
     s = ''

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -1,3 +1,4 @@
+import datetime
 import subprocess
 import urllib
 from collections import Counter
@@ -37,20 +38,25 @@ class View:
         return url_for('static', filename='js/pd.js', v=self.commit_id())
 
     def menu(self):
-        return [
+        menu = [
             {'name': 'Decks', 'url': url_for('home')},
             {'name': 'Competitions', 'url': url_for('competitions')},
             {'name': 'People', 'url': url_for('people')},
             {'name': 'Cards', 'url': url_for('cards')},
             {'name': 'Archetypes', 'url': url_for('archetypes')},
-            {'name': 'Resources', 'url': url_for('resources')},
+            {'name': 'Resources', 'url': url_for('resources')}
+        ]
+        if (rotation.next_rotation() - dtutil.now()) < datetime.timedelta(7):
+            menu += [{'name': 'Rotation', 'url': url_for('rotation')}]
+        menu += [
             {'name': 'About', 'url': url_for('about')},
             {'name': 'League', 'url': url_for('league'), 'has_submenu': True, 'submenu': [
                 {'name': 'Sign Up', 'url': url_for('signup')},
                 {'name': 'Report', 'url': url_for('report')},
-                {'name': 'Records', 'url': url_for('competition', competition_id=league.get_active_competition_id())},
+                {'name': 'Records', 'url': url_for('competition', competition_id=league.get_active_competition_id())}
             ]}
         ]
+        return menu
 
     def favicon_url(self):
         return url_for('favicon', rest='.ico')

--- a/decksite/views/archetype.py
+++ b/decksite/views/archetype.py
@@ -2,10 +2,11 @@ from decksite.view import View
 
 # pylint: disable=no-self-use
 class Archetype(View):
-    def __init__(self, archetype):
+    def __init__(self, archetype, archetypes):
         self.archetype = archetype
-        self.archetypes = [archetype]
+        self.archetypes = archetypes
         self.decks = archetype.decks
+        self.roots = [a for a in self.archetypes if a.is_root]
 
     def __getattr__(self, attr):
         return getattr(self.archetype, attr)

--- a/decksite/views/archetypes.py
+++ b/decksite/views/archetypes.py
@@ -5,6 +5,7 @@ class Archetypes(View):
     def __init__(self, archetypes):
         self.archetypes = archetypes
         self.decks = []
+        self.roots = [a for a in self.archetypes if a.is_root]
 
     def subtitle(self):
         return 'Archetypes'

--- a/decksite/views/deck.py
+++ b/decksite/views/deck.py
@@ -1,4 +1,5 @@
 from flask import url_for
+import inflect
 
 from decksite import deck_name, league
 from decksite.data import deck
@@ -36,7 +37,12 @@ class Deck(View):
         return 'https://pennydreadfulmagic.com' + url_for('decks', deck_id=self._deck.id)
 
     def og_description(self):
-        description = 'A {archetype_name} deck by {author}'.format(archetype_name=self.archetype_name, author=str(self.person))
+        if self.archetype_name:
+            p = inflect.engine()
+            archetype_s = p.a(self.archetype_name).title()
+        else:
+            archetype_s = 'A'
+        description = '{archetype_s} deck by {author}'.format(archetype_s=archetype_s, author=self.person.decode('utf-8'))
         return description
 
     def __getattr__(self, attr):

--- a/price_grabber/price_grabber.py
+++ b/price_grabber/price_grabber.py
@@ -21,6 +21,9 @@ def fetch():
     sets = parse_sets(s)
     for code in sets:
         for suffix in ['', '_F']:
+            if code == 'PZ' and suffix == '_F':
+                print('Explicitly skipping PZ_F because it is a lie.')
+                continue
             code = '{code}{suffix}'.format(code=code, suffix=suffix)
             url = set_url(code)
             s = fetcher_internal.fetch(url)

--- a/pylintrc
+++ b/pylintrc
@@ -277,7 +277,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=apsw,munch,matplotlib,seaborn
+ignored-modules=anytree,apsw,inflect,matplotlib,munch,seaborn
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/pylintrc
+++ b/pylintrc
@@ -277,7 +277,7 @@ ignore-mixin-members=yes
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=anytree,apsw,inflect,matplotlib,munch,seaborn
+ignored-modules=anytree,apsw,inflect,matplotlib,munch,pytest,seaborn
 
 # List of class names for which member attributes should not be checked (useful
 # for classes with dynamically set attributes). This supports the use of

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ bs4
 coverage
 discord.py[voice]>=0.13.0
 flask
+inflect
 matplotlib
 munch
 mysqlclient==1.3.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+anytree
 bs4
 coverage
 discord.py[voice]>=0.13.0


### PR DESCRIPTION
(1) Simplify tree code by using the anytree library instead of homespun code.
(2) Use the anytree NodeMixin to make Archetypes and tree entries one and the
    same thing (so we don't have to `update` each tree entry to get the
    archetype properties).
(3) Make Archetype a class instead of using Container so we can use NodeMixin.
(4) Load parent information when querying for archetypes in order to use
    anytree's features.
(5) ORDER BY number of decks by default so output from anytree shows more
    popular archetypes first among archetypes at the same level. ORDER BY name
    for the dropdown on edit archtypes page still.
(6) Remove load_tree because anytree does that for us by traversing using
    parent.
(7) Add a load_archetypes_without_deck_with_root helper function to find any
    given archetypes slice of the whole tree without gumming up main.py.
(8) Use load_archetypes_without_deck_with_root results to display the correct
    slice of the archetype tree on the archetype detail page.
(9) Highlight the currently viewed archetype in the tree slice on the
    archetype detail page with a light gray background.
(10) Replace homespun preorder code with anytree's.
(11) Remove sorting. Combination of preorder and database ORDER BY now gets us
     that for free.
(12) Add dependency on anytree to requirements.txt