### PR TITLE
Get accurate "was a hit in last run" information by left-padding run files with zeroes

### DIFF
--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -67,7 +67,7 @@ def process(all_prices: Dict[str, PriceListType]) -> int:
 def process_sets(seen_sets: Set[str], used_sets: Set[str], hits: Set[str], ignored: Set[str]) -> int:
     files = rotation.files()
     n = len(files) + 1
-    path = os.path.join(configuration.get_str('legality_dir'), 'Run_{n}.txt').format(n=n.zfill(3))
+    path = os.path.join(configuration.get_str('legality_dir'), 'Run_{n}.txt').format(n=str(n).zfill(3))
     h = open(path, mode='w', encoding='utf-8')
     for card in hits:
         line = card + '\n'

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -67,7 +67,7 @@ def process(all_prices: Dict[str, PriceListType]) -> int:
 def process_sets(seen_sets: Set[str], used_sets: Set[str], hits: Set[str], ignored: Set[str]) -> int:
     files = rotation.files()
     n = len(files) + 1
-    path = os.path.join(configuration.get_str('legality_dir'), 'Run_{n}.txt').format(n=n)
+    path = os.path.join(configuration.get_str('legality_dir'), 'Run_{n}.txt').format(n=n.zfill(3))
     h = open(path, mode='w', encoding='utf-8')
     for card in hits:
         line = card + '\n'


### PR DESCRIPTION
Otherwise glob will give them back to us in an uncool order and we'll thing Run_9.txt or Run_99.txt is the 'latest' instead of Run_10.txt or Run_100.txt.