### PR TITLE
Add admin tool for finding decklists with more than one categorisation

### DIFF
--- a/decksite/admin.py
+++ b/decksite/admin.py
@@ -56,6 +56,8 @@ def post_archetypes():
                 redis.clear(f'decksite:deck:{deck_id}')
     elif request.form.get('q') is not None and request.form.get('notq') is not None:
         search_results = ds.load_decks_by_cards(request.form.get('q').splitlines(), request.form.get('notq').splitlines())
+    elif request.form.get('find_conflicts') is not None:
+        search_results = ds.load_conflicted_decks()
     elif request.form.get('rename_to') is not None:
         archs.rename(request.form.get('archetype_id'), request.form.get('rename_to'))
     elif request.form.get('new_description') is not None:

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -73,7 +73,7 @@
     </form>
 </section>
 <section>
-    <h2>Search By Card</h2>
+    <h2>Search for Decks</h2>
 
     <form method="post">
         <div>
@@ -84,7 +84,13 @@
             <label for="notq">Without these cards</label>
             <textarea name="notq">{{notquery}}</textarea>
         </div>
-        <button type="submit">Search</button>
+        <button type="submit">Search by Card</button>
+    </form>
+
+    <form method="post">
+        <p>Use this tool to automatically find cases where identical decks have been assigned different archetypes.</p>
+        <input type="hidden" name="find_conflicts" value="true"></input>
+        <button type="submit" name="conflicts">Search for Conflicts</button>
     </form>
 
     {{#has_search_results}}


### PR DESCRIPTION
Slightly rough-and-ready, but after clearing up the initial batch one should only ever need to use this to sort out a few conflicts at a time.
Closes #5609.