### PR TITLE
Disable guess_league_archetypes hourly job

### DIFF
--- a/maintenance/guess_league_archetypes.py
+++ b/maintenance/guess_league_archetypes.py
@@ -1,8 +1,6 @@
 from decksite.data import archetype, deck
 
-HOURLY = True
-
-def run() -> None:
+def ad_hoc() -> None:
     decks = deck.load_decks('NOT reviewed')
     deck.calculate_similar_decks(decks)
     for d in decks:


### PR DESCRIPTION
There's some chance this is implicated in site instability.

I can't get the run time below 2 mins on local even with a LIMIT on the load_decks because calcuate_similar_decks is expensive. Will need to be looked at in more depth. Disabling for now as hopeful quick fix.