### PR TITLE
Reject sixth report

### DIFF
--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -354,6 +354,13 @@ def load_opponent_stats(decks):
         decks_by_id[row['id']].stage_reached = row['stage_reached']
         decks_by_id[row['id']].elim = row['elim'] # This property is never used? and is always a bunch of zeroes?
 
+def count_matches(deck_id, opponent_deck_id):
+    sql = 'SELECT deck_id, count(id) as count FROM deck_match WHERE deck_id in (%s, %s) group by deck_id'
+    result = {int(deck_id): 0, int(opponent_deck_id): 0}
+    for row in db().execute(sql, [deck_id, opponent_deck_id]):
+        result[row['deck_id']] = row['count']
+    return result
+
 # pylint: disable=too-many-instance-attributes
 class Deck(Container):
     def __init__(self, params):

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -10,6 +10,7 @@ from shared import dtutil
 from shared.container import Container
 from shared.database import sqlescape
 from shared.pd_exception import InvalidDataException
+from shared.pd_exception import LockNotAcquiredException
 
 from decksite.data import competition, deck, guarantee
 from decksite.database import db
@@ -126,16 +127,35 @@ def active_decks_by(mtgo_username):
     return active_decks('p.mtgo_username = {mtgo_username}'.format(mtgo_username=sqlescape(mtgo_username, force_string=True)))
 
 def report(form):
-    db().begin()
-    match_id = deck.insert_match(dtutil.now(), form.entry, form.entry_games, form.opponent, form.opponent_games)
-    winner, loser = winner_and_loser(form)
-    if winner:
-        db().execute('UPDATE deck SET wins = (SELECT COUNT(*) FROM decksite.deck_match WHERE `deck_id` = %s AND `games` = 2) WHERE `id` = %s', [winner, winner])
-        db().execute('UPDATE deck SET losses = (SELECT COUNT(*) FROM decksite.deck_match WHERE `deck_id` = %s AND `games` < 2) WHERE `id` = %s', [loser, loser])
-    else:
-        db().execute('UPDATE deck SET draws = draws + 1 WHERE id = %s OR id = %s', [form.entry, form.opponent])
-    db().commit()
-    return match_id
+    try:
+        if (db().supports_lock()):
+            db().get_lock('deck_id:{id}'.format(id=form.entry))
+            db().get_lock('deck_id:{id}'.format(id=form.opponent))
+        counts = deck.count_matches(form.entry, form.opponent)
+        if counts[int(form.entry)] >= 5:
+            form.errors['entry'] = "You already have 5 matches reported"
+            return False
+        if counts[int(form.opponent)] >= 5:
+            form.errors['opponent'] = "Your opponent already has 5 matches reported"
+            return False
+
+        db().begin()
+        match_id = deck.insert_match(dtutil.now(), form.entry, form.entry_games, form.opponent, form.opponent_games)
+        winner, loser = winner_and_loser(form)
+        if winner:
+            db().execute('UPDATE deck SET wins = (SELECT COUNT(*) FROM decksite.deck_match WHERE `deck_id` = %s AND `games` = 2) WHERE `id` = %s', [winner, winner])
+            db().execute('UPDATE deck SET losses = (SELECT COUNT(*) FROM decksite.deck_match WHERE `deck_id` = %s AND `games` < 2) WHERE `id` = %s', [loser, loser])
+        else:
+            db().execute('UPDATE deck SET draws = draws + 1 WHERE id = %s OR id = %s', [form.entry, form.opponent])
+        db().commit()
+        return True
+    except LockNotAcquiredException:
+        form.errors['entry'] = "Cannot report right now, somebody else is reporting a match for you or your opponent. Try again a bit later"
+        return False
+    finally:
+        if (db().supports_lock()):
+            db().release_lock('deck_id:{id}'.format(id=form.opponent))
+            db().release_lock('deck_id:{id}'.format(id=form.entry))
 
 def winner_and_loser(params):
     if params.entry_games > params.opponent_games:

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -128,7 +128,7 @@ def active_decks_by(mtgo_username):
 
 def report(form):
     try:
