### PR TITLE
Always send a rotation hype message in response to the hype comamnd.

### DIFF
--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -353,7 +353,7 @@ async def get_role(guild: Guild, rolename: str, create: bool = False) -> Optiona
         return await guild.create_role(name=rolename)
     return None
 
-async def rotation_hype_message() -> Optional[str]:
+async def rotation_hype_message(force=True) -> Optional[str]:
     rotation.clear_redis()
     runs, runs_percent, cs = rotation.read_rotation_files()
     runs_remaining = rotation.TOTAL_RUNS - runs
@@ -363,7 +363,7 @@ async def rotation_hype_message() -> Optional[str]:
     num_undecided = len([c for c in cs if c.status == 'Undecided'])
     num_legal_cards = len([c for c in cs if c.status == 'Legal'])
     s = f'Rotation run number {runs} completed. Rotation is {runs_percent}% complete. {num_legal_cards} cards confirmed.'
-    if not newly_hit + newly_legal + newly_eliminated and runs != 1 and runs % 5 != 0 and runs < rotation.TOTAL_RUNS / 2:
+    if not force and not newly_hit + newly_legal + newly_eliminated and runs != 1 and runs % 5 != 0 and runs < rotation.TOTAL_RUNS / 2:
         return None # Sometimes there's nothing to report
     if len(newly_hit) > 0 and runs_remaining > runs:
         newly_hit_s = list_of_most_interesting(newly_hit)

--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -119,8 +119,7 @@ class Bot(commands.Bot):
             data = None
             # Linked to PDM
             if role is not None and not role in before.roles:
-                if data is None:
-                    data = await fetcher.person_data_async(before.id)
+                data = await fetcher.person_data_async(before.id)
                 if data.get('id', None):
                     await after.add_roles(role)
 

--- a/discordbot/commands/hype.py
+++ b/discordbot/commands/hype.py
@@ -12,10 +12,9 @@ from shared import dtutil
 async def hype(ctx: MtgContext) -> None:
     """Display the latest rotation hype message."""
     until_rotation = rotation.next_rotation() - dtutil.now()
-    last_run_time = rotation.last_run_time()
     msg = None
-    if until_rotation < datetime.timedelta(7) and last_run_time is not None:
-        msg = await bot.rotation_hype_message()
+    if until_rotation < datetime.timedelta(7) and rotation.last_run_time() is not None:
+        msg = await bot.rotation_hype_message(force=True)
     if msg:
         await ctx.send(msg)
     else:


### PR DESCRIPTION
Even if nothing interesting has happened.

(tbh the skipping of reports when nothing has happened is confusing and should
probably just be removed - #general is buy enough now it's never just the
bot talking to itself and if it is does it matter?)