### PR TITLE
Ajax magic for /admin/rules

### DIFF
--- a/decksite/data/rule.py
+++ b/decksite/data/rule.py
@@ -35,6 +35,7 @@ def mistagged_decks() -> List[Deck]:
     sql = """
             SELECT
                 deck_id,
+                rule_archetype.id AS rule_archetype_id,
                 rule_archetype.name AS rule_archetype_name,
                 tagged_archetype.name AS tagged_archetype_name
             FROM
@@ -56,13 +57,13 @@ def mistagged_decks() -> List[Deck]:
             """.format(apply_rules_query=apply_rules_query())
     rule_archetypes = {}
     for r in (Container(row) for row in db().select(sql)):
-        rule_archetypes[r.deck_id] = r.rule_archetype_name
+        rule_archetypes[r.deck_id] = (r.rule_archetype_id, r.rule_archetype_name)
     if not rule_archetypes:
         return []
     ids_list = ', '.join(str(deck_id) for deck_id in rule_archetypes)
     result = deck.load_decks(where=f'd.id IN ({ids_list})')
     for d in result:
-        d.rule_archetype_name = rule_archetypes[d.id]
+        d.rule_archetype_id, d.rule_archetype_name = rule_archetypes[d.id]
     return result
 
 def doubled_decks() -> List[Deck]:

--- a/decksite/templates/editrules.mustache
+++ b/decksite/templates/editrules.mustache
@@ -43,18 +43,18 @@
                     <th>Deck Name</th>
                     <th>Manually-assigned</th>
                     <th>Rule-assigned</th>
-                    <th></th>
+                    <td></td>
                 </tr>
             </thead>
             <tbody>
                 {{#mistagged_decks}}
-                    <tr id="deck-row-{{id}}">
+                    <tr>
                         <td>{{{colors_safe}}}</td>
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{archetype_url}}">{{archetype_name}}</a></td>
                         <td><a href="{{rule_archetype_url}}">{{rule_archetype_name}}</a></td>
                         <td>
-                        <a class="reassign" data-deck_id="{{id}}" data-rule_archetype_id="{{rule_archetype_id}}">Reassign to {{rule_archetype_name}}</a>
+                            <a class="reassign" data-deck_id="{{id}}" data-rule_archetype_id="{{rule_archetype_id}}">Reassign to {{rule_archetype_name}}</a>
                         </td>
                     </tr>
                 {{/mistagged_decks}}

--- a/decksite/templates/editrules.mustache
+++ b/decksite/templates/editrules.mustache
@@ -43,15 +43,19 @@
                     <th>Deck Name</th>
                     <th>Manually-assigned</th>
                     <th>Rule-assigned</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
                 {{#mistagged_decks}}
-                    <tr>
+                    <tr id="deck-row-{{id}}">
                         <td>{{{colors_safe}}}</td>
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{archetype_url}}">{{archetype_name}}</a></td>
                         <td><a href="{{rule_archetype_url}}">{{rule_archetype_name}}</a></td>
+                        <td>
+                        <a class="reassign" data-deck_id="{{id}}" data-rule_archetype_id="{{rule_archetype_id}}">Reassign to {{rule_archetype_name}}</a>
+                        </td>
                     </tr>
                 {{/mistagged_decks}}
             </tbody>

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1853,6 +1853,11 @@ Fix the width of the column to prevent the table "jump"-ing around the screen as
 td.archetype-description {
     max-width: 26em;
 }
+/* Ajax links for the "Edit Rules" page */
+.reassign {
+    cursor: pointer;
+}
+
 /*
 
 News

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -8,6 +8,7 @@ PD.init = function () {
     PD.initTables();
     PD.initDetails();
     PD.initTooltips();
+    PD.initReassign();
     $("input[type=file]").on("change", PD.loadDeck).on("change", PD.toggleDrawDropdown);
     $(".bugtable").trigger("sorton", [[[2,0],[0,0]]]);
     $(".toggle-illegal").on("change", PD.toggleIllegalCards);
@@ -157,6 +158,16 @@ PD.initTooltips = function () {
         $("body").off();
     });
 };
+PD.initReassign = function () {
+    $(".reassign").click(function () {
+        $(this).hide();
+        $.post("/api/archetype/reassign", { 'deck_id': $(this).data('deck_id'), 'archetype_id': $(this).data('rule_archetype_id') }, PD.afterReassign);
+        return false;
+    });
+};
+PD.afterReassign = function (data) {
+    $('#deck-row-' + data.deck_id).hide()
+}
 PD.loadDeck = function () {
     var file = this.files[0],
         reader = new FileReader();

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -166,7 +166,7 @@ PD.initReassign = function () {
     });
 };
 PD.afterReassign = function (data) {
-    $('#deck-row-' + data.deck_id).hide()
+    $('tr:has(a[data-deck_id="' + data.deck_id + '"])').hide()
 }
 PD.loadDeck = function () {
     var file = this.files[0],


### PR DESCRIPTION
The "rules give a different result to the manually-assigned archetype" table now has a link to quickly reassign each deck to the rule-assigned archetype without refreshing the page.

Breaking some new ground here (for me at least) so won't merge until someone tells me this is sane.