### PR TITLE
Keep the left-hand column of archetypes column the same size always.

### DIFF
--- a/decksite/static/css/pd.css
+++ b/decksite/static/css/pd.css
@@ -1657,14 +1657,26 @@ tr.archetype-0.current > .primary.initial {
     padding-left: 0.422em; /* This looks weird hugging the exact left of the highlight so indent a little. */
 }
 
-/* max-width on table columns does not include padding so account for that here. */
+/*
+   max-width on table columns does not include padding so account for that here.
+   Use a fixed width rather than a max-width so the column doesn't "jump" when getting smaller because of losing then indents when sorted by something other than archetype name.
+*/
+
+tr > .initial {
+    width: 13rem; /* Same as td's max-width. */
+}
+@media only screen and (max-width: 640px) {
+    tr > .initial {
+        width: 10rem; /* Same as td's max-width. */
+    }
+}
 
 tr > .primary.initial {
-    max-width: 9.446em; /* 13em - 3.554em; */
+    width: 7.669em; /* 13em - 5.331em; */
 }
 @media only screen and (max-width: 640px) {
     tr > .primary.initial {
-        max-width: 6.446em; /* 10em - 3.554em; */
+        width: 4.669em; /* 10em - 5.331em; */
     }
 }
 


### PR DESCRIPTION
This avoids an unsightly "jump" when ordering by something other than name
and back again.

Fixes #1601.