### PR TITLE
Fix regression introduced in d51c137d79c723ecd2e0d408fd052aca8f070837.

### DIFF
--- a/logsite/view.py
+++ b/logsite/view.py
@@ -2,9 +2,6 @@ from flask import url_for
 
 from shared_web.base_view import BaseView
 
-from . import APP
-
-
 # pylint: disable=no-self-use, too-many-public-methods
 class View(BaseView):
     def js_extra_url(self):
@@ -23,6 +20,3 @@ class View(BaseView):
 
     def subtitle(self):
         return None
-
-    def commit_id(self, path: str = None) -> str:
-        return APP.config['commit-id']

--- a/logsite/view.py
+++ b/logsite/view.py
@@ -2,6 +2,7 @@ from flask import url_for
 
 from shared_web.base_view import BaseView
 
+
 # pylint: disable=no-self-use, too-many-public-methods
 class View(BaseView):
     def js_extra_url(self):

--- a/shared_web/base_view.py
+++ b/shared_web/base_view.py
@@ -24,10 +24,15 @@ class BaseView:
         return
 
     def commit_id(self, path: str = None) -> str:
-        args = ['git', 'log', '--format="%H"', '-n', '1']
-        if path:
-            args.append(path)
-        return subprocess.check_output(args, universal_newlines=True).strip('\n').strip('"')
+        if not path:
+            return current_app.config['commit-id']
+        key = f'commit-id-{path}'
+        commit = current_app.config.get(key, None)
+        if commit is None:
+            args = ['git', 'log', '--format="%H"', '-n', '1', path]
+            commit = subprocess.check_output(args, universal_newlines=True).strip('\n').strip('"')
+            current_app.config[key] = commit
+        return commit
 
     def git_branch(self) -> str:
         return current_app.config['branch']


### PR DESCRIPTION
The fix for #1963 involved running three seperate `git` executions per page request.
This commit fixes that by once again caching commit-ids on the flask application instance.

bors r+