### PR TITLE
Retire show only my deck

### DIFF
--- a/decksite/data/guarantee.py
+++ b/decksite/data/guarantee.py
@@ -7,3 +7,11 @@ def exactly_one(l):
         return l[0]
     except IndexError as e:
         raise DoesNotExistException('Did not find an item when expecting one.') from e
+
+def at_most_one(l):
+    if len(l) > 1:
+        raise TooManyItemsException('Found {n} items when expecing at most 1 in `{l}`.'.format(n=len(l), l=l))
+    elif len(l) == 0:
+        return None
+    else:
+        return l[0]

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -121,10 +121,13 @@ def associate(d, discord_id):
     return db().execute(sql, [discord_id, person.id])
 
 def is_allowed_to_retire(deck_id, discord_id):
-    people = load_people('p.discord_id = {discord_id}'.format(discord_id=sqlescape(discord_id)))
-    if len(people) == 0:
+    person = load_person_by_discord_id(discord_id)
+    if person is None:
         return True
-    return any(int(deck_id) == deck.id for deck in people[0].decks)
+    return any(int(deck_id) == deck.id for deck in person.decks)
+
+def load_person_by_discord_id(discord_id):
+    return guarantee.at_most_one(load_people('p.discord_id = {discord_id}'.format(discord_id=sqlescape(discord_id))))
 
 class Person(Container):
     pass

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -98,9 +98,17 @@ class ReportForm(Form):
 class RetireForm(Form):
     def __init__(self, form, deck_id=None, discord_user=None):
         super().__init__(form)
-        decks = active_decks()
+        person_object = None
+        if discord_user is not None:
+            person_object = person.load_person_by_discord_id(discord_user)
+        if person_object:
+            decks = active_decks_by_person(person_object.id)
+        else:
+            decks = active_decks()
         self.entry_options = deck_options(decks, self.get('entry', deck_id))
         self.discord_user = discord_user
+        if len(decks) == 0:
+            self.errors['entry'] = "You don't have any decks to retire"
 
     def do_validation(self):
         if len(self.entry) == 0:
@@ -128,6 +136,9 @@ def active_decks(additional_where='1 = 1'):
 
 def active_decks_by(mtgo_username):
     return active_decks('p.mtgo_username = {mtgo_username}'.format(mtgo_username=sqlescape(mtgo_username, force_string=True)))
+
+def active_decks_by_person(person_id):
+    return active_decks('p.id = {id}'.format(id=person_id))
 
 def report(form):
     try:

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -347,7 +347,8 @@ def unauthorized(error=None):
 @APP.route('/logout/')
 def logout():
     auth.logout()
-    return redirect(url_for('home'))
+    target = request.args.get('target', 'home')
+    return redirect(url_for(target))
 
 # Infra
 

--- a/decksite/templates/retire.mustache
+++ b/decksite/templates/retire.mustache
@@ -14,5 +14,6 @@
         </div>
         <button type="submit">Retire</button>
     </form>
+    <div>Not your decks? <a href="{{logout_url}}">Log out</a>
     {{> contact}}
 </section>

--- a/decksite/views/retire.py
+++ b/decksite/views/retire.py
@@ -1,6 +1,11 @@
 from decksite.views import LeagueForm
+from flask import url_for
 
 # pylint: disable=no-self-use
 class Retire(LeagueForm):
+    def __init__(self, form):
+        super().__init__(form)
+        self.logout_url = url_for('logout', target='retire')
+
     def subtitle(self):
         return 'Retire'


### PR DESCRIPTION
Fixes: #3778

Two things could be made better:
- We are still showing a combo box, while when the decks are filtered it's guaranteed that there will be only one.
- Some refactors could be done in RetireForm __init__ cause I think that when we load a person it contains all their decks, so we could avoid 2 queries with a little bit more ifs and elses.