### PR TITLE
Load archetypes that don't have cache entries.

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -77,7 +77,7 @@ def load_archetypes_deckless(order_by: str = '`num_decks` DESC, `wins` DESC, nam
             IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent
         FROM
             archetype AS a
-        INNER JOIN
+        LEFT JOIN
             _archetype_stats AS ars ON a.id = ars.archetype_id
         LEFT JOIN
             archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1


### PR DESCRIPTION
This is so that if you add an archetype at /admin/archetypes/ you can see
it to add decks to it (!)

Fixes #5386.