### PR TITLE
Version compare compat

### DIFF
--- a/magic/database.py
+++ b/magic/database.py
@@ -21,7 +21,7 @@ def init():
         setup()
 
 def version() -> str:
-    return pkg_resources.parse_version(db().value('SELECT version FROM version', [], '0'))
+    return db().value('SELECT version FROM version', [], '0')
 
 def db_version() -> int:
     return db().value('SELECT version FROM db_version', [], 0)

--- a/magic/database.py
+++ b/magic/database.py
@@ -1,5 +1,3 @@
-import pkg_resources
-
 from magic import card
 from shared import configuration
 from shared.database import get_database

--- a/magic/fetcher.py
+++ b/magic/fetcher.py
@@ -6,7 +6,6 @@ from urllib import parse
 from functools import wraps
 import time as py_time
 
-import pkg_resources
 import pytz
 
 import magic.fetcher_internal as internal

--- a/magic/fetcher.py
+++ b/magic/fetcher.py
@@ -114,7 +114,7 @@ def legal_cards(force=False, season=None):
     return legal_txt.strip().split('\n')
 
 def mtgjson_version():
-    return pkg_resources.parse_version(internal.fetch_json('https://mtgjson.com/json/version.json'))
+    return internal.fetch_json('https://mtgjson.com/json/version.json')
 
 def mtgo_status():
     try:

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -13,7 +13,6 @@ SEASONS = ['EMN', 'KLD', 'AER', 'AKH', 'HOU', 'XLN', 'RIX']
 
 def init():
     current_version = fetcher.mtgjson_version()
-    database_version = database.version()
     if pkg_resources.parse_version(current_version) > pkg_resources.parse_version(database.version()):
         print('Database update required')
         update_database(current_version)

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -1,4 +1,5 @@
 import re
+import pkg_resources
 
 from magic import card, database, fetcher, rotation
 from magic.database import db
@@ -12,9 +13,12 @@ SEASONS = ['EMN', 'KLD', 'AER', 'AKH', 'HOU', 'XLN', 'RIX']
 
 def init():
     current_version = fetcher.mtgjson_version()
-    if current_version > database.version():
+    print(current_version)
+    database_version = database.version()
+    print(database_version)
+    if pkg_resources.parse_version(current_version) > pkg_resources.parse_version(database.version()):
         print('Database update required')
-        update_database(str(current_version))
+        update_database(current_version)
         set_legal_cards()
         update_cache()
 

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -13,9 +13,7 @@ SEASONS = ['EMN', 'KLD', 'AER', 'AKH', 'HOU', 'XLN', 'RIX']
 
 def init():
     current_version = fetcher.mtgjson_version()
-    print(current_version)
     database_version = database.version()
-    print(database_version)
     if pkg_resources.parse_version(current_version) > pkg_resources.parse_version(database.version()):
         print('Database update required')
         update_database(current_version)


### PR DESCRIPTION
I was having problems with the database update checker. The culprit was that different versions of setuptools had different return types for the parse_version method. This commit cleans up the usage of str of the returned object in favor of storing the version coming from mtgjson, and use pkg_resources.parse_version only for the comparison.