### PR TITLE
Truly differentiate person_id from mtgo_username in URLs.

### DIFF
--- a/decksite/controllers/competitions.py
+++ b/decksite/controllers/competitions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from flask import redirect, url_for
 from werkzeug import wrappers
 
@@ -8,6 +10,7 @@ from decksite.data import competition as comp
 from decksite.data import person as ps
 from decksite.views import (Achievements, Competition, Competitions, PersonAchievements,
                             TournamentHosting, TournamentLeaderboards, Tournaments)
+from shared.pd_exception import DoesNotExistException
 
 
 @APP.route('/competitions/')
@@ -56,10 +59,17 @@ def achievements() -> str:
     view = Achievements(achs.load_achievements(p, season_id=get_season_id()))
     return view.page()
 
-@APP.route('/people/<person_id>/achievements')
-@SEASONS.route('/people/<person_id>/achievements')
-def person_achievements(person_id: str) -> str:
-    p = ps.load_person_by_id_or_mtgo_username(person_id, season_id=get_season_id())
+@APP.route('/people/<mtgo_username>/achievements')
+@APP.route('/people/id/<int:person_id>/achievements')
+@SEASONS.route('/people/<mtgo_username>/achievements')
+@SEASONS.route('/people/id/<int:person_id>/achievements')
+def person_achievements(mtgo_username: Optional[str] = None, person_id: Optional[int] = None) -> str:
+    if mtgo_username:
+        p = ps.load_person_by_mtgo_username(mtgo_username, season_id=get_season_id())
+    elif person_id:
+        p = ps.load_person_by_id(person_id, season_id=get_season_id())
+    else:
+        raise DoesNotExistException(f"Can't load a person with `{mtgo_username}` and `{person_id}`.")
     view = PersonAchievements(p, achs.load_achievements(p, season_id=get_season_id(), with_detail=True))
     return view.page()
 

--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -56,11 +56,18 @@ def people() -> str:
     view = People(ps.load_people(season_id=get_season_id()))
     return view.page()
 
-@APP.route('/people/<person_id>/')
-@SEASONS.route('/people/<person_id>/')
+@APP.route('/people/<mtgo_username>/')
+@APP.route('/people/id/<int:person_id>/')
+@SEASONS.route('/people/<mtgo_username>/')
+@SEASONS.route('/people/id/<int:person_id>/')
 @cached()
-def person(person_id: str) -> str:
-    p = ps.load_person_by_id_or_mtgo_username(person_id, season_id=get_season_id())
+def person(mtgo_username: Optional[str] = None, person_id: Optional[int] = None) -> str:
+    if mtgo_username:
+        p = ps.load_person_by_mtgo_username(mtgo_username, season_id=get_season_id())
+    elif person_id:
+        p = ps.load_person_by_id(person_id, season_id=get_season_id())
+    else:
+        raise DoesNotExistException(f"Can't load a person with `{mtgo_username}` and `{person_id}`.")
     person_cards = cs.load_cards(person_id=p.id, season_id=get_season_id())
     person_archetypes = archs.load_archetypes_deckless(person_id=p.id, season_id=get_season_id())
     all_archetypes = archs.load_archetypes_deckless(season_id=get_season_id())
@@ -71,11 +78,18 @@ def person(person_id: str) -> str:
     view = Person(p, person_cards, person_archetypes, all_archetypes, person_matchups, your_cards, get_season_id())
     return view.page()
 
-@APP.route('/people/<person_id>/matches/')
-@SEASONS.route('/people/<person_id>/matches/')
+@APP.route('/people/<mtgo_username>/matches/')
+@APP.route('/people/id/<int:person_id>/matches/')
+@SEASONS.route('/people/<mtgo_username>/matches/')
+@SEASONS.route('/people/id/<int:person_id>/matches/')
 @cached()
