### PR TITLE
Completely ignore the gatherling-provided archetypes

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -36,9 +36,9 @@ def load_archetype(archetype, season_id=None):
         archetype.decks = []
     return archetype
 
-def load_archetypes(where='1 = 1', merge=False, season_id=None):
+def load_archetypes(where: str = '1 = 1', merge: bool = False, season_id: int = None) -> List[Archetype]:
     decks = deck.load_decks(where, season_id=season_id)
-    archetypes = {}
+    archetypes: Dict[str, Archetype] = {}
     for d in decks:
         if d.archetype_id is None:
             continue
@@ -66,8 +66,8 @@ def load_archetypes(where='1 = 1', merge=False, season_id=None):
             if d.source_name == 'League' and d.wins >= 5 and d.losses == 0:
                 archetype.season_perfect_runs = archetype.get('season_all_perfect_runs', 0) + 1
         archetypes[key] = archetype
-    archetypes = list(archetypes.values())
-    return archetypes
+    archetype_list = list(archetypes.values())
+    return archetype_list
 
 def load_archetypes_deckless(where: str = '1 = 1',
                              order_by: str = '`all_num_decks` DESC, `all_wins` DESC, name',
@@ -118,8 +118,8 @@ def add(name: str, parent: int) -> None:
     sql += '({ancestor}, {descendant}, {depth})'.format(ancestor=archetype_id, descendant=archetype_id, depth=0)
     db().execute(sql)
 
-def assign(deck_id: int, archetype_id: int) -> None:
-    db().execute('UPDATE deck SET reviewed = TRUE, archetype_id = %s WHERE id = %s', [archetype_id, deck_id])
+def assign(deck_id: int, archetype_id: int, reviewed: bool = True) -> None:
+    db().execute('UPDATE deck SET reviewed = %s, archetype_id = %s WHERE id = %s', [reviewed, archetype_id, deck_id])
 
 def load_all_matchups(where='TRUE', season_id=None):
     sql = """

--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -398,6 +398,22 @@ def load_similar_decks(ds: List[Deck]) -> None:
     for d in ds:
         d.similar_decks = []
 
+def calculate_similar_decks(ds: List[Deck]) -> None:
+    threshold = 20
+    cards_escaped = ', '.join(sqlescape(name) for name in all_card_names(ds))
+    if not cards_escaped:
+        for d in ds:
+            d.similar_decks = []
+        return
+    potentially_similar = load_decks('d.id IN (SELECT deck_id FROM deck_card WHERE card IN ({cards_escaped}))'.format(cards_escaped=cards_escaped))
+    for d in ds:
+        for psd in potentially_similar:
+            psd.similarity_score = round(similarity_score(d, psd) * 100)
+        d.similar_decks = [psd for psd in potentially_similar if psd.similarity_score >= threshold and psd.id != d.id]
+        d.similar_decks.sort(key=lambda d: -(d.similarity_score))
+        redis.store('decksite:deck:{id}:similar'.format(id=d.id), d.similar_decks, ex=172800)
+
+
 def all_card_names(ds: List[Deck]) -> Set[str]:
     basic_lands = ['Plains', 'Island', 'Swamp', 'Mountain', 'Forest']
     names = set()

--- a/decksite/scrapers/gatherling.py
+++ b/decksite/scrapers/gatherling.py
@@ -10,7 +10,6 @@ from decksite.data import archetype, competition, deck, match
 from decksite.database import db
 from decksite.scrapers import decklist
 from magic import fetcher
-from maintenance import calculate_similar_decks
 from shared import dtutil
 from shared.pd_exception import InvalidDataException
 from shared_web import logger
@@ -97,7 +96,7 @@ def add_decks(dt: datetime.datetime, competition_id: int, final: Dict[str, int],
     return decks_added
 
 def guess_archetypes(ds: List[deck.Deck]) -> None:
-    calculate_similar_decks.load_similar_decks(ds)
+    deck.calculate_similar_decks(ds)
     for d in ds:
         if d.similar_decks:
             archetype.assign(d.id, d.similar_decks[0].archetype_id, False)

--- a/decksite/scrapers/gatherling.py
+++ b/decksite/scrapers/gatherling.py
@@ -6,10 +6,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import bs4
 from bs4 import BeautifulSoup, ResultSet
 
-from decksite.data import competition, deck, match
+from decksite.data import archetype, competition, deck, match
 from decksite.database import db
 from decksite.scrapers import decklist
 from magic import fetcher
+from maintenance import calculate_similar_decks
 from shared import dtutil
 from shared.pd_exception import InvalidDataException
 from shared_web import logger
@@ -92,7 +93,14 @@ def add_decks(dt: datetime.datetime, competition_id: int, final: Dict[str, int],
                 matches += tournament_matches(d)
     add_ids(matches, ds)
     insert_matches_without_dupes(dt, matches)
+    guess_archetypes(ds)
     return decks_added
+
+def guess_archetypes(ds: List[deck.Deck]) -> None:
+    calculate_similar_decks.load_similar_decks(ds)
+    for d in ds:
+        if d.similar_decks:
+            archetype.assign(d.id, d.similar_decks[0].archetype_id, False)
 
 def rankings(soup: BeautifulSoup) -> List[str]:
     rows = soup.find(text='Current Standings').find_parent('table').find_all('tr')

--- a/maintenance/calculate_similar_decks.py
+++ b/maintenance/calculate_similar_decks.py
@@ -1,10 +1,6 @@
 import time
-from typing import List
 
 from decksite.data import archetype, deck
-from magic.models import Deck
-from shared import redis
-from shared.database import sqlescape
 
 
 def ad_hoc() -> None:
@@ -12,21 +8,6 @@ def ad_hoc() -> None:
     for a in archetypes:
         print(f'Generating Similar Decks for {a.name} ({len(a.decks)} decks)')
         s = time.perf_counter()
-        load_similar_decks(a.decks)
+        deck.calculate_similar_decks(a.decks)
         t = time.perf_counter() - s
         print(f'Completed {len(a.decks)} decks in {t}')
-
-def load_similar_decks(ds: List[Deck]) -> None:
-    threshold = 20
-    cards_escaped = ', '.join(sqlescape(name) for name in deck.all_card_names(ds))
-    if not cards_escaped:
-        for d in ds:
-            d.similar_decks = []
-        return
-    potentially_similar = deck.load_decks('d.id IN (SELECT deck_id FROM deck_card WHERE card IN ({cards_escaped}))'.format(cards_escaped=cards_escaped))
-    for d in ds:
-        for psd in potentially_similar:
-            psd.similarity_score = round(deck.similarity_score(d, psd) * 100)
-        d.similar_decks = [psd for psd in potentially_similar if psd.similarity_score >= threshold and psd.id != d.id]
-        d.similar_decks.sort(key=lambda d: -(d.similarity_score))
-        redis.store('decksite:deck:{id}:similar'.format(id=d.id), d.similar_decks, ex=172800)

--- a/maintenance/calculate_similar_decks.py
+++ b/maintenance/calculate_similar_decks.py
@@ -1,0 +1,32 @@
+import time
+from typing import List
+
+from decksite.data import archetype, deck
+from magic.models import Deck
+from shared import redis
+from shared.database import sqlescape
+
+
+def ad_hoc() -> None:
+    archetypes = archetype.load_archetypes()
+    for a in archetypes:
+        print(f'Generating Similar Decks for {a.name} ({len(a.decks)} decks)')
+        s = time.perf_counter()
+        load_similar_decks(a.decks)
+        t = time.perf_counter() - s
+        print(f'Completed {len(a.decks)} decks in {t}')
+
+def load_similar_decks(ds: List[Deck]) -> None:
+    threshold = 20
+    cards_escaped = ', '.join(sqlescape(name) for name in deck.all_card_names(ds))
+    if not cards_escaped:
+        for d in ds:
+            d.similar_decks = []
+        return
+    potentially_similar = deck.load_decks('d.id IN (SELECT deck_id FROM deck_card WHERE card IN ({cards_escaped}))'.format(cards_escaped=cards_escaped))
+    for d in ds:
+        for psd in potentially_similar:
+            psd.similarity_score = round(deck.similarity_score(d, psd) * 100)
+        d.similar_decks = [psd for psd in potentially_similar if psd.similarity_score >= threshold and psd.id != d.id]
+        d.similar_decks.sort(key=lambda d: -(d.similarity_score))
+        redis.store('decksite:deck:{id}:similar'.format(id=d.id), d.similar_decks, ex=172800)


### PR DESCRIPTION
The Gatherling scraper uses the `similar_decks` logic to make a best-guess at what the pre-review archetype should be.