### PR TITLE
Better Beta workflow

### DIFF
--- a/github_tools/__init__.py
+++ b/github_tools/__init__.py
@@ -47,7 +47,7 @@ def on_pull_request(data):
     print([org, repo, pr_number])
     if data['action'] == 'synchronize' or data['action'] == 'opened':
         webhooks.set_check(data, 'pending', 'Waiting for tests')
-    if data['action'] == 'labeled':
+    if data['action'] == 'labeled' or data['action'] == 'unlabeled':
         pr = webhooks.load_pr(data)
         if pr.state == 'open':
             return webhooks.check_pr_for_mergability(pr)

--- a/github_tools/webhooks.py
+++ b/github_tools/webhooks.py
@@ -94,6 +94,12 @@ def check_pr_for_mergability(pr: PullRequest) -> str:
         commit.create_status(state='pending', description='Waiting for "merge when ready"', context=PDM_CHECK_CONTEXT)
         return 'Waiting for label'
 
+    if 'beta test' in labels:
+        trying = repo.get_git_ref('trying')
+        trying.edit(commit.sha, True)
+        commit.create_status(state='success', description='Deployed to test branch', context=PDM_CHECK_CONTEXT)
+        return 'beta test'
+
     commit.create_status(state='success', description='Ready to merge', context=PDM_CHECK_CONTEXT)
     pr.merge()
     return 'good to merge'


### PR DESCRIPTION
If a PR has the beta test label, deploy it to `trying` instead of merging.