### PR TITLE
Fix #6410 - in certain circumstances, filter code is being applied incorrectly.

### DIFF
--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -372,6 +372,11 @@ PD.filter = {};
 
 PD.filter.init = function () {
 
+    // if there are no filter-forms on the page, don't try to set anything up
+    if ($(".scryfall-filter-form").length == 0) {
+        return false;
+    }
+
     $(".toggle-filters-button").click(PD.filter.toggleDisplayFilter);
 
     // Apply the filter with the initial value of the form


### PR DESCRIPTION
The issue appears to be that the `onpopstate` handler is being called when Chrome mobile applies the #content or something like that. 