### PR TITLE
Allow 'penny' as well as 'pd' for format in search

### DIFF
--- a/find/find_test.py
+++ b/find/find_test.py
@@ -453,6 +453,15 @@ def test_is_commander() -> None:
     do_test('is:commander', "((type_line LIKE '%%legendary%%') AND ((type_line LIKE '%%creature%%') OR (oracle_text LIKE CONCAT('%%', name, ' can be your commander%%'))) AND (c.id IN (SELECT card_id FROM card_legality WHERE format_id = 4 AND legality <> 'Banned')))")
 
 @pytest.mark.functional
+def test_format_functional() -> None:
+    legal = ['Plains']
+    not_legal = ['Black Lotus']
+    do_functional_test('f:penny', legal, not_legal)
+    do_functional_test('f:pd', legal, not_legal)
+    do_functional_test('-f:penny', not_legal, legal)
+    do_functional_test('-f:pd', not_legal, legal)
+
+@pytest.mark.functional
 def test_is_commander_illegal_commander_functional() -> None:
     do_functional_test('c:g cmc=2 is:commander', ['Ayula, Queen Among Bears', 'Gaddock Teeg'], ['Fblthp, the Lost', 'Rofellos, Llanowar Emissary'])
 

--- a/find/search.py
+++ b/find/search.py
@@ -267,7 +267,7 @@ def set_where(name: str) -> str:
     return '(c.id IN (SELECT card_id FROM printing WHERE set_id IN (SELECT id FROM `set` WHERE name = {name} OR code = {name})))'.format(name=sqlescape(name))
 
 def format_where(term: str) -> str:
-    if term == 'pd' or term == 'Penny Dreadful':
+    if term == 'pd' or term.startswith('penny'):
         term = seasons.current_season_name()
     format_id = db().value('SELECT id FROM format WHERE name LIKE %s', ['{term}%%'.format(term=card.unaccent(term))])
     if format_id is None:


### PR DESCRIPTION
Fixes #9187.
