### PR TITLE
Allow scryfall-like searching of rotation cards.

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -30,7 +30,7 @@ from decksite.views import (About, AboutPdm, Achievements, AddForm, Archetype,
                             TournamentHosting, TournamentLeaderboards,
                             Tournaments)
 from magic import card as mc
-from magic import image_fetcher, oracle
+from magic import fetcher, image_fetcher, oracle
 from shared import perf
 from shared.pd_exception import (DoesNotExistException, InvalidDataException,
                                  TooFewItemsException)
@@ -259,7 +259,9 @@ def community_guidelines() -> str:
 @APP.route('/rotation/<interestingness>/')
 @cached()
 def rotation(interestingness: Optional[str] = None) -> str:
-    view = Rotation(interestingness)
+    rotation_query = request.args.get('rq')
+    _, cardnames = fetcher.search_scryfall(rotation_query, exhaustive=True) if rotation_query else (None, None)
+    view = Rotation(interestingness, rotation_query, cardnames)
     return view.page()
 
 @APP.route('/export/<deck_id>/')

--- a/decksite/templates/rotation.mustache
+++ b/decksite/templates/rotation.mustache
@@ -4,6 +4,14 @@
     {{#runs}}
         <p>{{runs}} ({{runs_percent}}%) of 168 runs completed. {{num_cards}} cards have hits.</p>
         <p>Stats on undecided cards are redacted to reduce rampant market manipulation.</p>
+        {{#rotation_query}}
+            <p>
+                <form class="inline">
+                    <input type="text" name="rq" value="{{rotation_query}}">
+                    <button type="submit">Submit</button>
+                </form>
+            </p>
+        {{/rotation_query}}
         {{> spinner}}
         <table class="highlights">{{! Allow overflow-x so highlighting shows in left margin.}}
             <thead>
@@ -29,3 +37,17 @@
         {{> rotationkey}}
     {{/runs}}
 </section>
+{{^rotation_query}}
+    <section>
+        <h2>Search</h2>
+        <form>
+            <p>Search using Scryfall syntax.</p>
+            <div>
+                <label>Query</label>
+                <input type="text" name="rq" value="{{rotation_query}}">
+            </div>
+            <button type="submit">Submit</button>
+            <p>Warning: can be very slow.</p>
+        </form>
+    </section>
+{{/rotation_query}}

--- a/decksite/views/rotation.py
+++ b/decksite/views/rotation.py
@@ -14,7 +14,7 @@ from shared.pd_exception import DoesNotExistException
 
 # pylint: disable=no-self-use,too-many-instance-attributes
 class Rotation(View):
-    def __init__(self, interestingness: Optional[str] = None) -> None:
+    def __init__(self, interestingness: Optional[str] = None, rotation_query: Optional[str] = None, only_these: Optional[List[str]] = None) -> None:
         super().__init__()
         self.playability = card.playability()
         until_full_rotation = rotation.next_rotation() - dtutil.now()
@@ -36,7 +36,10 @@ class Rotation(View):
         self.show_interesting = True
         if interestingness:
             self.cards = [c for c in self.cards if c.get('interestingness') == interestingness]
+        if only_these:
+            self.cards = [c for c in self.cards if c.name in only_these]
         self.num_cards = len(self.cards)
+        self.rotation_query = rotation_query or ''
 
     def read_rotation_files(self) -> None:
         lines = []

--- a/shared/redis.py
+++ b/shared/redis.py
@@ -59,7 +59,7 @@ def get_container(key: str, ex: Optional[int] = None) -> Optional[Container]:
                 return Container(val)
     return None
 
-def get_list(key: str) -> Optional[List[str]]:
+def get_list(key: str) -> Optional[List[Any]]:
     if REDIS is not None:
         blob = _get(key)
         if blob is not None:


### PR DESCRIPTION
This is potentially dangerous as we now allow ridiculously lengthy searches
of Scryfall but a combination of redis caching and sleeping for 100ms after
each search should limit the problems to our side of things.

Because we store a list of dicts in redis I had to despecify the return value
of redis.get_list.