### PR TITLE
Fix badge text on person page

### DIFF
--- a/decksite/templates/person.mustache
+++ b/decksite/templates/person.mustache
@@ -19,7 +19,7 @@
         <h2>Achievements</h2>
         <ul class="buttons">
             {{#displayed_achievements}}
-                <li title="{{detail}}">{{name}}</li>
+                <li title="{{detail}}">{{title}}</li>
             {{/displayed_achievements}}
         </ul>
         <p><a href="{{achievements_url}}">See all achievements</a></p>


### PR DESCRIPTION
Achievement badges should now display the name of the achievement again instead of your own name.