### PR TITLE
Make homepage deck query 2s faster.

### DIFF
--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -17,6 +17,9 @@ from shared.database import sqlescape
 from shared.pd_exception import InvalidDataException
 
 
+def latest_decks() -> List[Deck]:
+    return load_decks(where='d.created_date > UNIX_TIMESTAMP(NOW() - INTERVAL 30 DAY)', limit='LIMIT 50')
+
 def load_deck(deck_id: int) -> Deck:
     return guarantee.exactly_one(load_decks('d.id = {deck_id}'.format(deck_id=sqlescape(deck_id))))
 

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -37,7 +37,7 @@ from shared.pd_exception import (DoesNotExistException, InvalidDataException,
 @APP.route('/')
 @cached()
 def home():
-    view = Home(ns.all_news(max_items=10), ds.load_decks(limit='LIMIT 50'), cs.load_cards(season_id=get_season_id()))
+    view = Home(ns.all_news(max_items=10), ds.latest_decks(), cs.load_cards(season_id=get_season_id()))
     return view.page()
 
 @APP.route('/decks/')


### PR DESCRIPTION
Basically every deck with an active date that is relevant will be from the
last 30 days so this essentially gives the same results just much faster.