### PR TITLE
Month is prices from the last month not the last 7 months.

### DIFF
--- a/price_grabber/price.py
+++ b/price_grabber/price.py
@@ -40,7 +40,7 @@ def cache() -> None:
 
     now = round(time.time())
     week = now - 60 * 60 * 24 * 7
-    month = now - 60 * 60 * 24 * 7 * 30
+    month = now - 60 * 60 * 24 * 30
     last_rotation = int(rotation.last_rotation().timestamp())
 
     sql = 'SELECT MAX(`time`) FROM low_price'


### PR DESCRIPTION
This hasn't tripped us up that much because we delete older than start of
season/1 month ago but late in the season it will have been incorrect.

Hat tip to Briar_moss for spotting this one.