### PR TITLE
More sophisticated deck rules

### DIFF
--- a/decksite/admin.py
+++ b/decksite/admin.py
@@ -1,5 +1,4 @@
 from typing import Dict, List, Optional
-import re
 
 from flask import request, session, url_for
 
@@ -12,10 +11,10 @@ from decksite.data import match as ms
 from decksite.data import news as ns
 from decksite.data import person as ps
 from decksite.data import rule as rs
+from decksite.scrapers.decklist import parse_line
 from decksite.views import (Admin, EditAliases, EditArchetypes, EditMatches,
                             EditNews, EditRules, PlayerNotes, Prizes,
                             RotationChecklist, Unlink)
-from decksite.scrapers.decklist import parse_line
 from magic.models import Deck
 from shared import dtutil, redis
 from shared.container import Container

--- a/decksite/admin.py
+++ b/decksite/admin.py
@@ -1,4 +1,5 @@
 from typing import Dict, List, Optional
+import re
 
 from flask import request, session, url_for
 
@@ -14,6 +15,7 @@ from decksite.data import rule as rs
 from decksite.views import (Admin, EditAliases, EditArchetypes, EditMatches,
                             EditNews, EditRules, PlayerNotes, Prizes,
                             RotationChecklist, Unlink)
+from decksite.scrapers.decklist import parse_line
 from magic.models import Deck
 from shared import dtutil, redis
 from shared.container import Container
@@ -101,8 +103,8 @@ def edit_rules() -> str:
 @auth.demimod_required
 def post_rules() -> str:
     if request.form.get('rule_id') is not None and request.form.get('include') is not None and request.form.get('exclude') is not None:
-        inc = request.form.get('include').strip().splitlines()
-        exc = request.form.get('exclude').strip().splitlines()
+        inc = [parse_line(line) for line in request.form.get('include').strip().splitlines()]
+        exc = [parse_line(line) for line in request.form.get('exclude').strip().splitlines()]
         rs.update_cards(request.form.get('rule_id'), inc, exc)
     elif request.form.get('archetype_id') is not None:
         rs.add_rule(request.form.get('archetype_id'))

--- a/decksite/data/rule.py
+++ b/decksite/data/rule.py
@@ -107,10 +107,10 @@ def update_cards(rule_id: int, inc: str, exc: str) -> None:
     sql = 'DELETE FROM rule_card WHERE rule_id = %s'
     db().execute(sql, [rule_id])
     for card in inc:
-        sql = 'INSERT INTO rule_card (rule_id, card, include) VALUES (%s, %s, TRUE)'
+        sql = 'INSERT INTO rule_card (rule_id, card, n, include) VALUES (%s, %s, 1, TRUE)'
         db().execute(sql, [rule_id, card])
     for card in exc:
-        sql = 'INSERT INTO rule_card (rule_id, card, include) VALUES (%s, %s, FALSE)'
+        sql = 'INSERT INTO rule_card (rule_id, card, n, include) VALUES (%s, %s, 1, FALSE)'
         db().execute(sql, [rule_id, card])
     db().commit('update_rule_cards')
 
@@ -166,7 +166,7 @@ def apply_rules_query(deck_query: str = '1 = 1', include_all_rules: bool = False
             ON
                 rule.id = rule_card_count.id
             WHERE
-                deck_card.sideboard = FALSE AND {deck_query}
+                deck_card.sideboard = FALSE AND deck_card.n >= inclusions.n AND {deck_query}
             GROUP BY
                 deck.id, rule.id
             HAVING
@@ -201,7 +201,7 @@ def apply_rules_query(deck_query: str = '1 = 1', include_all_rules: bool = False
         LEFT JOIN
             deck_card
         ON
-            candidates.deck_id = deck_card.deck_id AND exclusions.card = deck_card.card
+            candidates.deck_id = deck_card.deck_id AND exclusions.card = deck_card.card AND deck_card.n >= exclusions.n
         GROUP BY
             candidates.deck_id, rule_id
         HAVING

--- a/decksite/data/rule.py
+++ b/decksite/data/rule.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from decksite.data import deck
 from decksite.database import db
@@ -111,7 +111,7 @@ def add_rule(archetype_id: int) -> None:
     sql = 'INSERT INTO rule (archetype_id) VALUES (%s)'
     db().insert(sql, [archetype_id])
 
-def update_cards(rule_id: int, inc: str, exc: str) -> None:
+def update_cards(rule_id: int, inc: List[Tuple[int, str]], exc: List[Tuple[int, str]]) -> None:
     db().begin('update_rule_cards')
     sql = 'DELETE FROM rule_card WHERE rule_id = %s'
     db().execute(sql, [rule_id])

--- a/decksite/sql/49.sql
+++ b/decksite/sql/49.sql
@@ -1,0 +1,3 @@
+ALTER TABLE rule_card ADD n INTEGER;
+UPDATE rule_card SET n=1;
+ALTER TABLE rule_card MODIFY n INTEGER NOT NULL;

--- a/decksite/templates/editrules.mustache
+++ b/decksite/templates/editrules.mustache
@@ -69,9 +69,9 @@
                     <th>Must not include</th>
                 </tr>
                 <tr>
-                    <td><textarea name="include">{{#included_cards}}{{.}}
+                    <td><textarea name="include">{{#included_cards}}{{n}} {{card}}
 {{/included_cards}}</textarea></td>
-                    <td><textarea name="exclude">{{#excluded_cards}}{{.}}
+                    <td><textarea name="exclude">{{#excluded_cards}}{{n}} {{card}}
 {{/excluded_cards}}</textarea></td>
                 </tr>
             </table>


### PR DESCRIPTION
You can (and must) now specify the number of a card in each rule.
- For included cards, the rule only applies if that many of the card or more are present
- For excluded cards, the rule will not apply if that many or more of the card are present

Also fixed a bug where the rules page would throw an exception in certain rare circumstances where a rule had no decks, by rewriting the query to do something much more straightforward (which should protect against further similar bugs).