### PR TITLE
This is the worst-performing query on the site and frequently takes >10s.

### DIFF
--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -54,36 +54,6 @@ def load_card(name: str, season_id: Optional[int] = None) -> Card:
     c.played_competitively = c.all_wins or c.all_losses or c.all_draws
     return c
 
-def only_played_by(person_id: int, season_id: Optional[int] = None) -> List[Card]:
-    sql = """
-        SELECT
-            card AS name
-        FROM
-            deck_card AS dc
-        INNER JOIN
-            deck AS d ON dc.deck_id = d.id
-        {season_join}
-        WHERE
-            deck_id
-        IN
-            (
-                SELECT
-                    DISTINCT deck_id
-                FROM
-                    deck_match
-            ) -- Only include cards that actually got played competitively rather than just posted to Goldfish as "new cards this season" or similar.
-        AND
-            ({season_query})
-        GROUP BY
-            card
-        HAVING
-            COUNT(DISTINCT d.person_id) = 1
-        AND
-            MAX(d.person_id) = {person_id} -- In MySQL 5.7+ this could/should be ANY_VALUE not MAX but this works with any version. The COUNT(DISTINCT  p.id) ensures this only has one possible value but MySQL can't work that out.-- In MySQL 5.7+ this could/should be ANY_VALUE not MAX but this works with any version. The COUNT(DISTINCT  p.id) ensures this only has one possible value but MySQL can't work that out.
-    """.format(season_join=query.season_join(), season_query=query.season_query(season_id), person_id=sqlescape(person_id))
-    cards = {c.name: c for c in oracle.load_cards()}
-    return [cards[r['name']] for r in db().execute(sql)]
-
 def playability() -> Dict[str, float]:
     sql = """
         SELECT

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -78,7 +78,7 @@ def people():
 def person(person_id):
     p = ps.load_person(person_id, season_id=get_season_id())
     played_cards = cs.played_cards_by_person(p.id, get_season_id())
-    only_played_cards = cs.only_played_by(p.id, get_season_id())
+    only_played_cards = []
     view = Person(p, played_cards, only_played_cards)
     return view.page()
 


### PR DESCRIPTION
This is very much a nice-to-have feature so I'm going to remove it for now.

It actually makes no sense in that if your first use is any good someone else
will use the card so this becomes essentially your "hall of shame" of mistakes
you made! It is interesting though so I'll try to find a replacement or generate
it offline or speed up the query.