-def person_matches(person_id: str) -> str:
-    p = ps.load_person_by_id_or_mtgo_username(person_id, season_id=get_season_id())
+def person_matches(mtgo_username: Optional[str] = None, person_id: Optional[int] = None) -> str:
+    if mtgo_username:
+        p = ps.load_person_by_mtgo_username(mtgo_username, season_id=get_season_id())
+    elif person_id:
+        p = ps.load_person_by_id(person_id, season_id=get_season_id())
+    else:
+        raise DoesNotExistException(f"Can't load a person with `{mtgo_username}` and `{person_id}`.")
     matches = ms.load_matches_by_person(person_id=p.id, season_id=get_season_id())
     matches.reverse() # We want the latest at the top.
     view = PersonMatches(p, matches)

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -17,22 +17,10 @@ def load_person_by_id(person_id: int, season_id: Optional[int] = None) -> Person
 def load_person_by_mtgo_username(username: str, season_id: Optional[int] = None) -> Person:
     return load_person('p.mtgo_username = {username}'.format(username=sqlescape(username, force_string=True)), season_id=season_id)
 
-
 def load_person_by_discord_id(discord_id: int, season_id: Optional[int] = None) -> Person:
     return load_person(f'p.discord_id = {discord_id}', season_id=season_id)
 
 # pylint: disable=invalid-name
-def load_person_by_id_or_mtgo_username(person: str, season_id: Optional[int] = None) -> Person:
-    if person.isdigit():
-        try:
-            return load_person_by_id(int(person), season_id)
-        except DoesNotExistException:
-            pass # If we failed to load by id we want to try and load as a Magic Online username for people with Magic Online usernames that are integers like '4423'.
-    return load_person_by_mtgo_username(person, season_id)
-
-# pylint: disable=invalid-name
-
-
 def load_person_by_discord_id_or_username(person: str, season_id: int = 0) -> Person:
     # It would probably be better if this method did not exist but for now it's required by the API.
     # The problem is that Magic Online usernames can be integers so we cannot be completely unambiguous here.

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -16,7 +16,10 @@ def prepare_deck(d: Deck) -> None:
     set_stars_and_top8(d)
     if d.get('colors') is not None:
         d.colors_safe = colors_html(d.colors, d.colored_symbols)
-    d.person_url = '/people/{id}/'.format(id=d.person_id)
+    if d.get('mtgo_username'):
+        d.person_url = f'/people/{d.mtgo_username}/'
+    else:
+        d.person_url = f'/people/id/{d.person_id}/'
     d.date_sort = dtutil.dt2ts(d.active_date)
     d.display_date = dtutil.display_date(d.active_date)
     d.show_record = d.wins or d.losses or d.draws

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -238,7 +238,10 @@ class View(BaseView):
 
     def prepare_people(self) -> None:
         for p in getattr(self, 'people', []):
-            p.url = '/people/{id}/'.format(id=p.id)
+            if p.get('mtgo_username'):
+                p.url = f'/people/{p.mtgo_username}/'
+            else:
+                p.url = f'/people/id/{p.id}/'
             p.show_record = p.get('wins', None) or p.get('losses', None) or p.get('draws', None)
 
     def prepare_archetypes(self) -> None:
@@ -303,7 +306,7 @@ class View(BaseView):
             if m.get('deck_id'):
                 m.deck_url = url_for('deck', deck_id=m.deck_id)
             if m.get('opponent'):
-                m.opponent_url = url_for('.person', person_id=m.opponent)
+                m.opponent_url = url_for('.person', mtgo_username=m.opponent)
             if m.get('opponent_deck_id'):
                 m.opponent_deck_url = url_for('deck', deck_id=m.opponent_deck_id)
             if m.get('mtgo_id'):

--- a/decksite/views/person.py
+++ b/decksite/views/person.py
@@ -26,7 +26,7 @@ class Person(View):
         self.cards = cards
         for record in person.head_to_head:
             record.show_record = True
-            record.opp_url = url_for('.person', person_id=record.opp_mtgo_username)
+            record.opp_url = url_for('.person', mtgo_username=record.opp_mtgo_username)
         self.show_head_to_head = len(person.head_to_head) > 0
         self.show_seasons = True
         self.displayed_achievements = [{'title': a.title, 'detail': titlecase.titlecase(a.display(self.person))} for a in Achievement.all_achievements if a.display(self.person)]


### PR DESCRIPTION
We now have more than 4423 players so player with mtgo username of '4423' is
getting someone else's person page at /peope/4423/.