### PR TITLE
Allow large tables to sideways scroll rather than going into margin.

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -345,6 +345,7 @@ section {
     float: left;
     margin: 0 3.8445rem /* Width of .marginalia + left-padding + right-padding * font-size */ 1rem 0;
     max-width: 100%; /* So that overflow-x on contained table clips overly wide content, otherwise the fact that sections are floated means it is ignored. */
+    overflow-x: auto;
     padding-top: 1rem;
 }
 


### PR DESCRIPTION
Neither thing is desirable but this is definitely better. Generally this is a
sign that a page's columns are not set up for mobile view properly. Inciting
incident here involves /rotation/.

Fixes #6373.