### PR TITLE
Hide the status bar after 20 requests (about 10 page views)

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -120,7 +120,7 @@ def after_request(response: Response) -> Response:
     return response
 
 @APP.teardown_request
-def teardown_request(e: Optional[Exception]) -> None:
+def teardown_request(_: Optional[Exception]) -> None:
     if g.get('p') is not None:
         perf.check(g.p, 'slow_page', request.path, 'decksite')
     db().close()

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -18,7 +18,7 @@ from decksite.database import db
 from decksite.views import Home
 from magic import card as mc
 from magic import image_fetcher, oracle
-from shared import perf
+from shared import dtutil, perf
 from shared.pd_exception import TooFewItemsException
 from shared_web import logger
 
@@ -110,13 +110,20 @@ def banner(seasonnum: str) -> Response:
 def before_request() -> None:
     g.p = perf.start()
 
-@APP.teardown_request # type: ignore
-def teardown_request(response: Response) -> Response:
+@APP.after_request
+def after_request(response: Response) -> Response:
+    requests_until_we_hide_intro_box = 20 # Typically ten page views because of async requests for the status bar.
+    views = int(request.cookies.get('views', 0)) + 1
+    response.set_cookie('views', str(views))
+    if views >= requests_until_we_hide_intro_box:
+        response.set_cookie('hide_intro', value=str(True), expires=dtutil.dt2ts(dtutil.now()) + 60 *  60 * 24 * 365 * 10)
+    return response
+
+@APP.teardown_request
+def teardown_request(e: Optional[Exception]) -> None:
     if g.get('p') is not None:
         perf.check(g.p, 'slow_page', request.path, 'decksite')
     db().close()
-    return response
-
 
 def init(debug: bool = True, port: Optional[int] = None) -> None:
     """This method is only called when initializing the dev server.  uwsgi (prod) doesn't call this method"""

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -112,10 +112,10 @@ def before_request() -> None:
 
 @APP.after_request
 def after_request(response: Response) -> Response:
-    requests_until_we_hide_intro_box = 20 # Typically ten page views because of async requests for the status bar.
+    requests_until_no_intro = 20 # Typically ten page views because of async requests for the status bar.
     views = int(request.cookies.get('views', 0)) + 1
     response.set_cookie('views', str(views))
-    if views >= requests_until_we_hide_intro_box:
+    if views >= requests_until_no_intro:
         response.set_cookie('hide_intro', value=str(True), expires=dtutil.dt2ts(dtutil.now()) + 60 *  60 * 24 * 365 * 10)
     return response
 


### PR DESCRIPTION
Also clean up some typing around after_request and teardown_request that was
a bit confused.

Fixes #7534.