### PR TITLE
Fix duplicate empty rules bug

### DIFF
--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -185,7 +185,7 @@ PD.initRuleForms = function () {
 PD.afterRuleUpdate = function(data) {
     if (data.success)
     {
-        location.reload(true);
+        location.href = location.href; // make sure it's a GET refresh and not a duplicate of a previous POST
     }
     else
     {


### PR DESCRIPTION
Should no longer create additional empty rules after adding cards to a newly-created rule.