### PR TITLE
New "Deck Builder" achievement

### DIFF
--- a/decksite/achievements.py
+++ b/decksite/achievements.py
@@ -43,6 +43,7 @@ def preaggregate_achievements() -> None:
 def preaggregate_query() -> str:
     create_columns = ', '.join(f'`{a.key}` INT NOT NULL' for a in Achievement.all_achievements if a.in_db)
     select_columns = ', '.join(f'{a.sql} as `{a.key}`' for a in Achievement.all_achievements if a.in_db)
+    with_clauses = ', '.join(a.with_sql for a in Achievement.all_achievements if a.with_sql is not None)
     return """
         CREATE TABLE IF NOT EXISTS _new_achievements (
             person_id INT NOT NULL,
@@ -52,6 +53,8 @@ def preaggregate_query() -> str:
             FOREIGN KEY (season_id) REFERENCES season (id) ON UPDATE CASCADE ON DELETE CASCADE,
             FOREIGN KEY (person_id) REFERENCES person (id) ON UPDATE CASCADE ON DELETE CASCADE
         ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci AS
+        WITH
+        {with_clauses}
         SELECT
             p.id AS person_id,
             season.id AS season_id,
@@ -69,7 +72,7 @@ def preaggregate_query() -> str:
             season.id
         HAVING
             season.id IS NOT NULL
-    """.format(cc=create_columns, sc=select_columns, season_join=query.season_join(), competition_join=query.competition_join())
+    """.format(cc=create_columns, sc=select_columns, with_clauses=with_clauses, season_join=query.season_join(), competition_join=query.competition_join())
 
 def displayed_achievements(p: 'person.Person') -> List[Dict[str, str]]:
     return [d for d in ({'title': a.title, 'detail': a.display(p)} for a in Achievement.all_achievements) if d['detail']]
@@ -80,6 +83,7 @@ class Achievement:
     all_achievements: List['Achievement'] = []
     key: Optional[str] = None
     sql: Optional[str] = None
+    with_sql: Optional[str] = None
     in_db = True
     title = ''
     description_safe = ''
@@ -315,6 +319,24 @@ class PerfectRunCrusher(CountedAchievement):
                             SUM(CASE WHEN dm.games < odm.games AND dm.match_id IN (SELECT MAX(match_id) FROM deck_match WHERE deck_id = d.id) THEN 1 ELSE 0 END) = 1
                     )
                 THEN 1 ELSE 0 END)""".format(competition_ids_by_type_select=query.competition_ids_by_type_select('League'))
+
+class Deckbuilder(CountedAchievement):
+    key = 'deckbuilder'
+    title = 'Deck Builder'
+    singular = 'deck played by others'
+    plural = 'decks played by others'
+    description_safe = 'Have someone else register an exact copy of a deck you registered first.'
+    sql = 'COUNT(DISTINCT CASE WHEN d.id IN (SELECT original FROM netdecks) AND d.id NOT IN (SELECT copy FROM netdecks) THEN d.id ELSE NULL END)'
+    with_sql = """netdecks AS
+                    (
+                        SELECT
+                            d1.id AS original, d2.id AS copy
+                        FROM
+                            deck AS d1
+                        JOIN
+                            deck AS d2
+                        ON d1.decklist_hash = d2.decklist_hash AND d1.created_date < d2.created_date AND d1.person_id != d2.person_id
+                    )"""
 
 class Pioneer(CountedAchievement):
     key = 'pioneer'

--- a/decksite/achievements.py
+++ b/decksite/achievements.py
@@ -339,9 +339,11 @@ class PerfectRunCrusher(CountedAchievement):
 class Deckbuilder(CountedAchievement):
     key = 'deckbuilder'
     title = 'Deck Builder'
-    singular = 'deck played by others'
-    plural = 'decks played by others'
     description_safe = 'Have someone else register an exact copy of a deck you registered first.'
+    def leaderboard_heading(self):
+        return gettext('decks played by others')
+    def localised_display(self, n):
+        return ngettext('1 deck played by others', '%(num)d decks played by others', n)
     sql = 'COUNT(DISTINCT CASE WHEN d.id IN (SELECT original FROM repeats WHERE newplayer = TRUE) AND d.id NOT IN (SELECT copy FROM repeats) THEN d.id ELSE NULL END)'
     with_sql = """repeats AS
                     (


### PR DESCRIPTION
Achievement for having someone else register your exact same 75 (determined by comparing decklist_hash). Any given deck can only give this achievement once ever, to the first player who registered it.

Also adds a new hook for achievements to add an SQL WITH clause on the beginning of the preaggregation query, which might enable rewriting some of the more tortured queries in a more straightforward way.

Closes #5002