### PR TITLE
Account for "double width" images like dfcs when making composite images.

### DIFF
--- a/magic/image_fetcher.py
+++ b/magic/image_fetcher.py
@@ -148,7 +148,8 @@ def download_image(cards: List[Card]) -> Optional[str]:
 def save_composite_image(in_filepaths: List[str], out_filepath: str) -> None:
     images = list(map(Image.open, in_filepaths))
     for image in images:
-        image.thumbnail([312, 445])
+        aspect_ratio = image.width / image.height
+        image.thumbnail([aspect_ratio * 445, 445])
     widths, heights = zip(*(i.size for i in images))
     total_width = sum(widths)
     max_height = max(heights)


### PR DESCRIPTION
Fixes #5371.