### PR TITLE
/admin/rules optimisation

### DIFF
--- a/decksite/admin.py
+++ b/decksite/admin.py
@@ -95,6 +95,7 @@ def edit_rules() -> str:
     cnum = rs.num_classified_decks()
     tnum = ds.num_decks()
     archetypes = archs.load_archetypes_deckless(order_by='a.name')
+    rs.cache_all_rules()
     view = EditRules(cnum, tnum, rs.doubled_decks(), rs.mistagged_decks(), rs.overlooked_decks(), rs.load_all_rules(), archetypes)
     return view.page()
 


### PR DESCRIPTION
Previously this page was executing `apply_rules_query` for every separate section of the page (five times total). Now it executes it once and stores the result in a temporary table. On my local this cuts about 40s off page load time.