### PR TITLE
Include referrer info when present in 404 logging

### DIFF
--- a/shared_web/flask_app.py
+++ b/shared_web/flask_app.py
@@ -72,7 +72,8 @@ class PDFlask(Flask):
     def not_found(self, e: Exception) -> Union[Response, Tuple[str, int]]:
         if request.path.startswith('/error/HTTP_BAD_GATEWAY'):
             return return_json(generate_error('BADGATEWAY', 'Bad Gateway'), status=502)
-        logger.warning('404 Not Found ' + request.path)
+        referrer = ', referrer: ' + request.referrer if request.referrer else ''
+        logger.warning('404 Not Found ' + request.path + referrer)
         if request.path.startswith('/api/'):
             return return_json(generate_error('NOTFOUND', 'Endpoint not found'), status=404)
         view = NotFound(e)


### PR DESCRIPTION
I want to see if we're still referring to /people/&lt;id&gt;/ anywhere or if these are just coming from stale links elsewhere