### PR TITLE
Prevent search area from "covering" pdm title (so you can't click to go home).

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1723,7 +1723,6 @@ We need to override a lot of Google's inline styles hence a lot of !important.
 /* When search wraps under the logo it needs different behavior. */
 @media only screen and (max-width: 800px) {
     .search {
-        float: none;
         margin-bottom: 1rem;
         margin-left: 0;
         padding-top: 1rem;


### PR DESCRIPTION
The never-ending battle against Google CSS changes continues.

Fixes #6248.