### PR TITLE
fixed #9080

### DIFF
--- a/magic/fetcher.py
+++ b/magic/fetcher.py
@@ -237,7 +237,7 @@ async def dreadrise_search_cards(query: str, page_size: int = 60, pd_mode: Liter
         minus = '-' if pd_mode < 0 else ''
         query = f'{minus}f:pd+({query})'
     url = f'{domain}/cards/find?q={query}+output:pagetext&page_size={page_size}'
-    return str(await fetch_tools.fetch_async(url)).split('\n')
+    return [x for x in str(await fetch_tools.fetch_async(url)).split('\n') if x]
 
 async def dreadrise_search_json(url: str) -> Tuple[int, Any, Optional[str]]:
     try:


### PR DESCRIPTION
the way !drc command works is that it searches for cards legal in PD, then for cards not legal in PD. if no cards are legal in PD, then the search api outputs an empty string, which has 0 `\n` line breaks therefore it has 1 line, and that line was considered a card before, reducing the number of search results by 1. so the search in question found 3 cards (Skarrgan Hellkite, Mnemonic Betrayal, and Nullhide Ferox) but 0 cards were legal in PD so Skarrgan Hellkite was ignored.

in addition, fixed a potential bug which could happen if the search api output a linebreak at the end of all search results.

fixes #9080 