### PR TITLE
Show "newly hit" in first 83 rotation runs via bot.

### DIFF
--- a/decksite/templates/rotation.mustache
+++ b/decksite/templates/rotation.mustache
@@ -28,7 +28,7 @@
                         <td>{{#hit_in_last_run}}↑{{/hit_in_last_run}}{{^hit_in_last_run}}↓{{/hit_in_last_run}}</td>
                         <td>{{> singlecard}}</td>
                         <td class="n">{{hits}} ({{percent}}%)</td>
-                        <td class="n">{{hits_needed}} ({{percent_hits_needed}}%)</td>
+                        <td class="n">{{hits_needed}} ({{percent_needed}}%)</td>
                         <td>{{status}}</td>
                     </tr>
                 {{/cards}}

--- a/decksite/views/rotation.py
+++ b/decksite/views/rotation.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from decksite.data import card
 from decksite.view import View
@@ -38,6 +38,16 @@ class Rotation(View):
             self.cards = [c for c in self.cards if c.name in only_these]
         self.num_cards = len(self.cards)
         self.rotation_query = rotation_query or ''
+        for c in self.cards:
+            if c.status != 'Undecided':
+                continue
+            c.hits = redact(c.hits)
+            c.hits_needed = redact(c.hits_needed)
+            c.percent = redact(c.percent)
+            c.percent_needed = redact(c.percent_needed)
 
     def page_title(self) -> str:
         return 'Rotation'
+
+def redact(num: Union[str, int, float]) -> str:
+    return ''.join(['█' for _ in str(num)])

--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -339,8 +339,12 @@ def rotation_hype_message() -> str:
     runs_remaining = rotation.TOTAL_RUNS - runs
     newly_legal = [c for c in cs if c.hit_in_last_run and c.hits == rotation.TOTAL_RUNS / 2]
     newly_eliminated = [c for c in cs if not c.hit_in_last_run and c.status == 'Not Legal' and c.hits_needed == runs_remaining + 1]
+    newly_hit = [c for c in cs if c.hit_in_last_run and c.hits == 1]
     num_undecided = len([c for c in cs if c.status == 'Undecided'])
     s = f'Rotation run number {runs} completed. Rotation is {runs_percent}% complete.'
+    if len(newly_hit) > 0 and runs_remaining > runs:
+        newly_hit_s = list_of_most_interesting(newly_hit)
+        s += f'\nFirst hit for: {newly_hit_s}.'
     if len(newly_legal) > 0:
         newly_legal_s = list_of_most_interesting(newly_legal)
         s += f'\nConfirmed legal: {newly_legal_s}.'

--- a/magic/rotation.py
+++ b/magic/rotation.py
@@ -212,14 +212,11 @@ def process_score(name: str, hits: int, cs: Dict[str, Card], runs: int, latest_l
         status = 'Undecided'
     hit_in_last_run = name in latest_list
     c.update({
-        'hits': redact(hits) if status == 'Undecided' else hits,
-        'hits_needed': redact(hits_needed) if status == 'Undecided' else hits_needed,
-        'percent': redact(percent) if status == 'Undecided' else percent,
-        'percent_hits_needed': redact(percent_needed) if status == 'Undecided' else percent_needed,
+        'hits': hits,
+        'hits_needed': hits_needed,
+        'percent': percent,
+        'percent_needed': percent_needed,
         'status': status,
         'hit_in_last_run': hit_in_last_run
     })
     return c
-
-def redact(num: Union[str, int, float]) -> str:
-    return ''.join(['█' for _ in str(num)])


### PR DESCRIPTION
Move redaction out of magic.rotation and into the view where it more
rightly belongs in order to get access to actual number of hits in bot
rotation hype message.

Fixes #6372.