### PR TITLE
Fix text color when typing in search box.

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1663,6 +1663,10 @@ button, form, input, select, textarea {
     font-size: inherit;
 }
 
+header input {
+    color: #502828;
+}
+
 button, main input, select, textarea, .uploader-label, .instructions {
     width: 20rem;
 }


### PR DESCRIPTION
This was broken trying to make the data table dropdown and search box pale
   instead of pure black.