### PR TITLE
New archetype-classification rules report

### DIFF
--- a/decksite/admin.py
+++ b/decksite/admin.py
@@ -95,7 +95,7 @@ def edit_rules() -> str:
     cnum = rs.num_classified_decks()
     tnum = ds.num_decks()
     archetypes = archs.load_archetypes_deckless(order_by='a.name')
-    view = EditRules(cnum, tnum, rs.doubled_decks(), rs.mistagged_decks(), rs.load_all_rules(), archetypes)
+    view = EditRules(cnum, tnum, rs.doubled_decks(), rs.mistagged_decks(), rs.overlooked_decks(), rs.load_all_rules(), archetypes)
     return view.page()
 
 @APP.route('/admin/rules/', methods=['POST'])

--- a/decksite/templates/editrules.mustache
+++ b/decksite/templates/editrules.mustache
@@ -50,9 +50,31 @@
         </table>
     {{/has_mistagged_decks}}
 
+    {{#has_overlooked_decks}}
+        <h2>Decks which don't match a rule, but a rule exists for the manually-assigned archetype</h2>
+        {{>spinner}}
+        <table>
+            <thead>
+                <tr>
+                    <th>Colors</th>
+                    <th>Deck Name</th>
+                    <th>Manually-assigned</th>
+            </thead>
+            <tbody>
+                {{#overlooked_decks}}
+                    <tr>
+                        <td>{{{colors_safe}}}</td>
+                        <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
+                        <td>{{archetype_name}}</td>
+                    </tr>
+                {{/overlooked_decks}}
+            </tbody>
+        </table>
+    {{/has_overlooked_decks}}
+
     <h2>Other reports</h2>
-    <p>Not currently reported: Archetypes with no matching rule, list of decks not covered by any rule.
-    (These could be added if and when the list of rules is closer to being complete.)</p>
+    <p>Not currently reported: Archetypes with no matching rule.
+    (This could be added if and when the list of rules is closer to being complete.)</p>
 
 </section>
 <section>

--- a/decksite/views/edit_rules.py
+++ b/decksite/views/edit_rules.py
@@ -13,6 +13,7 @@ class EditRules(View):
                  num_total: int,
                  doubled_decks: List[Deck],
                  mistagged_decks: List[Deck],
+                 overlooked_decks: List[Deck],
                  rules: List[Container],
                  archetypes: List[Archetype]) -> None:
         super().__init__()
@@ -20,6 +21,7 @@ class EditRules(View):
         self.num_total = num_total
         self.doubled_decks = doubled_decks
         self.mistagged_decks = mistagged_decks
+        self.overlooked_decks = overlooked_decks
         self.rules = rules
         self.archetypes = archetypes
         self.rules.sort(key=lambda c: c.archetype_name)
@@ -27,8 +29,11 @@ class EditRules(View):
             self.prepare_deck(d)
         for d in self.mistagged_decks:
             self.prepare_deck(d)
+        for d in self.overlooked_decks:
+            self.prepare_deck(d)
         self.has_doubled_decks = len(self.doubled_decks) > 0
         self.has_mistagged_decks = len(self.mistagged_decks) > 0
+        self.has_overlooked_decks = len(self.overlooked_decks) > 0
 
     def page_title(self):
         return 'Edit Rules'


### PR DESCRIPTION
Now lists cases where the rule for an archetype fails to identify one or more decks which were manually assigned that archetype.