### PR TITLE
Extend is_very_large behavior to large deck tables too.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ imports:
 	@echo
 	@echo "******************************** Import Ordering ******************************"
 	@echo
-	@isort --check-only --dont-skip=__init__.py
+	@isort --check-only
 	@echo
 
 fiximports:

--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -306,8 +306,6 @@ def get_archetype_id(archetype) -> Optional[int]:
 def load_similar_decks(ds: List[Deck]) -> None:
     threshold = 20
     cards_escaped = ', '.join(sqlescape(name) for name in all_card_names(ds))
-    if len(cards_escaped) == 0:
-        return
     potentially_similar = load_decks('d.id IN (SELECT deck_id FROM deck_card WHERE card IN ({cards_escaped}))'.format(cards_escaped=cards_escaped))
     for d in ds:
         for psd in potentially_similar:

--- a/decksite/templates/decktable.mustache
+++ b/decksite/templates/decktable.mustache
@@ -1,5 +1,5 @@
 {{> spinner}}
-<table class="with-marginalia">
+<table class="with-marginalia {{#is_very_large}}very-large{{/is_very_large}}"">
     <thead>
         <tr>
             <th data-breakpoints="xs" class="marginalia" data-sortInitialOrder="desc">⇅</th>

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -209,6 +209,7 @@ class View(BaseView):
         self.prepare_leaderboards()
 
     def prepare_decks(self) -> None:
+        self.is_very_large = self.is_very_large or len(getattr(self, 'decks', [])) > 500
         # The 'list' here is just to get past codacy and is a no-op.
         active_runs = [d for d in list(getattr(self, 'decks', [])) if d.is_in_current_run()]
         if len(active_runs) > 0:
@@ -269,7 +270,7 @@ class View(BaseView):
         d.average_cmc = round(total / max(1, num_cards), 2)
 
     def prepare_cards(self) -> None:
-        self.is_very_large = len(getattr(self, 'cards', [])) > 500
+        self.is_very_large = self.is_very_large or len(getattr(self, 'cards', [])) > 500
         for c in getattr(self, 'cards', []):
             self.prepare_card(c)
         for c in getattr(self, 'only_played_cards', []):

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -30,4 +30,3 @@ class EditArchetypes(View):
 
     def page_title(self):
         return 'Edit Archetypes'
-

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -11,9 +11,7 @@ class EditArchetypes(View):
         self.queue = deck.load_decks(where='NOT d.reviewed', order_by='updated_date DESC', limit='LIMIT 10')
         deck.load_similar_decks(self.queue)
         for d in self.queue:
-            if len(d.similar_decks) > 0:
-                d.suggestion = d.similar_decks[0]
-                self.prepare_deck(d.suggestion)
+            self.find_and_prepare_suggestion(d)
         for d in self.queue:
             self.prepare_deck(d)
         self.has_search_results = len(search_results) > 0
@@ -21,5 +19,15 @@ class EditArchetypes(View):
         for d in self.search_results:
             self.prepare_deck(d)
 
+    def find_and_prepare_suggestion(self, d: deck.Deck) -> None:
+        if len(d.similar_decks) == 0:
+            return
+        d.suggestion = d.similar_decks[0]
+        # Because we load similar decks for the whole queue all at once guard against "double-preparing" a similar deck.
+        if not d.suggestion.get('prepared'):
+            self.prepare_deck(d.suggestion)
+            d.suggestion.prepared = True
+
     def page_title(self):
         return 'Edit Archetypes'
+


### PR DESCRIPTION
This improves time to first seeing the table by up to 30s.

It's no perfect solution for display and performance of large tables but
it's better.

See #4739.