### PR TITLE
decksite: remove automatic association in deck view

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -54,12 +54,7 @@ def decks():
 @auth.logged
 def deck(deck_id):
     d = ds.load_deck(deck_id)
-    if auth.discord_id() and auth.logged_person() is None and not d.is_person_associated():
-        ps.associate(d, auth.discord_id())
-        p = ps.load_person_by_discord_id(auth.discord_id())
-        auth.log_person(p)
-
-    view = Deck(d, auth.logged_person())
+    view = Deck(d, auth.logged_person(), auth.discord_id())
     return view.page()
 
 @APP.route('/seasons/')

--- a/decksite/templates/deck.mustache
+++ b/decksite/templates/deck.mustache
@@ -38,7 +38,12 @@
         <h2>Decklist</h2>
         <p>This deck is hidden because it is active in the league.</p>
         {{^logged_person_id}}
-            <p>If it's your deck <a href="{{authenticate_url}}">login with discord</a> to see it.</p>
+            {{^discord_id}}
+                <p>If it's your deck <a href="{{authenticate_url}}">login with discord</a> to see it.</p>
+            {{/discord_id}}
+            {{#discord_id}}
+                <p>Your account is not linked. Please use the status bar to link it</a>.</p>
+            {{/discord_id}}
         {{/logged_person_id}}
         {{#logged_person_id}}
             <p>You are logged in but this deck is not yours. <a href="{{logout_url}}">Logout</a></p>

--- a/decksite/views/deck.py
+++ b/decksite/views/deck.py
@@ -11,7 +11,7 @@ from shared.pd_exception import InvalidDataException
 
 # pylint: disable=no-self-use, too-many-instance-attributes
 class Deck(View):
-    def __init__(self, d, logged_person_id=None):
+    def __init__(self, d, logged_person_id=None, discord_id=None):
         super().__init__()
         self._deck = d
         self.prepare_deck(self._deck)
@@ -48,6 +48,7 @@ class Deck(View):
         self.legal_formats = list(sorted(d.legal_formats, key=legality.order_score))
         self.is_in_current_run = d.is_in_current_run()
         self.logged_person_id = logged_person_id
+        self.discord_id = discord_id
 
     def has_matches(self):
         return len(self.matches) > 0


### PR DESCRIPTION
Remove the automatic association of discord_id to person (mtgo_username) when visiting a deck page. With the status bar providing an easy way to link your account, this doesn't make sense anymore.

As discussed in discord: the automatic association is kept when Signing Up for the league, and when retiring a deck. Possibly reassess this in the future.