### PR TITLE
Limit /api/competitions/ to returning the 50 most recent competitions

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -299,7 +299,7 @@ class LoadRandomDeck(Resource):
 def competitions_api() -> Response:
     # Don't send competitions with any decks that do not have their correct archetype to third parties otherwise they
     # will store it and be wrong forever.
-    comps = comp.load_competitions(having='num_reviewed = num_decks', should_load_decks=True)
+    comps = comp.load_competitions(having='num_reviewed = num_decks', limit='LIMIT 50', should_load_decks=True)
     r = []
     for c in comps:
         if c.decks:

--- a/decksite/data/competition.py
+++ b/decksite/data/competition.py
@@ -58,7 +58,7 @@ def get_or_insert_competition(start_date: datetime.datetime,
 def load_competition(competition_id: int) -> Competition:
     return guarantee.exactly_one(load_competitions('c.id = {competition_id}'.format(competition_id=sqlescape(competition_id)), should_load_decks=True))
 
-def load_competitions(where: str = 'TRUE', having: str = 'TRUE', season_id: Optional[int] = None, should_load_decks: Optional[bool] = False) -> List[Competition]:
+def load_competitions(where: str = 'TRUE', having: str = 'TRUE', limit: str = '', season_id: Optional[int] = None, should_load_decks: Optional[bool] = False) -> List[Competition]:
     sql = """
         SELECT
             c.id,
@@ -93,7 +93,8 @@ def load_competitions(where: str = 'TRUE', having: str = 'TRUE', season_id: Opti
         ORDER BY
             c.start_date DESC,
             c.name
-    """.format(season_join=query.season_join(), where=where, season_query=query.season_query(season_id, 'season.id'), having=having)
+        {limit}
+    """.format(season_join=query.season_join(), where=where, season_query=query.season_query(season_id, 'season.id'), having=having, limit=limit)
     competitions = [Competition(r) for r in db().select(sql)]
     for c in competitions:
         c.start_date = dtutil.ts2dt(c.start_date)


### PR DESCRIPTION
The endpoint had become nonfunctional trying to return all competitions ever