### PR TITLE
Add regular rotation messages from the bot during rotation season.

### DIFF
--- a/decksite/view.py
+++ b/decksite/view.py
@@ -119,7 +119,7 @@ class View(BaseView):
         return inflect.engine().number_to_words(len(tournaments.all_series_info()))
 
     def rotation_text(self) -> str:
-        return rotation.text()
+        return rotation.message()
 
     def learn_more_url(self) -> str:
         return url_for('about', hide_intro=True)

--- a/decksite/views/rotation.py
+++ b/decksite/views/rotation.py
@@ -1,21 +1,17 @@
 import datetime
-import os
-from collections import Counter
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from decksite.data import card
 from decksite.view import View
-from magic import multiverse, oracle, rotation
+from magic import rotation
 from magic.models import Card
-from shared import configuration, dtutil, redis, text
-from shared.pd_exception import DoesNotExistException
+from shared import configuration, dtutil
 
 
 # pylint: disable=no-self-use,too-many-instance-attributes
 class Rotation(View):
     def __init__(self, interestingness: Optional[str] = None, rotation_query: Optional[str] = None, only_these: Optional[List[str]] = None) -> None:
         super().__init__()
-        self.playability = card.playability()
         until_full_rotation = rotation.next_rotation() - dtutil.now()
         until_supplemental_rotation = rotation.next_supplemental() - dtutil.now()
         in_rotation = configuration.get_bool('always_show_rotation')
@@ -29,9 +25,12 @@ class Rotation(View):
             self.rotation_msg = 'Full rotation is ' + dtutil.display_date(rotation.next_rotation(), 2)
         else:
             self.rotation_msg = 'Supplemental rotation is ' + dtutil.display_date(rotation.next_supplemental(), 2)
-        self.cards: List[Card] = []
         if in_rotation:
-            self.read_rotation_files()
+            self.runs, self.runs_percent, self.cards = rotation.read_rotation_files()
+            # Now add interestingness to the cards, which only decksite knows not magic.rotation.
+            playability = card.playability()
+            for c in self.cards: # type: Card
+                c.interestingness = rotation.interesting(playability, c)
         self.show_interesting = True
         if interestingness:
             self.cards = [c for c in self.cards if c.get('interestingness') == interestingness]
@@ -40,70 +39,5 @@ class Rotation(View):
         self.num_cards = len(self.cards)
         self.rotation_query = rotation_query or ''
 
-    def read_rotation_files(self) -> None:
-        lines = []
-        files = rotation.files()
-        if len(files) == 0:
-            if not os.path.isdir(configuration.get_str('legality_dir')):
-                raise DoesNotExistException('Invalid configuration.  Could not find legality_dir.')
-            self.runs = 0
-            self.runs_percent = 0
-            return
-        self.latest_list = open(files[-1], 'r').read().splitlines()
-        for filename in files:
-            for line in self.get_file_contents(filename):
-                line = text.sanitize(line)
-                lines.append(line.strip())
-        scores = Counter(lines).most_common()
-        self.runs = scores[0][1]
-        self.runs_percent = round(round(self.runs / 168, 2) * 100)
-        self.cs = oracle.cards_by_name()
-        for name, hits in scores:
-            self.process_score(name, hits)
-
-    def get_file_contents(self, file: str) -> List[str]:
-        key = f'decksite:rotation:{file}'
-        contents = redis.get_list(key)
-        if contents is not None:
-            return contents
-        with open(file) as f:
-            contents = f.readlines()
-        redis.store(key, contents, ex=3600)
-        return contents
-
-    def process_score(self, name: str, hits: int) -> None:
-        remaining_runs = (168 - self.runs)
-        hits_needed = max(84 - hits, 0)
-        c = self.cs[name]
-        if c.layout not in multiverse.playable_layouts():
-            return
-        percent = round(round(hits / self.runs, 2) * 100)
-        if remaining_runs == 0:
-            percent_needed = '0'
-        else:
-            percent_needed = str(round(round(hits_needed / remaining_runs, 2) * 100))
-        if c is None:
-            raise DoesNotExistException("Legality list contains unknown card '{name}'".format(name=name))
-        if remaining_runs + hits < 84:
-            status = 'Not Legal'
-        elif hits >= 84:
-            status = 'Legal'
-        else:
-            status = 'Undecided'
-        hit_in_last_run = name in self.latest_list
-        c.update({
-            'hits': redact(hits) if status == 'Undecided' else hits,
-            'hits_needed': redact(hits_needed) if status == 'Undecided' else hits_needed,
-            'percent': redact(percent) if status == 'Undecided' else percent,
-            'percent_hits_needed': redact(percent_needed) if status == 'Undecided' else percent_needed,
-            'status': status,
-            'interestingness': rotation.interesting(self.playability, c),
-            'hit_in_last_run': hit_in_last_run
-        })
-        self.cards.append(c)
-
     def page_title(self) -> str:
         return 'Rotation'
