### PR TITLE
Make it more obvious that MTGO Traders credit comes at the end of a league.

### DIFF
--- a/decksite/templates/faqsbody.mustache
+++ b/decksite/templates/faqsbody.mustache
@@ -34,7 +34,7 @@
             <p>{{_ You play five matches per run. You can join the league at any time.}}</p>
             <p>{{_ To find a game sign up and then create a game in Constructed, Specialty, Freeform Tournament Practice with "Penny Dreadful League" as the comment.}}</p>
             <p>{{_ Top 8 finishers on each month's league leaderboard win credit with [MTGO Traders](https://www.mtgotraders.com/).}}</p>
-            <p>{{_ When you complete a five match league run for the first time ever you will get 1 tik credit with [MTGO Traders](https://www.mtgotraders.com/).}}</p>
+            <p>{{_ When you complete a five match league run for the first time ever you will get 1 tik credit with [MTGO Traders](https://www.mtgotraders.com/) (at the end of the month).}}</p>
             <p><a href="{{current_league_url}}">{{_ Current League}}</a></o>
             <p><a href="{{league_info_url}}">{{_ More Info}}</a></p>
             <p><a href="{{league_signup_url}}">{{_ Sign Up}}</a></p>

--- a/decksite/views/signup.py
+++ b/decksite/views/signup.py
@@ -9,7 +9,7 @@ class SignUp(DecklistForm):
         return '{league} Sign Up'.format(league=self.league['name'])
 
     def TT_MTGOTRADERS_SIGNUP_TIK(self) -> str:
-        return gettext('When you complete a five match league run for the first time ever you will get 1 tik credit with MTGO Traders. This credit will appear when you trade with one of their bots on Magic Online.')
+        return gettext('When you complete a five match league run for the first time ever you will get 1 tik credit with MTGO Traders (at the end of the month). This credit will appear when you trade with one of their bots on Magic Online.')
 
     def TT_MTGO_USERNAME(self) -> str:
         return gettext('Magic Online Username')

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -288,7 +288,7 @@ class Commands:
                 You play five matches per run. You can join the league at any time.
                 To find a game sign up and then create a game in Constructed, Specialty, Freeform Tournament Practice with "Penny Dreadful League" as the comment.
                 Top 8 finishers on each month's league leaderboard win credit with MTGO Traders.
-                When you complete a five match league run for the first time ever you will get 1 tik credit with MTGO Traders.
+                When you complete a five match league run for the first time ever you will get 1 tik credit with MTGO Traders (at the end of the month).
                 """,
                 {
                     'More Info': fetcher.decksite_url('/league/'),

--- a/shared_web/translations/messages.pot
+++ b/shared_web/translations/messages.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Penny-Dreadful-Tools 0.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-06-15 10:33-0700\n"
+"POT-Creation-Date: 2019-06-18 09:57-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -530,7 +530,8 @@ msgstr ""
 #: decksite/templates/faqsbody.mustache:1
 msgid ""
 "When you complete a five match league run for the first time ever you "
-"will get 1 tik credit with [MTGO Traders](https://www.mtgotraders.com/)."
+"will get 1 tik credit with [MTGO Traders](https://www.mtgotraders.com/) "
+"(at the end of the month)."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
@@ -612,7 +613,7 @@ msgstr ""
 msgid "You can [sign up]({signup_url}) at any time."
 msgstr ""
 
-#: decksite/templates/leagueinfo.mustache:1
+#: decksite/templates/leagueinfo.mustache:1 decksite/views/signup.py:12
 msgid ""
 "When you complete a five match league run for the first time ever you "
 "will get 1 tik credit with MTGO Traders (at the end of the month). This "
@@ -878,13 +879,6 @@ msgstr ""
 
 #: decksite/views/report.py:25
 msgid "Your Deck"
-msgstr ""
-
-#: decksite/views/signup.py:12
-msgid ""
-"When you complete a five match league run for the first time ever you "
-"will get 1 tik credit with MTGO Traders. This credit will appear when you"
-" trade with one of their bots on Magic Online."
 msgstr ""
 
 #: decksite/views/signup.py:15


### PR DESCRIPTION
Fixes #6216.