### PR TITLE
Have the bot clear the redis rotation cache before emitting hype message.

### DIFF
--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -354,6 +354,7 @@ async def get_role(guild: Guild, rolename: str, create: bool = False) -> Optiona
     return None
 
 async def rotation_hype_message() -> Optional[str]:
+    rotation.clear_redis()
     runs, runs_percent, cs = rotation.read_rotation_files()
     runs_remaining = rotation.TOTAL_RUNS - runs
     newly_legal = [c for c in cs if c.hit_in_last_run and c.hits == rotation.TOTAL_RUNS / 2]

--- a/discordbot/commands/hype.py
+++ b/discordbot/commands/hype.py
@@ -8,7 +8,6 @@ from magic import rotation
 from shared import dtutil
 
 
-@commands.is_owner()
 @commands.command()
 async def hype(ctx: MtgContext) -> None:
     """Display the latest rotation hype message."""
@@ -17,7 +16,6 @@ async def hype(ctx: MtgContext) -> None:
     msg = None
     if until_rotation < datetime.timedelta(7) and last_run_time is not None:
         msg = await bot.rotation_hype_message()
-        rotation.clear_redis()
     if msg:
         await ctx.send(msg)
     else:

--- a/magic/rotation.py
+++ b/magic/rotation.py
@@ -216,7 +216,7 @@ def rotation_redis_store() -> Tuple[int, int, List[Card]]:
         if c is not None:
             cards.append(c)
             classify_by_status(c, card_names_by_status)
-    redis.store('decksite:rotation:summary:runs', runs, ex=300)
+    redis.store('decksite:rotation:summary:runs', runs, ex=604800)
     redis.store('decksite:rotation:summary:runs_percent', runs_percent, ex=604800)
     redis.store('decksite:rotation:summary:cards', cards, ex=604800)
     if 'Undecided' in card_names_by_status:


### PR DESCRIPTION
The semantics of decksite are quite simple - have a long-lived cache but remove
it when a run completes.

Because the bot does not use the same redis db as decksite and the rotation
script this won't work for the bot. Instead clear the cache immediately
before generating the hourly message. Cache will still be used for `!hype`
command but maybe it makes sense to clear it there too.