### PR TITLE
Remove special treatment of overflow in sections/highlights.

### DIFF
--- a/decksite/templates/rotation.mustache
+++ b/decksite/templates/rotation.mustache
@@ -8,7 +8,7 @@
             {{> scryfallfilterwithtoggle}}
         {{/in_rotation}}
         {{> spinner}}
-        <table class="highlights">{{! Allow overflow-x so highlighting shows in left margin.}}
+        <table>
             <thead>
                 <tr>
                     <th>⇅</th>

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -345,7 +345,6 @@ section {
     float: left;
     margin: 0 3.8445rem /* Width of .marginalia + left-padding + right-padding * font-size */ 1rem 0;
     max-width: 100%; /* So that overflow-x on contained table clips overly wide content, otherwise the fact that sections are floated means it is ignored. */
-    overflow-x: auto;
     padding-top: 1rem;
 }
 
@@ -602,13 +601,6 @@ main table {
 
 main table.very-large {
     visibility: visible;
-}
-
-/* Allow overflow-x so highlighting shows in left margin. Looks clipped in narrowest view to get sideways scrolling. */
-@media only screen and (min-width: 360px) {
-    main table.highlights, main table.highlights td {
-        overflow: visible;
-    }
 }
 
 /* Turn off small caps link style in tables. */


### PR DESCRIPTION
As it currently stands this clips the loading spinner and part of the L of
Loading. If we just remove the overflow-x: auto then tables like /rotation/
that don't get footable behavior overflow into the right margin. So we remove
overflow: visible on narrow view also. I'm not sure what this was showing
before but all interestingness remains visible so I think this is ok.