### PR TITLE
Speed-up rotation page with redis

### DIFF
--- a/magic/models/card.py
+++ b/magic/models/card.py
@@ -5,10 +5,13 @@ from shared.container import Container
 
 
 class Card(Container):
-    def __init__(self, params: Dict[str, Any]) -> None:
+    def __init__(self, params: Dict[str, Any], predetermined_values: bool = False) -> None:
         super().__init__()
         for k in params.keys():
-            setattr(self, k, determine_value(k, params))
+            if predetermined_values:
+                setattr(self, k, params[k])
+            else:
+                setattr(self, k, determine_value(k, params))
         if not hasattr(self, 'names'):
             setattr(self, 'names', [self.name])
 

--- a/magic/rotation.py
+++ b/magic/rotation.py
@@ -198,9 +198,9 @@ def last_run_time() -> Optional[datetime.datetime]:
 def read_rotation_files() -> Tuple[int, int, List[Card]]:
     runs_str = redis.get_str('decksite:rotation:summary:runs')
     runs_percent_str = redis.get_str('decksite:rotation:summary:runs_percent')
-    cards = redis.get_container_list('decksite:rotation:summary:cards')
+    cards = redis.get_list('decksite:rotation:summary:cards')
     if runs_str is not None and runs_percent_str is not None and cards is not None:
-        return int(runs_str), int(runs_percent_str), [Card(c) for c in cards]
+        return int(runs_str), int(runs_percent_str), [Card(c, predetermined_values=True) for c in cards]
     lines = []
     fs = files()
     if len(fs) == 0:

--- a/magic/rotation.py
+++ b/magic/rotation.py
@@ -236,7 +236,7 @@ def get_file_contents(file: str) -> List[str]:
     redis.store(key, contents)
     return contents
 
-def clear_redis(clear_files: bool = True) -> None:
+def clear_redis(clear_files: bool = False) -> None:
     redis.clear(*redis.keys('decksite:rotation:summary:*'))
     if clear_files:
         redis.clear(*redis.keys('decksite:rotation:file:*'))

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -31,6 +31,11 @@ def run() -> None:
         print('ETA: {t}'.format(t=dtutil.display_time(time_until.total_seconds())))
         return
 
+    if n == 0:
+        rotation.clear_redis(clear_files=True)
+    else:
+        rotation.clear_redis()
+
     all_prices = {}
     for url in configuration.get_list('cardhoarder_urls'):
         s = fetcher_internal.fetch(url)

--- a/shared/redis.py
+++ b/shared/redis.py
@@ -1,11 +1,12 @@
+import json
 from typing import Any, AnyStr, List, Optional, TypeVar
 
 import redis as redislib
-import json
 
 from . import configuration
 from .container import Container
 from .serialization import extra_serializer
+
 
 def init() -> Optional[redislib.Redis]:
     if not configuration.get_bool('redis_enabled'):
@@ -106,6 +107,9 @@ def increment(key: str, **kwargs: Any) -> Optional[int]:
 
 def clear(*keys_list: AnyStr) -> None:
     if REDIS is not None:
+        if len(keys_list) == 0:
+            # redis errors on a delete with no arguments, but we don't have to
+            return
         REDIS.delete(*keys_list) # type: ignore
 
 

--- a/shared/redis.py
+++ b/shared/redis.py
@@ -1,12 +1,11 @@
-import json
-from typing import Any, List, Optional, TypeVar
+from typing import Any, AnyStr, List, Optional, TypeVar
 
 import redis as redislib
+import json
 
 from . import configuration
 from .container import Container
 from .serialization import extra_serializer
-
 
 def init() -> Optional[redislib.Redis]:
     if not configuration.get_bool('redis_enabled'):
@@ -105,9 +104,9 @@ def increment(key: str, **kwargs: Any) -> Optional[int]:
             pass
     return None
 
-def clear(*keys: str) -> None:
+def clear(*keys_list: AnyStr) -> None:
     if REDIS is not None:
-        REDIS.delete(*keys) # type: ignore
+        REDIS.delete(*keys_list) # type: ignore
 
 
 def expire(key: str, time: int) -> None:
@@ -118,3 +117,8 @@ def expire(key: str, time: int) -> None:
             pass
         except redislib.exceptions.ConnectionError:
             pass
+
+def keys(pattern: str) -> List[bytes]:
+    if REDIS is not None:
+        return REDIS.keys(pattern) # type: ignore
+    return []


### PR DESCRIPTION
Before:
- We store the contents of each individual rotation file in redis. But, we give it a 1-hour expiration.

After:
- We still store the contents of each file in redis. But they don't have any expiration time.
- We **also** store the summary of the results - the number of runs and totaled hits for each card - in redis, so we don't even need to reiterate through the runs and tally things up again
- Rotation script needs to be aware of this, so it can invalidate keys as appropriate.

Before:
- With file contents in redis, 6.05s, 6.24s, 7.26s to load /rotation/ out of three attempts locally
- Cumulative time for `read_rotation_files` ~2.6s to 3s.

After:
- with redis fully loaded, 4.98s. 5.20s, 4.72s out of three attempts locally
- `read_rotation_files` doesn't need to be called.

What's next:
- The vast majority of the time left (3.6-4s locally) is spent in pystache.