### PR TITLE
Fix for issue #5959 - error on archetype pages when there's 0 tournament decks.

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -33,6 +33,7 @@ def load_archetype(archetype: Union[int, str], season_id: int = None) -> Archety
     arch.name = db().value('SELECT name FROM archetype WHERE id = %s', [archetype_id])
     if len(archetypes) == 0:
         arch.decks = []
+    arch.decks_tournament = arch.get('decks_tournament', [])
     return arch
 
 def load_archetypes(where: str = '1 = 1', merge: bool = False, season_id: int = None) -> List[Archetype]:


### PR DESCRIPTION
There was already code for what to do when there's no deck at all, so I put a line in to handle when there's no tournament decks right next to it.