### PR TITLE
I don't know why Yore-Tiller was the only 4-colour name, or why it broke things

### DIFF
--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -48,7 +48,7 @@ class Deck(Container):
 
     def __str__(self):
         self.sort()
-        s = '# {url}\n'.format(url=url_for('deck', deck_id=self.id, _external=True))
+        s = ''.format(url=url_for('deck', deck_id=self.id, _external=True))
         for entry in self.maindeck:
             s += '{n} {name}\n'.format(n=entry['n'], name=entry['name'])
         s += '\n'

--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -47,7 +47,7 @@ COLOR_COMBINATIONS = {
     'Abzan': ['W', 'B', 'G'],
     'Jeskai': ['W', 'U', 'R'],
     'Sultai': ['U', 'B', 'G'],
-    'Yore-Tiller': ['W', 'U', 'B', 'R'],
+    'WUBR': ['W', 'U', 'B', 'R'],
     'UBRG': ['U', 'B', 'R', 'G'],
     'BRGW': ['B', 'R', 'G', 'W'],
     'RGWU': ['R', 'G', 'W', 'U'],
@@ -77,7 +77,7 @@ def normalize(d: 'Deck') -> str:
         name = ucase_trailing_roman_numerals(name)
         return titlecase.titlecase(name)
     except ValueError:
-        raise InvalidDataException('Failed to normalize {d}'.format(d=d))
+        raise InvalidDataException('Failed to normalize {d}'.format(d=repr(d)))
 
 def file_name(d: 'Deck') -> str:
     safe_name = normalize(d).replace(' ', '-')

--- a/decksite/deck_name_test.py
+++ b/decksite/deck_name_test.py
@@ -56,6 +56,7 @@ TESTDATA = [
     ('PD', 'Azorius', ['U', 'W'], 'Unclassified'),
     ('White Jund', 'White Jund', None, None),
     ('Bant #Value', 'Bant Yisan-Prophet', ['G', 'U', 'W'], 'Yisan-Prophet'),
+    ('Yore-Tiller Control', 'Yore-Tiller Control', ['W', 'U', 'B', 'R'], 'Control'),
 
     # Cases that used to work well under strip-and-replace that no longer do
     # ('White Green', 'Selesnya Aggro', ['W', 'G'], 'Aggro'),


### PR DESCRIPTION
But normalizing it fixed the deck that was breaking reprime_cache.

bors r+