### PR TITLE
Remove leading space from names of free credit earners in league prizes.

### DIFF
--- a/decksite/templates/prizes.mustache
+++ b/decksite/templates/prizes.mustache
@@ -10,10 +10,8 @@
 {{#months}}
     <section>
         <h2>{{competition_name}}</h2>
-        <pre>
         {{#people}}
-            {{mtgo_username}}
+            {{mtgo_username}}<br>
         {{/people}}
-        </pre>
     </section>
 {{/months}}


### PR DESCRIPTION
Fixes #6281.