### PR TITLE
Make news section a section instead of an article.

### DIFF
--- a/decksite/templates/news.mustache
+++ b/decksite/templates/news.mustache
@@ -1,8 +1,8 @@
-<article class="news">
+<section class="news">
     <h2>News</h2>
         <ul>
             {{#news}}
                 <li class="item {{type}}">{{#url}}<a href="{{url}}">{{/url}} <span class="story">{{title}}</span> <span class="date">{{display_date}}</span>{{#url}}</a>{{/url}}</li>
             {{/news}}
         </ul>
-</article>
+</section>

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -340,6 +340,7 @@ footer {
 /* Because the status bar takes a reasonable amount of vertical real estate in the default version we also check height for this one. See #6068. */
 @media only screen and (max-width: 640px), only screen and (max-height: 640px) {
     .status-bar {
+        font-size: 0.75rem;
         padding-bottom: 0;
         padding-top: 1em;
     }


### PR DESCRIPTION
I don't know why it was an article. Semantically it is a section and it
behaves way better as one on the homepage.