### PR TITLE
Give demimods the ability to view decklist

### DIFF
--- a/decksite/view.py
+++ b/decksite/view.py
@@ -196,7 +196,7 @@ class View(BaseView):
             d.legal_icons += '<a href="{url}"><i class="ss ss-{set} ss-common ss-grad">S{n}</i></a>'.format(url='/seasons/{id}/'.format(id=n), set=code.lower(), n=n)
         if 'Commander' in d.legal_formats: # I think C16 looks the nicest.
             d.legal_icons += '<i class="ss ss-c16 ss-uncommon ss-grad">CMDR</i>'
-        if session.get('admin') or not d.is_in_current_run():
+        if session.get('admin') or session.get('demimod') or not d.is_in_current_run():
             d.decklist = str(d).replace('\n', '<br>')
         else:
             d.decklist = ''


### PR DESCRIPTION
Give demimods the ability to see the decklist when they hover over the deck name on the archetype admin page. Closes #5379 