### PR TITLE
Revert "Switch to Scryfall's CDN for card images."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,6 @@ lint:
 	@pylint  --generate-rcfile | grep -v "ignored-modules=" >.pylintrc.tmp
 	@find . -name "*.py" | grep -v .git | xargs pylint --ignored-modules=MySQLdb --rcfile=.pylintrc.tmp --reports=n -f parseable; (ret=$$?; echo; rm -f .pylintrc.tmp && exit $$ret)
 
-shortlint:
-	@echo
-	@echo "******************************** Lint *****************************************"
-	@echo
-	@find . -name "*.py" | grep -v .git | xargs pylint -f parseable -E
-	@echo
-
 readme:
 	@echo
 	@echo "******************************** Generating README ****************************"

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -180,7 +180,7 @@ class View:
 
     def prepare_card(self, c):
         c.url = '/cards/{id}/'.format(id=c.name)
-        c.img_url = 'https://api.scryfall.com/cards/named?exact={name}&format=image'.format(name=urllib.parse.quote(c.name))
+        c.img_url = 'http://magic.bluebones.net/proxies/index2.php?c={name}'.format(name=urllib.parse.quote(c.name))
         c.card_img_class = 'two-faces' if c.layout in ['double-faced', 'meld'] else ''
         c.pd_legal = c.legalities.get('Penny Dreadful', False) and c.legalities['Penny Dreadful'] != 'Banned'
         c.legal_formats = set([k for k, v in c.legalities.items() if v != 'Banned'])


### PR DESCRIPTION
This reverts commit 5b8a968db46a3040b93c45db8c176607d27f9a28.

I've changed bluebones back to how it was but with a special case for BFM.

Scryfall don't offer a simple way to get the reverse of meld cards.