### PR TITLE
Fix "you have less than 60 cards" being displayed when issue is deck formatting

### DIFF
--- a/magic/legality.py
+++ b/magic/legality.py
@@ -17,6 +17,17 @@ def legal_formats(d: Container, formats_to_check: Set[str] = None, errors: Dict[
     if errors is None:
         errors = {}
     formats_to_discard = set()
+
+    # When the formatting of the deck cannot be read, the decklist reader will return an empty deck.
+    # When the text box is empty, a different error will pop up.
+    # So if the text box is not empty, but no cards are read, it must be a formatting issue.
+    if (sum(e['n'] for e in d.maindeck) + sum(e['n'] for e in d.sideboard)) <= 0:
+        for f in formats_to_check:
+            add_error(errors, f, 'Legality_General', 'Deck\'s formatting cannot be read.')
+            formats_to_discard.add(f)
+        # I returned here because I want to skip all other checks.
+        return formats_to_check - formats_to_discard
+
     if sum(e['n'] for e in d.maindeck) < 60:
         for f in formats_to_check:
             add_error(errors, f, 'Legality_General', 'You have less than 60 cards.')

--- a/magic/legality.py
+++ b/magic/legality.py
@@ -23,7 +23,7 @@ def legal_formats(d: Container, formats_to_check: Set[str] = None, errors: Dict[
     # So if the text box is not empty, but no cards are read, it must be a formatting issue.
     if (sum(e['n'] for e in d.maindeck) + sum(e['n'] for e in d.sideboard)) <= 0:
         for f in formats_to_check:
-            add_error(errors, f, 'Legality_General', 'Deck\'s formatting cannot be read.')
+            add_error(errors, f, 'Legality_General', "I'm afraid I don't recognize that decklist format. Try exporting from MTGO.")
             formats_to_discard.add(f)
         # I returned here because I want to skip all other checks.
         return formats_to_check - formats_to_discard


### PR DESCRIPTION
Fix PennyDreadfulMTG/Penny-Dreadful-Tools#7454

This fix is a bit temporary, as it's only returning the error "formatting cannot be read" when the decklist textbox is not empty, but the decklist produced by interpreter in `decklist.py` is empty.

Still, it does fixes the problem, that is `We sometimes say "you have less than 60 cards" on league sign up when the error is something else`.

I'm not sure if we are ready to close the issue now. I can't find any new ways to reproduce the issue anymore. But if there is time, we probably should have a better fix where `decklist.py` tells `legality.py` there is an issue, or just return the issue to the webpage directly.
