### PR TITLE
Better display of metagame page on mobile

### DIFF
--- a/decksite/data/playability.py
+++ b/decksite/data/playability.py
@@ -43,6 +43,8 @@ def key_cards(season_id: int) -> Dict[int, str]:
         ) AS pm ON p.archetype_id = pm.archetype_id AND p.playability = pm.playability
         WHERE
             {where}
+        ORDER BY
+            p.name
     """
     return {r['archetype_id']: r['name'] for r in db().select(sql)}
 

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -216,9 +216,9 @@ class View(BaseView):
 
     def prepare_archetypes(self) -> None:
         for a in getattr(self, 'archetypes', []):
-            self.prepare_archetype(a, getattr(self, 'archetypes', []))
+            self.prepare_archetype(a, getattr(self, 'archetypes', []), self.tournament_only)
 
-    def prepare_archetype(self, a: archetype.Archetype, archetypes: List[archetype.Archetype]) -> None:
+    def prepare_archetype(self, a: archetype.Archetype, archetypes: List[archetype.Archetype], tournament_only: bool = False) -> None:
         a.current = a.id == getattr(self, 'archetype', {}).get('id', None)
         a.show_record = a.get('num_decks') is not None and (a.get('wins') or a.get('draws') or a.get('losses'))
         counter = Counter()  # type: ignore
@@ -237,7 +237,7 @@ class View(BaseView):
             a.most_common_cards.append(cs[v[0]])
         a.has_most_common_cards = len(a.most_common_cards) > 0
         for b in [b for b in PreOrderIter(a) if b.id in [a.id for a in archetypes]]:
-            b['url'] = url_for('.archetype', archetype_id=b['id'])
+            b['url'] = url_for('.archetype', archetype_id=b['id'], deck_type=DeckType.TOURNAMENT.value if tournament_only else None)
             # It perplexes me that this is necessary. It's something to do with the way NodeMixin magic works. Mustache doesn't like it.
             b['depth'] = b.depth
 

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -359,6 +359,7 @@ main {
 .content {
     display: flex;
     flex-wrap: wrap;
+    overflow: scroll;
 }
 
 footer {
@@ -653,7 +654,7 @@ ul.decklist {
 
 Tables
 
-Our tables are constrained to a single line, allow no column to become very large and will clip overflow with an elipsis.
+Our tables are constrained to a single line, allow no column to become very large and will clip overflow with an ellipsis.
 We make occasional use of space in the margin to the left. This is called 'marginalia'.
 
 Sizes in the table are in ems because they should relate to the size of table text not the page base.


### PR DESCRIPTION
- Make archetype links on tournament-only pages link to tournament-only pages
- Don't have /metagame go all funky at narrow widths, instead scroll