-        if (db().supports_lock()):
+        if db().supports_lock():
             db().get_lock('deck_id:{id}'.format(id=form.entry))
             db().get_lock('deck_id:{id}'.format(id=form.opponent))
         counts = deck.count_matches(form.entry, form.opponent)
@@ -140,7 +140,7 @@ def report(form):
             return False
 
         db().begin()
-        match_id = deck.insert_match(dtutil.now(), form.entry, form.entry_games, form.opponent, form.opponent_games)
+        deck.insert_match(dtutil.now(), form.entry, form.entry_games, form.opponent, form.opponent_games)
         winner, loser = winner_and_loser(form)
         if winner:
             db().execute('UPDATE deck SET wins = (SELECT COUNT(*) FROM decksite.deck_match WHERE `deck_id` = %s AND `games` = 2) WHERE `id` = %s', [winner, winner])
@@ -153,7 +153,7 @@ def report(form):
         form.errors['entry'] = "Cannot report right now, somebody else is reporting a match for you or your opponent. Try again a bit later"
         return False
     finally:
-        if (db().supports_lock()):
+        if db().supports_lock():
             db().release_lock('deck_id:{id}'.format(id=form.opponent))
             db().release_lock('deck_id:{id}'.format(id=form.entry))
 

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -214,8 +214,7 @@ def report(form=None):
 @APP.route('/report/', methods=['POST'])
 def add_report():
     form = ReportForm(request.form)
-    if form.validate():
-        lg.report(form)
+    if form.validate() and lg.report(form):
         response = make_response(redirect(url_for('decks', deck_id=form.entry)))
         response.set_cookie('deck_id', form.entry)
         return response

--- a/shared/database_generic.py
+++ b/shared/database_generic.py
@@ -28,3 +28,8 @@ class GenericDatabase:
     # pylint: disable=no-self-use
     def is_sqlite(self):
         return False
+
+    # pylint: disable=no-self-use
+    def supports_lock(self):
+        return False
+

--- a/shared/database_generic.py
+++ b/shared/database_generic.py
@@ -32,4 +32,3 @@ class GenericDatabase:
     # pylint: disable=no-self-use
     def supports_lock(self):
         return False
-

--- a/shared/database_mysql.py
+++ b/shared/database_mysql.py
@@ -6,6 +6,7 @@ import MySQLdb
 from shared import configuration
 from shared.database_generic import GenericDatabase
 from shared.pd_exception import DatabaseException
+from shared.pd_exception import LockNotAcquiredException
 from shared import perf
 
 class MysqlDatabase(GenericDatabase):
@@ -72,3 +73,15 @@ class MysqlDatabase(GenericDatabase):
     # pylint: disable=no-self-use
     def is_mysql(self):
         return True
+
+    # pylint: disable=no-self-use
+    def supports_lock(self):
+        return True
+
+    def get_lock(self, lock_id, timeout=4):
+        result = self.value('select get_lock(%s, %s)', [lock_id, timeout])
+        if result != 1:
+            raise LockNotAcquiredException
+
+    def release_lock(self, lock_id):
+        self.execute('select release_lock(%s)', [lock_id])

--- a/shared/database_mysql.py
+++ b/shared/database_mysql.py
@@ -85,3 +85,4 @@ class MysqlDatabase(GenericDatabase):
 
     def release_lock(self, lock_id):
         self.execute('select release_lock(%s)', [lock_id])
+        

--- a/shared/pd_exception.py
+++ b/shared/pd_exception.py
@@ -24,3 +24,6 @@ class TooFewItemsException(PDException):
 
 class InvalidArgumentException(PDException):
     pass
+
+class LockNotAcquiredException(DatabaseException):
+	pass

--- a/shared/pd_exception.py
+++ b/shared/pd_exception.py
@@ -26,4 +26,4 @@ class InvalidArgumentException(PDException):
     pass
 
 class LockNotAcquiredException(DatabaseException):
-	pass
+    pass


### PR DESCRIPTION
As explained in discord: in the report method I'm checking that neither you nor your opponent have already 5 matches reported. It wraps the whole check + update in a distributed lock if the DB supports it. If we want to quickly deactivate the lock the easiest way would be to change database_mysql.py to return False in the supports_lock method.