### PR TITLE
--check-untyped-defs is now enabled

### DIFF
--- a/decksite/api.py
+++ b/decksite/api.py
@@ -42,7 +42,7 @@ def competitions_api():
             cr['name'] = c.name
             cr['url'] = url_for('competition_api', competition_id=c.id, _external=True)
             r.append(cr)
-    return return_json(r)
+    return return_json(r) # type: ignore
 
 @APP.route('/api/competitions/<competition_id>')
 def competition_api(competition_id: int) -> Response:

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -180,7 +180,7 @@ def signup(form: SignUpForm) -> deck.Deck:
     form.name = form.name.strip()
     return deck.add_deck(form)
 
-def identifier(params):
+def identifier(params: Dict[str, str]) -> str:
     # Current timestamp is part of identifier here because we don't need to defend against dupes in league – it's fine to enter the same league with the same deck, later.
     return json.dumps([params['mtgo_username'], params['competition_id'], str(round(time.time()))])
 

--- a/decksite/views/resources.py
+++ b/decksite/views/resources.py
@@ -1,17 +1,32 @@
+from typing import List
+
+from mypy_extensions import TypedDict
+
 from decksite.view import View
 from magic import fetcher
 
+ResourceDescription = TypedDict('ResourceDescription',
+                                {
+                                    'text': str,
+                                    'url': str,
+                                    'is_external': bool,
+                                })
+SectionDescription = TypedDict('SectionDescription',
+                               {
+                                   'title': str,
+                                   'items': List[ResourceDescription],
+                               })
 
 # pylint: disable=no-self-use
 class Resources(View):
     def sections(self):
         raw_resources = fetcher.resources()
-        sections = []
+        sections: List[SectionDescription] = []
         for title, raw_section in raw_resources.items():
-            section = {'title': title, 'items': []}
+            section: SectionDescription = {'title': title, 'items': []}
             sections.append(section)
             for text, url in raw_section.items():
-                item = {'text': text, 'url': url, 'is_external': url.startswith('http') and '://pennydreadfulmagic.com/' not in url}
+                item: ResourceDescription = {'text': text, 'url': url, 'is_external': url.startswith('http') and '://pennydreadfulmagic.com/' not in url}
                 section['items'].append(item)
         return sections
 

--- a/dev.py
+++ b/dev.py
@@ -80,10 +80,10 @@ def mypy(argv: List[str], strict: bool = False) -> None:
         '--disallow-untyped-calls',     # Strict Mode.  All function calls must have a return type.
         '--warn-redundant-casts',
         '--disallow-incomplete-defs',   # All parameters must have type definitions.
+        '--check-untyped-defs'          # Typecheck on all methods, not just typed ones.
         ]
     if strict:
-        args.append('--check-untyped-defs') # Typecheck on all methods, not just typed ones.
-        # args.append('--disallow-untyped-defs') # All methods must be typed.
+        args.append('--disallow-untyped-defs') # All methods must be typed.
     args.extend(argv or [
         '.'                             # Invoke on the entire project.
         ])


### PR DESCRIPTION
This means that even if a method doesn't have a type definition itself, we still check the things it does inside.