### PR TITLE
Fix aliases for Gatherling<->MTGO (for admins).

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -46,8 +46,8 @@ def edit_aliases() -> str:
     view = EditAliases(aliases, all_people)
     return view.page()
 
-@fill_form('person_id')
 @APP.route('/admin/aliases/', methods=['POST'])
+@fill_form('person_id', 'alias')
 @auth.admin_required
 def post_aliases(person_id: int = None, alias: str = None) -> Union[str, wrappers.Response]:
     if person_id is not None and alias is not None and len(alias) > 0:
@@ -160,8 +160,8 @@ def edit_news() -> str:
     view = EditNews(news_items)
     return view.page()
 
-@fill_form('news_id', 'title', 'url')
 @APP.route('/admin/news/', methods=['POST'])
+@fill_form('news_id', 'title', 'url')
 @auth.admin_required
 def post_news(news_id: int, title: str = None, url: str = None, date: str = None) -> wrappers.Response:
     if request.form.get('action') == 'delete':

--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -208,8 +208,8 @@ def post_reassign(deck_id: int, archetype_id: int) -> Response:
     return return_json({'success':True, 'deck_id':deck_id})
 
 @APP.route('/api/rule/update', methods=['POST'])
-@auth.demimod_required
 @fill_form('rule_id')
+@auth.demimod_required
 def post_rule_update(rule_id: int = None) -> Response:
     if rule_id is not None and request.form.get('include') is not None and request.form.get('exclude') is not None:
         inc = []

--- a/decksite/scrapers/gatherling.py
+++ b/decksite/scrapers/gatherling.py
@@ -67,8 +67,8 @@ def get_dt_and_series(name: str, day_s: str) -> Tuple[datetime.datetime, str]:
         competition_series = 'Penny Dreadful FNM - EU'
         start_time = '13:30'
         dt = get_dt(day_s, start_time, dtutil.GATHERLING_TZ)
-    elif 'Penny Dreadful FNM Mar 20' in name:
-        competition_series = 'Penny Dreadful FNM - EU' # Dubious but this was a one-off competition let's not fret.
+    elif 'FNM' in name:
+        competition_series = 'Penny Dreadful FNM - EU' # Dubious but this is a couple of impromptu tournaments so let's not fret.
         start_time = '20:00'
         dt = get_dt(day_s, start_time, dtutil.GATHERLING_TZ)
     else:

--- a/decksite/scrapers/gatherling.top8.html
+++ b/decksite/scrapers/gatherling.top8.html
@@ -221,7 +221,7 @@ Hosted by <a href="profile.php?player=littlefield">littlefield</a><br /><a href=
 <td align="right">Midrange</td></tr>
 <tr style="><td></td>
 <td align="left"></td>
-<td align="left"><a href="profile.php?player=MrSad">MrSad<img width="12" height="12" src="styles/Chandra/images/verified.png" /></a></td>
+<td align="left"><a href="profile.php?player=Cody_">Cody_<img width="12" height="12" src="styles/Chandra/images/verified.png" /></a></td>
 <td align=\left">1-2</td><td align="left"><a href="deck.php?mode=view&id=55051">GW Unclassified</a></td>
 <td align="right">Unclassified</td></tr>
 <tr><td><img src="styles/Chandra/images/manawgu.png" />&nbsp;</td>
@@ -442,7 +442,7 @@ Hosted by <a href="profile.php?player=littlefield">littlefield</a><br /><a href=
                   <td>1</td>
                   </tr><tr>
                   <td>18</td>
-                  <td>MrSad</td>
+                  <td>Cody_</td>
                   <td>3</td>
                   <td>0.639</td>
                   <td>0.286</td>

--- a/decksite/scrapers/gatherling_test.py
+++ b/decksite/scrapers/gatherling_test.py
@@ -71,7 +71,7 @@ def test_rankings() -> None:
     assert rankings[14] == 'pumpkinwavy'
     assert rankings[15] == 'Yuin'
     assert rankings[16] == 'crazybaloth'
-    assert rankings[17] == 'MrSad'
+    assert rankings[17] == 'Cody_'
     assert rankings[18] == 'insan3_'
     assert rankings[19] == 'Renner'
     assert rankings[20] == 'Daesik'

--- a/decksite/views/seasons.py
+++ b/decksite/views/seasons.py
@@ -17,6 +17,8 @@ class Seasons(View):
             season.update(season_info)
             season_stats = stats.get(cast(int, season['num']), {})
             season.update(season_stats)
+            if season.get('start_date') is None:
+                continue
             for k, v in season.items():
                 if isinstance(v, int):
                     season[k] = '{:,}'.format(v) # Human-friendly number formatting like "29,000".


### PR DESCRIPTION
Add missing param to fill_form annotation that was stopping aliases working.

Also rearrange the order of annotations - security MUST come last to work.

Fixes #7125.