### PR TITLE
Retire protection

### DIFF
--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -86,5 +86,11 @@ def associate(d, discord_id):
     sql = 'UPDATE person SET discord_id = ? WHERE id = ?'
     return db().execute(sql, [discord_id, person.id])
 
+def is_allowed_to_retire(deck_id, discord_id):
+    people = load_people('p.discord_id = {discord_id}'.format(discord_id=sqlescape(discord_id)))
+    if len(people) == 0:
+        return True
+    return any(int(deck_id)==deck.id for deck in people[0].decks)
+
 class Person(Container):
     pass

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -90,7 +90,7 @@ def is_allowed_to_retire(deck_id, discord_id):
     people = load_people('p.discord_id = {discord_id}'.format(discord_id=sqlescape(discord_id)))
     if len(people) == 0:
         return True
-    return any(int(deck_id)==deck.id for deck in people[0].decks)
+    return any(int(deck_id) == deck.id for deck in people[0].decks)
 
 class Person(Container):
     pass

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -100,7 +100,7 @@ class RetireForm(Form):
         super().__init__(form)
         decks = active_decks()
         self.entry_options = deck_options(decks, self.get('entry', deck_id))
-        self.discord_user=discord_user
+        self.discord_user = discord_user
 
     def do_validation(self):
         if len(self.entry) == 0:

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -12,7 +12,7 @@ from shared.database import sqlescape
 from shared.pd_exception import InvalidDataException
 from shared.pd_exception import LockNotAcquiredException
 
-from decksite.data import competition, deck, guarantee
+from decksite.data import competition, deck, guarantee, person
 from decksite.database import db
 from decksite.scrapers import decklist
 
@@ -96,14 +96,17 @@ class ReportForm(Form):
             self.errors['opponent'] = "You can't play yourself"
 
 class RetireForm(Form):
-    def __init__(self, form, deck_id=None):
+    def __init__(self, form, deck_id=None, discord_user=None):
         super().__init__(form)
         decks = active_decks()
         self.entry_options = deck_options(decks, self.get('entry', deck_id))
+        self.discord_user=discord_user
 
     def do_validation(self):
         if len(self.entry) == 0:
             self.errors['entry'] = 'Please select your deck'
+        if not person.is_allowed_to_retire(self.entry, self.discord_user):
+            self.errors['entry'] = 'You cannot retire this deck. This discord user is already assigned to another mtgo user'
         print(self.errors)
 
 def signup(form):

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -230,14 +230,14 @@ def add_report():
 @auth.login_required
 def retire(form=None):
     if form is None:
-        form = RetireForm(request.form, request.cookies.get('deck_id', ''))
+        form = RetireForm(request.form, request.cookies.get('deck_id', ''), session.get('id'))
     view = Retire(form)
     return view.page()
 
 @APP.route('/retire/', methods=['POST'])
 @auth.login_required
 def do_claim():
-    form = RetireForm(request.form)
+    form = RetireForm(request.form, discord_user=session.get('id'))
     if form.validate():
         d = deck.load_deck(form.entry)
         ps.associate(d, session['id'])

--- a/decksite/scrapers/scraper_test.py
+++ b/decksite/scrapers/scraper_test.py
@@ -12,11 +12,9 @@ from decksite.scrapers import tappedout, gatherling
 
 @pytest.mark.slowtest
 def test_gatherling():
-    APP.config["SERVER_NAME"] = "127:0.0.1:5000"
     with APP.app_context():
         gatherling.scrape(5)
 
 def test_manual_tappedout():
-    APP.config["SERVER_NAME"] = "127:0.0.1:5000"
     with APP.app_context():
         tappedout.scrape_url('http://tappedout.net/mtg-decks/60-island/') # Best deck


### PR DESCRIPTION
Validates that the discord user is allowed to retire a deck. It checks that the discord_id is either not yet present in the person table or that the deck belongs to them. Fixes #1413 (at least somewhat).