-
-def redact(num: Union[str, int]) -> str:
-    return ''.join(['█' for _ in str(num)])

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -683,7 +683,7 @@ Want to contribute? Send a Pull Request."""
     @cmd_header('Commands')
     async def rotation(self, channel: TextChannel, **_: Dict[str, Any]) -> None:
         """`!rotation` Date of the next Penny Dreadful rotation."""
-        await send(channel, rotation.text())
+        await send(channel, rotation.message())
 
     @cmd_header('Commands')
     async def rulings(self, client: Client, channel: TextChannel, args: str, author: Member, **_: Dict[str, Any]) -> None:

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -14,8 +14,6 @@ from shared import configuration, dtutil, fetcher_internal, text
 BLACKLIST: Set[str] = set()
 WHITELIST: Set[str] = set()
 
-TOTAL_RUNS = 168
-
 TIME_UNTIL_FULL_ROTATION = rotation.next_rotation() - dtutil.now()
 TIME_UNTIL_SUPPLEMENTAL_ROTATION = rotation.next_supplemental() - dtutil.now()
 TIME_SINCE_SUPPLEMENTAL_ROTATION = dtutil.now() - rotation.this_supplemental()
@@ -24,7 +22,7 @@ def run() -> None:
     files = rotation.files()
     n = len(files)
     time_until = min(TIME_UNTIL_FULL_ROTATION, TIME_UNTIL_SUPPLEMENTAL_ROTATION) - datetime.timedelta(weeks=1)
-    if n >= TOTAL_RUNS:
+    if n >= rotation.TOTAL_RUNS:
         print('It is the moment of discovery, the triumph of the mind, and the end of this rotation.')
         return
 
@@ -44,7 +42,7 @@ def run() -> None:
         all_prices['mtgotraders'] = parse_mtgotraders_prices(s)
 
     run_number = process(all_prices)
-    if run_number == TOTAL_RUNS:
+    if run_number == rotation.TOTAL_RUNS:
         make_final_list()
 
 def process(all_prices: Dict[str, PriceListType]) -> int:
@@ -109,7 +107,7 @@ def make_final_list() -> None:
 
     passed: List[str] = []
     for name, count in scores:
-        if count >= TOTAL_RUNS / 2:
+        if count >= rotation.TOTAL_RUNS / 2:
             passed.append(name)
     final = list(passed)
     if is_supplemental():

--- a/shared/configuration.py
+++ b/shared/configuration.py
@@ -69,6 +69,8 @@ DEFAULTS = {
     'redis_enabled': True,
     'redis_host': 'localhost',
     'redis_port': 6379,
+    # Discord channel id to emit rotation-in-progress messages to.
+    'rotation_hype_channel_id': '207281932214599682',
     'save_historic_legal_lists': False,
     'scratch_dir': '.',
     'slow_fetch': 10.0,


### PR DESCRIPTION
This meant pushing a lot of what was happening in decksite.views.rotation
into magic.rotation.

Unfortunately it is not possible to push interestingness into magic.rotation
because it needs knowledge only decksite has.

So the view still decorates the cards with interestingness after the
magic.rotation stuff.

And the bot doesn't know how interesting cards are and just lists an arbitrary
four.

It would be better to expose interestingness to the bot somehow but that will
be a future improvement.