### PR TITLE
Let archetype sculptors reassign a deck's archetype on the deck page

### DIFF
--- a/decksite/templates/deck.mustache
+++ b/decksite/templates/deck.mustache
@@ -123,7 +123,7 @@
 {{/has_similar}}
 {{/public}}
 {{> legal}}
-<section class="admin">
+<section class="admin demimod">
     <h2>Admin</h2>
         <p>
             <p>Original name: {{original_name}}</p>


### PR DESCRIPTION
Fixes #5589 