### PR TITLE
decksite: fix person + lint warnings

### DIFF
--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -66,6 +66,7 @@ def load_decks(where='1 = 1', order_by=None, limit=''):
             {person_query} AS person,
             p.id AS person_id,
             p.banned,
+            p.discord_id,
             d.created_date AS `date`,
             d.decklist_hash,
             d.retired,
@@ -443,3 +444,6 @@ class Deck(Container):
         for entry in self.sideboard:
             s += '{n} {name}\n'.format(n=entry['n'], name=entry['name'])
         return s.strip()
+
+    def is_person_associated(self):
+        return self.discord_id is not None

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -37,7 +37,7 @@ def decks():
 @auth.logged
 def deck(deck_id):
     d = ds.load_deck(deck_id)
-    if auth.discord_id() and auth.logged_person() is None:
+    if auth.discord_id() and auth.logged_person() is None and not d.is_person_associated():
         ps.associate(d, auth.discord_id())
         p = ps.load_person_by_discord_id(auth.discord_id())
         auth.log_person(p.id, p.name)

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -12,13 +12,13 @@ from typing import List
 
 import inflect
 
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 from discordbot import emoji
 from find import search
 from magic import card, database, image_fetcher, fetcher, multiverse, oracle, rotation, tournaments
 from shared import configuration, dtutil, repo
 from shared.pd_exception import TooFewItemsException
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 
 
 DEFAULT_CARDS_SHOWN = 4


### PR DESCRIPTION
Fixes the problem of a new person overwriting the discord_id of an existing person through the decks/<deck_id> route.