### PR TITLE
Make art crop filename a little big less gross.

### DIFF
--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -439,7 +439,7 @@ Want to contribute? Send a Pull Request."""
         await bot.client.send_typing(channel)
         c = await single_card_or_send_error(bot, channel, args, author)
         if c is not None:
-            image_file = image_fetcher.download_scryfall_image([c], image_fetcher.determine_filepath([c]) + 'art_crop.jpg', version='art_crop')
+            image_file = image_fetcher.download_scryfall_image([c], image_fetcher.determine_filepath([c]) + '.art_crop.jpg', version='art_crop')
             await bot.send_image_with_retry(channel, image_file)
 
     @cmd_header('Commands')


### PR DESCRIPTION
I don't think it's worth making the code more complicated to give a temporary
file a truly good name but something.jpg.art_crop.jpg is better than
something.jpgart_crop.jpg. I think.