### PR TITLE
Fix /tournaments/ bug rules

### DIFF
--- a/decksite/templates/tournaments.mustache
+++ b/decksite/templates/tournaments.mustache
@@ -74,7 +74,7 @@
         <h2><a name="bugs">Bugs</a></h2>
         <p>We allow the playing of cards with known bugs in Penny Dreadful with specific conditions.</p>
         <ul>
-            <li>Cards with game-breaking bugs should not be played.</li>
+            <li>Cards with game-breaking bugs may not be played. Exceptions: Swerve and Sylvan Primordial are permitted at the players own risk resulting in a game loss if the bug occurs.</li>
             <li>Cards with disadvantageous bugs can be played and no extra rules apply. The opposing player is under no obligation to treat the card as if it worked properly.</li>
             <li>Cards with advantageous bugs can be played but accruing advantage intentionally will result in disqualification.</li>
             <li>Accruing advantage any other way with a card with an advantageous bug is a game loss for the owner of the bugged card.</li>

--- a/decksite/templates/tournaments.mustache
+++ b/decksite/templates/tournaments.mustache
@@ -74,7 +74,7 @@
         <h2><a name="bugs">Bugs</a></h2>
         <p>We allow the playing of cards with known bugs in Penny Dreadful with specific conditions.</p>
         <ul>
-            <li>Cards with game-breaking bugs may not be played. Exceptions: Swerve and Sylvan Primordial are permitted at the players own risk resulting in a game loss if the bug occurs.</li>
+            <li>Cards with game-breaking bugs must not be played. Exceptions: Sylvan Primordial.</li>
             <li>Cards with disadvantageous bugs can be played and no extra rules apply. The opposing player is under no obligation to treat the card as if it worked properly.</li>
             <li>Cards with advantageous bugs can be played but accruing advantage intentionally will result in disqualification.</li>
             <li>Accruing advantage any other way with a card with an advantageous bug is a game loss for the owner of the bugged card.</li>


### PR DESCRIPTION
Update /tournaments/ rules with "must not" (the strongest verbiage) and corrected exception list to 1 card per stash86, Sylvan Primordial

https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/issues/4224