### PR TITLE
Don't show an incorrect date for PD500

### DIFF
--- a/decksite/view.py
+++ b/decksite/view.py
@@ -142,9 +142,8 @@ class View(BaseView):
     # Sitewide notice in a banner at the top of every page, for very important things only!
     def notice_html(self) -> str:
         now = dtutil.now(dtutil.GATHERLING_TZ)
-        pd500_date = tournaments.pd500_date()
-        if pd500_date is not None and tournaments.is_pd500_week(now):
-            date = dtutil.display_date_with_date_and_year(pd500_date)
+        if tournaments.is_pd500_week(now):
+            date = dtutil.display_date_with_date_and_year(tournaments.pd500_date())
             return template.render_name('pd500notice', {'url': url_for('pd500'), 'date': date})
         if tournaments.is_kick_off_week(now):
             date = dtutil.display_date_with_date_and_year(tournaments.kick_off_date())

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -22,7 +22,7 @@ class Home(View):
         self.setup_tournaments()
         self.pd500_url = url_for('pd500')
         pd500_date = tournaments.pd500_date()
-        if pd500_date is not None and pd500_date > dtutil.now():
+        if pd500_date > dtutil.now():
             self.pd500_date = dtutil.display_date_with_date_and_year(pd500_date)
         self.kick_off_url = url_for('kickoff')
         kick_off_date = tournaments.kick_off_date()

--- a/decksite/views/pd500.py
+++ b/decksite/views/pd500.py
@@ -16,7 +16,7 @@ class PD500(View):
         self.people_with_byes = [{'person': person, 'url': url_for('.person', mtgo_username=person)} for person in people]
         self.people_with_byes = sorted(self.people_with_byes, key=lambda k: k['person'])
         pd500_date = tournaments.pd500_date()
-        if pd500_date is None or dtutil.now() > pd500_date:
+        if dtutil.now() > pd500_date:
             self.date_info = 'The Penny Dreadful 500 is on the second-last Saturday of the season'
         else:
             self.date_info = 'The next Penny Dreadful 500 is on ' + dtutil.display_date_with_date_and_year(pd500_date)

--- a/magic/tournaments.py
+++ b/magic/tournaments.py
@@ -80,14 +80,15 @@ def get_all_next_tournament_dates(start: datetime.datetime, index: int = 0) -> L
 
 # Note: this may be in the past. It always gives the date for the current season.
 # Note: if the start date of next season is not known then the date of the PD 500 cannot be known and in such a case this return None.
-def pd500_date() -> Optional[datetime.datetime]:
+def pd500_date() -> datetime.datetime:
+    if seasons.next_rotation_ex().codename == '???':
+        return datetime.datetime(1970, 1,1)
+
     end_of_season = seasons.next_rotation()
     return end_of_season - datetime.timedelta(days=12, hours=13, minutes=30) # This effectively hardcodes a 10:30 PD Sat start time AND a Thu/Fri midnight rotation time.
 
 def is_pd500_week(start: datetime.datetime) -> bool:
     date_of_pd500 = pd500_date()
-    if date_of_pd500 is None:
-        return False
     return start <= date_of_pd500 <= start + datetime.timedelta(days=7)
 
 # Note: this may be in the past. It always gives the date for the current season.

--- a/magic/tournaments.py
+++ b/magic/tournaments.py
@@ -1,7 +1,7 @@
 import datetime
 import sys
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 
 import inflect
 from dateutil import rrule  # type: ignore # dateutil stubs are incomplete
@@ -82,7 +82,7 @@ def get_all_next_tournament_dates(start: datetime.datetime, index: int = 0) -> L
 # Note: if the start date of next season is not known then the date of the PD 500 cannot be known and in such a case this return None.
 def pd500_date() -> datetime.datetime:
     if seasons.next_rotation_ex().codename == '???':
-        return datetime.datetime(1970, 1,1)
+        return datetime.datetime(1970, 1, 1)
 
     end_of_season = seasons.next_rotation()
     return end_of_season - datetime.timedelta(days=12, hours=13, minutes=30) # This effectively hardcodes a 10:30 PD Sat start time AND a Thu/Fri midnight rotation time.


### PR DESCRIPTION
Actually fix #8337, and do so in a way that doesn't require null checks.