### PR TITLE
Only replace the color word once to avoid "Gruul EnGruuly".

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -135,7 +135,7 @@ def normalize_colors(name: str) -> str:
     color_words = list(unique_color_words)
     canonical_colors = canonicalize_colors(color_words)
     true_color = name_from_colors(canonical_colors)
-    name = name.replace(color_words[0], true_color)
+    name = name.replace(color_words[0], true_color, 1)
     for color_word in color_words[1:]:
         name = name.replace(color_word, '')
     if len(canonical_colors) == 1 and name.startswith(true_color):

--- a/decksite/deck_name_test.py
+++ b/decksite/deck_name_test.py
@@ -67,7 +67,8 @@ TESTDATA = [
     ('ゼウスサイクリング', 'Sultai New Perspectives', ['U', 'G', 'B'], 'New Perspectives'),
     ('$', 'UBRG Necrotic Ooze Combo', ['U', 'B', 'R', 'G'], 'Necrotic Ooze Combo'),
     ('White Green', 'Selesnya Aggro', ['W', 'G'], 'Aggro'),
-    ('White Green', 'Selesnya', ['W', 'G'], None)
+    ('White Green', 'Selesnya', ['W', 'G'], None),
+    ('RG Energy', 'Gruul Energy', ['R', 'G'], 'Pummeler')
 ]
 
 @pytest.mark.parametrize('original_name,expected,colors,archetype_name', TESTDATA)


### PR DESCRIPTION
This isn't actually perfect in that it will mess up on something like
"Energy RG". But is someone really going to name a deck that?

Fixes #5181.