### PR TITLE
Rotation part 8

### DIFF
--- a/price_grabber/parser.py
+++ b/price_grabber/parser.py
@@ -1,10 +1,11 @@
 import html
 import re
+import traceback
 from typing import Dict, List, Tuple
 
 from magic import card, multiverse
 from magic.database import db
-from shared.pd_exception import InvalidDataException
+from shared.pd_exception import InvalidDataException, DatabaseException
 
 PriceList = List[Tuple[str, str, str]] # pylint: disable=invalid-name
 
@@ -46,10 +47,17 @@ def name_lookup(name: str) -> str:
         name = 'Kongming, "Sleeping Dragon"'
     elif name == 'Pang Tong, Young Phoenix':
         name = 'Pang Tong, "Young Phoenix"'
-    if not CARDS:
-        rs = db().execute(multiverse.base_query())
-        for row in rs:
-            CARDS[card.canonicalize(row['name'])] = row['name']
+    try:
+        if not CARDS:
+            rs = db().execute(multiverse.base_query())
+            for row in rs:
+                CARDS[card.canonicalize(row['name'])] = row['name']
+    except DatabaseException:
+        tb = traceback.format_exc()
+        print(tb)
+        if not CARDS:
+            CARDS[''] = '' # Filler, so that we don't try to do this every lookup.
+
     canonical = card.canonicalize(name)
     if canonical not in CARDS:
         print('WARNING: Bogus name {name} ({canonical}) found.'.format(name=name, canonical=canonical))

--- a/price_grabber/parser.py
+++ b/price_grabber/parser.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Tuple
 
 from magic import card, multiverse
 from magic.database import db
-from shared.pd_exception import InvalidDataException, DatabaseException
+from shared.pd_exception import DatabaseException, InvalidDataException
 
 PriceList = List[Tuple[str, str, str]] # pylint: disable=invalid-name
 

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -23,11 +23,18 @@ TIME_SINCE_SUPPLEMENTAL_ROTATION = dtutil.now() - rotation.this_supplemental()
 def run() -> None:
     files = rotation.files()
     n = len(files)
+    time_until = min(TIME_UNTIL_FULL_ROTATION, TIME_UNTIL_SUPPLEMENTAL_ROTATION)
     if n >= TOTAL_RUNS:
         print('It is the moment of discovery, the triumph of the mind, and the end of this rotation.')
+
+        if time_until < datetime.timedelta(weeks=2):
+            for f in files:
+                print('Removing {f}'.format(f=f))
+                os.remove(f)
         return
     if n == 0 and TIME_UNTIL_FULL_ROTATION > datetime.timedelta(7) and TIME_UNTIL_SUPPLEMENTAL_ROTATION > datetime.timedelta(7):
         print('The monks of the North Tree rarely saw their kodama until the rotation, when it woke like a slumbering, angry bear.')
+        print('ETA: {t}'.format(t=dtutil.display_time(time_until.total_seconds())))
         return
     all_prices = {}
     for url in configuration.get_list('cardhoarder_urls'):


### PR DESCRIPTION
Print rotation ETA, and clean up files if we've forgotten to do so.
Also handle database errors more gracefully, should `cards` not be available.

I swear this is the last thing before it's properly finished.