### PR TITLE
Revert "Add pdm site link to discordbot's reply when showing a single card"

### DIFF
--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -992,13 +992,12 @@ async def send_image_with_retry(channel: TextChannel, image_file: str, text: str
 def single_card_text_internal(client: Client, requested_card: Card, disable_emoji: bool) -> str:
     mana = emoji.replace_emoji(''.join(requested_card.mana_cost or []), client)
     legal = ' — ' + emoji.info_emoji(requested_card, verbose=True)
-    url = fetcher.decksite_url('cards/{name}'.format(name=fetcher.internal.escape(requested_card.name)))
     if disable_emoji:
         legal = ''
     if requested_card.get('mode', None) == '$':
-        text = '{name} {legal} — {price} — <{url}>'.format(name=requested_card.name, price=fetcher.card_price_string(requested_card), legal=legal, url=url)
+        text = '{name} {legal} — {price}'.format(name=requested_card.name, price=fetcher.card_price_string(requested_card), legal=legal)
     else:
-        text = '{name} {mana} — {type}{legal} — <{url}>'.format(name=requested_card.name, mana=mana, type=requested_card.type_line, legal=legal, url=url)
+        text = '{name} {mana} — {type}{legal}'.format(name=requested_card.name, mana=mana, type=requested_card.type_line, legal=legal)
     if requested_card.bugs:
         for bug in requested_card.bugs:
             text += '\n:beetle:{rank} bug: {bug}'.format(bug=bug['description'], rank=bug['classification'])


### PR DESCRIPTION
Feedback was that the link takes up too much space, especially in mobile.

This reverts commit 9a5a5f5bafc7e72f1f5fd0bb6a8b8fe11aed36a6.