### PR TITLE
update swiss.py command to solve issue #8480

### DIFF
--- a/discordbot/commands/swiss.py
+++ b/discordbot/commands/swiss.py
@@ -21,10 +21,22 @@ async def swiss(ctx: MtgContext, num_players: Optional[int], num_rounds: Optiona
         top_n = 2 ** num_elimination_rounds
     s = ''
     num_players_by_losses, record_required = swisscalc(num_players, num_rounds, num_elimination_rounds)
+    players_in_top_n = 0
+    players_who_dont_miss = None  # number of players with the worst record that still makes top 8 who make top 8
     for i, n in enumerate(num_players_by_losses):
         s += f'{round(n, 1)} players at {num_rounds - i}-{i}\n'
+        players_in_top_n += n
+        if players_in_top_n > top_n and players_who_dont_miss is None:
+            players_who_dont_miss = n + top_n - players_in_top_n
+    if players_who_dont_miss is None: players_who_dont_miss = num_players
+
     if record_required and top_n:
-        s += f'\nIt is likely that a record of {record_required} is needed to make the Top {top_n}'
+        if players_who_dont_miss - int(players_who_dont_miss) < 0.000001:  # if it's an integer number of players
+            s += f'\nIt is likely that {int(players_who_dont_miss)} ' \
+             f'people with a record of {record_required} will make the Top {top_n}'
+        else:
+            s += f'\nIt is likely that {int(players_who_dont_miss)}-{int(players_who_dont_miss) + 1} ' \
+             f'({round(players_who_dont_miss, 1)}) people with a record of {record_required} will make the Top {top_n}'
     await ctx.send(s)
 
 def swisscalc(num_players: int, num_rounds: int, num_elimination_rounds: int) -> Tuple[List[int], Optional[str]]:

--- a/discordbot/commands/swiss.py
+++ b/discordbot/commands/swiss.py
@@ -34,7 +34,7 @@ async def swiss(ctx: MtgContext, num_players: Optional[int], num_rounds: Optiona
 
     if record_required and top_n:
         if abs(players_who_dont_miss - int(players_who_dont_miss)) < 0.000001:  # if it's an integer number of players
-            people_person = "people" if round(players_who_dont_miss) != 1 else "person"
+            people_person = 'people' if round(players_who_dont_miss) != 1 else 'person'
             s += f'\nIt is likely that {round(players_who_dont_miss)} {people_person} with a record of {record_required} will make the Top {top_n}'
         else:
             s += f'\nIt is likely that {int(players_who_dont_miss)} or {int(players_who_dont_miss) + 1} ({round(players_who_dont_miss, 1)}) people with a record of {record_required} will make the Top {top_n}'

--- a/discordbot/commands/swiss.py
+++ b/discordbot/commands/swiss.py
@@ -26,17 +26,17 @@ async def swiss(ctx: MtgContext, num_players: Optional[int], num_rounds: Optiona
     for i, n in enumerate(num_players_by_losses):
         s += f'{round(n, 1)} players at {num_rounds - i}-{i}\n'
         players_in_top_n += n
-        if players_in_top_n > top_n and players_who_dont_miss is None:
-            players_who_dont_miss = n + top_n - players_in_top_n
-    if players_who_dont_miss is None: players_who_dont_miss = num_players
+        if top_n is not None:
+            if players_in_top_n > top_n and players_who_dont_miss is None:
+                players_who_dont_miss = n + top_n - players_in_top_n
+    if players_who_dont_miss is None:
+        players_who_dont_miss = num_players
 
     if record_required and top_n:
-        if players_who_dont_miss - int(players_who_dont_miss) < 0.000001:  # if it's an integer number of players
-            s += f'\nIt is likely that {int(players_who_dont_miss)} ' \
-             f'people with a record of {record_required} will make the Top {top_n}'
+        if abs(players_who_dont_miss - int(players_who_dont_miss)) < 0.000001:  # if it's an integer number of players
+            s += f'\nIt is likely that {int(players_who_dont_miss)} people with a record of {record_required} will make the Top {top_n}'
         else:
-            s += f'\nIt is likely that {int(players_who_dont_miss)}-{int(players_who_dont_miss) + 1} ' \
-             f'({round(players_who_dont_miss, 1)}) people with a record of {record_required} will make the Top {top_n}'
+            s += f'\nIt is likely that {int(players_who_dont_miss)}-{int(players_who_dont_miss) + 1} ({round(players_who_dont_miss, 1)}) people with a record of {record_required} will make the Top {top_n}'
     await ctx.send(s)
 
 def swisscalc(num_players: int, num_rounds: int, num_elimination_rounds: int) -> Tuple[List[int], Optional[str]]:

--- a/discordbot/commands/swiss.py
+++ b/discordbot/commands/swiss.py
@@ -34,9 +34,10 @@ async def swiss(ctx: MtgContext, num_players: Optional[int], num_rounds: Optiona
 
     if record_required and top_n:
         if abs(players_who_dont_miss - int(players_who_dont_miss)) < 0.000001:  # if it's an integer number of players
-            s += f'\nIt is likely that {int(players_who_dont_miss)} people with a record of {record_required} will make the Top {top_n}'
+            people_person = "people" if round(players_who_dont_miss) != 1 else "person"
+            s += f'\nIt is likely that {round(players_who_dont_miss)} {people_person} with a record of {record_required} will make the Top {top_n}'
         else:
-            s += f'\nIt is likely that {int(players_who_dont_miss)}-{int(players_who_dont_miss) + 1} ({round(players_who_dont_miss, 1)}) people with a record of {record_required} will make the Top {top_n}'
+            s += f'\nIt is likely that {int(players_who_dont_miss)} or {int(players_who_dont_miss) + 1} ({round(players_who_dont_miss, 1)}) people with a record of {record_required} will make the Top {top_n}'
     await ctx.send(s)
 
 def swisscalc(num_players: int, num_rounds: int, num_elimination_rounds: int) -> Tuple[List[int], Optional[str]]:


### PR DESCRIPTION
!swiss command should now report the number of players with the worst record that still makes top 8 rather than only the worst record that can make top 8

Fixes #8480