### PR TITLE
Use monospaced digits in numeric table columns.

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -692,6 +692,10 @@ td.n, th.n {
     text-align: right;
 }
 
+td.n {
+    font-variant-numeric: tabular-nums;
+}
+
 tr.wide td, tr.wide th {
     padding-bottom: 0.5em;
     padding-top: 0.5em;


### PR DESCRIPTION
This is for easier scannability/comparison across rows.

Fixes #7765.