### PR TITLE
decksite: rotation changes fixes and nitpicks

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -15,7 +15,7 @@ from decksite.cache import cached
 from decksite.data import archetype as archs, card as cs, competition as comp, deck as ds, person as ps, query
 from decksite.charts import chart
 from decksite.league import ReportForm, RetireForm, SignUpForm
-from decksite.views import About, AboutPdm, AddForm, Archetype, Archetypes, Bugs, Card, Cards, Competition, Competitions, Deck, Decks, EditArchetypes, EditMatches, Home, InternalServerError, LeagueInfo, NotFound, People, Person, Prizes, Report, Resources, Retire, Rotation, RotationChecklist, Season, Seasons, SignUp, TournamentHosting, TournamentLeaderboards, Tournaments, Unauthorized, RotationChanges
+from decksite.views import About, AboutPdm, AddForm, Archetype, Archetypes, Bugs, Card, Cards, Competition, Competitions, Deck, Decks, EditArchetypes, EditMatches, Home, InternalServerError, LeagueInfo, NotFound, People, Person, Prizes, Report, Resources, Retire, Rotation, RotationChanges, RotationChecklist, Season, Seasons, SignUp, TournamentHosting, TournamentLeaderboards, Tournaments, Unauthorized
 
 # Decks
 

--- a/decksite/views/rotation_changes.py
+++ b/decksite/views/rotation_changes.py
@@ -5,10 +5,10 @@ class RotationChanges(View):
     def __init__(self, cards_in, cards_out):
         self.sections = []
         self.cards = cards_in + cards_out
-        entries_in = [{'n': None, 'name': c.name, 'card': c} for c in cards_in]
-        entries_out = [{'n': None, 'name': c.name, 'card': c} for c in cards_out]
-        self.sections.append({'name': 'New to the format', 'entries': entries_in, 'num_entries': len(entries_in)})
-        self.sections.append({'name': 'Left the format', 'entries': entries_out, 'num_entries': len(entries_out)})
+        entries_in = [{'name': c.name, 'card': c} for c in cards_in]
+        entries_out = [{'name': c.name, 'card': c} for c in cards_out]
+        self.sections.append({'name': 'New this season', 'entries': entries_in, 'num_entries': len(entries_in)})
+        self.sections.append({'name': 'Rotated out', 'entries': entries_out, 'num_entries': len(entries_out)})
 
     def subtitle(self):
         return 'Rotation Changes'

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -243,12 +243,14 @@ def changes_between_formats(f1, f2):
     return [query_diff_formats(f2, f1), query_diff_formats(f1, f2)]
 
 def query_diff_formats(f1, f2):
-    query = 'c.id IN (SELECT card_id FROM card_legality WHERE format_id = {format1}) AND c.id NOT IN (SELECT card_id FROM card_legality WHERE format_id = {format2})'
-    removals_query = multiverse.base_query(where=query.format(format1=f1, format2=f2))
+    where = '''
+    c.id IN 
+        (SELECT card_id FROM card_legality 
+            WHERE format_id = {format1}) 
+    AND c.id NOT IN 
+        (SELECT card_id FROM card_legality WHERE format_id = {format2})
+    '''.format(format1=f1, format2=f2)
 
-    sql = """
-        {base_query}
-    """.format(base_query=removals_query)
-    rs = db().execute(sql)
+    rs = db().execute(multiverse.cached_base_query(where=where))
     out = [card.Card(r) for r in rs]
     return sorted(out, key=lambda card: card['name'])


### PR DESCRIPTION
Some fixes as commented in the other pull request:
- Use cached query
- Cleanup unnecessary variables
- Title text in the page
- Avoiding setting a dict key to None explicitly
- Import in alphabetical order