### PR TITLE
Drop one second of "end date" of week to get better display

### DIFF
--- a/decksite/views/prizes.py
+++ b/decksite/views/prizes.py
@@ -45,7 +45,7 @@ def split_by_week(competitions: List[Competition]) -> List[Container]:
     while True:
         week = Container()
         week.start_date = dt
-        week.end_date = dt + datetime.timedelta(weeks=1)
+        week.end_date = dt + datetime.timedelta(weeks=1) - datetime.timedelta(seconds=1)
         week.competitions = []
         while len(competitions) > 0 and competitions[0].start_date > dt:
             week.competitions = week.competitions + [competitions.pop(0)]


### PR DESCRIPTION
It doesn't make sense to say "week ending Aug 7" when you mean ending at
midnight at the *start* of Aug 7.