### PR TITLE
Move models to magic. They are too tightly coupled to live in shared.

### DIFF
--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -3,9 +3,9 @@ from typing import Dict, List, Optional
 from decksite.data import deck, guarantee, query
 from decksite.database import db
 from magic import oracle
+from magic.models.card import Card
 from shared.container import Container
 from shared.database import sqlescape
-from shared.models.card import Card
 
 
 def played_cards(where: str = '1 = 1', season_id: Optional[int] = None) -> List[Card]:

--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -8,10 +8,10 @@ from decksite.data import guarantee, query
 from decksite.data.top import Top
 from decksite.database import db
 from magic import legality, mana, oracle, rotation
+from magic.models.deck import Deck
 from shared import dtutil
 from shared.container import Container
 from shared.database import sqlescape
-from shared.models.deck import Deck
 from shared.pd_exception import InvalidDataException
 
 

--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -4,7 +4,7 @@ from typing import List, Match, Optional
 import titlecase
 
 from magic import mana
-from shared.models.deck import Deck
+from magic.models.deck import Deck
 from shared.pd_exception import InvalidDataException
 
 WHITELIST = [

--- a/decksite/scrapers/decklist.py
+++ b/decksite/scrapers/decklist.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Tuple
 import untangle
 
 from magic import oracle
-from shared.models.deck import Deck
+from magic.models.deck import Deck
 from shared.pd_exception import InvalidDataException
 
 SectionType = Dict[str, int]

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -13,9 +13,9 @@ from werkzeug.routing import BuildError
 from decksite import APP, get_season_id
 from decksite.data import archetype
 from magic import oracle, rotation, tournaments
+from magic.models.card import Card
+from magic.models.deck import Deck
 from shared import dtutil
-from shared.models.card import Card
-from shared.models.deck import Deck
 from shared_web.base_view import BaseView
 
 SeasonInfoDescription = TypedDict('SeasonInfoDescription', {

--- a/decksite/views/about.py
+++ b/decksite/views/about.py
@@ -5,7 +5,7 @@ from flask import url_for
 
 from decksite.view import View
 from magic import legality, oracle
-from shared.models.card import Card
+from magic.models.card import Card
 
 
 # pylint: disable=no-self-use

--- a/decksite/views/rotation.py
+++ b/decksite/views/rotation.py
@@ -8,8 +8,8 @@ from typing import List
 from decksite.data import card
 from decksite.view import View
 from magic import multiverse, oracle, rotation
+from magic.models.card import Card
 from shared import configuration, dtutil, text
-from shared.models.card import Card
 from shared.pd_exception import DoesNotExistException
 
 

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -23,10 +23,10 @@ from googleapiclient.errors import HttpError
 from discordbot import emoji
 from magic import (card, database, fetcher, image_fetcher, multiverse, oracle,
                    rotation, tournaments)
+from magic.models.card import Card
 from magic.whoosh_search import SearchResult, WhooshSearcher
 from shared import configuration, dtutil, repo
 from shared.lazy import lazy_property
-from shared.models.card import Card
 from shared.pd_exception import TooFewItemsException
 
 DEFAULT_CARDS_SHOWN = 4

--- a/discordbot/emoji.py
+++ b/discordbot/emoji.py
@@ -4,7 +4,7 @@ from typing import Optional
 from discord.client import Client
 
 from magic import oracle
-from shared.models.card import Card
+from magic.models.card import Card
 
 
 def find_emoji(emoji: str, client: Client) -> Optional[str]:

--- a/discordbot/unit_test.py
+++ b/discordbot/unit_test.py
@@ -2,8 +2,8 @@ import os
 
 from discordbot import command, emoji
 from magic import fetcher_internal, image_fetcher, oracle
+from magic.models.card import Card
 from shared import configuration
-from shared.models.card import Card
 
 
 # Check that we can fetch card images.

--- a/generate_readme.py
+++ b/generate_readme.py
@@ -18,13 +18,13 @@ View individual subdirectories for details
 
 **decksite** is the code for [pennydreadfulmagic.com](https://pennydreadfulmagic.com/).
 
-**magic** knows everything about all magic cards and how to fetch that information from the internet.
+**magic** knows everything about all magic cards and how to fetch that information from the internet and model it.
 
 **logsite**  is the code for [logs.pennydreadfulmagic.com](https://logs.pennydreadfulmagic.com/).
 
 **price_grabber** builds a database of historic prices.
 
-**shared** contains a bunch of general purpose helper classes.
+**shared** contains a bunch of general purpose helper classes. Things that could be used in any project.
 
 **shared_web** contains a bunch of web-specific helper classes.
 

--- a/magic/fetcher.py
+++ b/magic/fetcher.py
@@ -9,8 +9,8 @@ import pytz
 
 import magic.fetcher_internal as internal
 from magic.fetcher_internal import FetchException
+from magic.models.card import Card
 from shared import configuration, dtutil
-from shared.models.card import Card
 from shared.pd_exception import TooFewItemsException
 
 

--- a/magic/legality.py
+++ b/magic/legality.py
@@ -2,8 +2,8 @@ from typing import Dict, List, Set
 
 from magic import oracle, rotation
 from magic.database import db
+from magic.models.card import Card
 from shared.container import Container
-from shared.models.card import Card
 
 FORMATS: Set[str] = set()
 

--- a/magic/legality_test.py
+++ b/magic/legality_test.py
@@ -1,5 +1,5 @@
 from magic import legality, oracle
-from shared.models.deck import Deck
+from magic.models.deck import Deck
 
 
 def test_legal_formats() -> None:

--- a/magic/models/card.py
+++ b/magic/models/card.py
@@ -9,7 +9,7 @@ class Card(Container):
         super().__init__()
         for k in params.keys():
             setattr(self, k, determine_value(k, params))
-        if not self.names:
+        if not hasattr(self, 'names'):
             setattr(self, 'names', [self.name])
 
     def is_creature(self) -> bool:

--- a/magic/models/deck.py
+++ b/magic/models/deck.py
@@ -2,9 +2,9 @@ from typing import List
 
 from flask import url_for
 
+from magic.models.card import Card
 from shared import dtutil
 from shared.container import Container
-from shared.models.card import Card
 
 
 # pylint: disable=too-many-instance-attributes
@@ -23,8 +23,8 @@ class Deck(Container):
 
     def sort(self):
         if not self.sorted and (len(self.maindeck) > 0 or len(self.sideboard) > 0):
-            self.maindeck.sort(key=lambda x: oracle.deck_sort(x['card']))
-            self.sideboard.sort(key=lambda x: oracle.deck_sort(x['card']))
+            self.maindeck.sort(key=lambda x: deck_sort(x['card']))
+            self.sideboard.sort(key=lambda x: deck_sort(x['card']))
             self.sorted = True
 
     def is_in_current_run(self) -> bool:

--- a/magic/models/deck.py
+++ b/magic/models/deck.py
@@ -2,6 +2,7 @@ from typing import List
 
 from flask import url_for
 
+from magic import oracle
 from magic.models.card import Card
 from shared import dtutil
 from shared.container import Container
@@ -23,8 +24,8 @@ class Deck(Container):
 
     def sort(self):
         if not self.sorted and (len(self.maindeck) > 0 or len(self.sideboard) > 0):
-            self.maindeck.sort(key=lambda x: deck_sort(x['card']))
-            self.sideboard.sort(key=lambda x: deck_sort(x['card']))
+            self.maindeck.sort(key=lambda x: oracle.deck_sort(x['card']))
+            self.sideboard.sort(key=lambda x: oracle.deck_sort(x['card']))
             self.sorted = True
 
     def is_in_current_run(self) -> bool:

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -5,10 +5,10 @@ import pkg_resources
 
 from magic import card, database, fetcher, rotation
 from magic.database import db
+from magic.models.card import Card
 from magic.whoosh_write import WhooshWriter
 from shared import dtutil
 from shared.database import sqlescape
-from shared.models.card import Card
 from shared.pd_exception import InvalidArgumentException, InvalidDataException
 
 # Database setup for the magic package. Mostly internal. To interface with what the package knows about magic cards use the `oracle` module.

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -2,9 +2,9 @@ from typing import Collection, Dict, List, Optional
 
 from magic import card, fetcher, mana, multiverse, rotation
 from magic.database import db
+from magic.models.card import Card
 from shared.container import Container
 from shared.database import sqlescape
-from shared.models.card import Card
 from shared.pd_exception import (InvalidArgumentException,
                                  InvalidDataException, TooFewItemsException)
 

--- a/magic/rotation.py
+++ b/magic/rotation.py
@@ -6,8 +6,8 @@ from typing import Dict, List, Optional, Union, cast
 from mypy_extensions import TypedDict
 
 from magic import fetcher
+from magic.models.card import Card
 from shared import configuration, dtutil
-from shared.models.card import Card
 from shared.pd_exception import DoesNotExistException, InvalidDataException
 
 SetInfoType = TypedDict('SetInfoType', {

--- a/magic/tournaments.py
+++ b/magic/tournaments.py
@@ -6,9 +6,9 @@ from typing import Any, Dict, List, Tuple
 import inflect
 from dateutil import rrule  # type: ignore # dateutil stubs are incomplete
 
+from magic.models.deck import Deck
 from shared import dtutil
 from shared.container import Container
-from shared.models.deck import Deck
 
 TournamentDateType = Tuple[str, datetime.datetime]
 

--- a/magic/whoosh_write.py
+++ b/magic/whoosh_write.py
@@ -4,8 +4,8 @@ from typing import List
 from whoosh.fields import NUMERIC, STORED, TEXT, Schema
 from whoosh.index import Index, create_in, open_dir
 
+from magic.models.card import Card
 from magic.whoosh_constants import WhooshConstants
-from shared.models.card import Card
 
 
 class WhooshWriter():

--- a/price_grabber/price.py
+++ b/price_grabber/price.py
@@ -4,8 +4,8 @@ from typing import Optional
 from mypy_extensions import TypedDict
 
 from magic import rotation
+from magic.models.card import Card
 from shared import configuration, database
-from shared.models.card import Card
 
 PriceDataType = TypedDict('PriceDataType', {
     'time': int,


### PR DESCRIPTION
I updated the README to reflect our new philosophy.

shared - Generic util code that could be used in any project (not MtG-specific).
magic - Code related to modeling Magic cards to be shared by bot/site/etc.

I think this is right but there's a chance magic is becoming a big blob that
knows everything and will need some intervention.