### PR TITLE
Seasonize most of the links on the metagame menu

### DIFF
--- a/decksite/__init__.py
+++ b/decksite/__init__.py
@@ -52,9 +52,9 @@ def build_menu() -> List[Dict[str, Union[str, Dict[str, str]]]]:
         {'name': gettext('Metagame'), 'endpoint': 'home', 'badge': archetypes_badge, 'submenu': [
             {'name': gettext('Meta'), 'endpoint': '.metagame'},
             {'name': gettext('Decks'), 'endpoint': '.decks'},
-            {'name': gettext('Archetypes'), 'endpoint': 'archetypes', 'badge': archetypes_badge},
-            {'name': gettext('People'), 'endpoint': 'people'},
-            {'name': gettext('Cards'), 'endpoint': 'cards'},
+            {'name': gettext('Archetypes'), 'endpoint': '.archetypes', 'badge': archetypes_badge},
+            {'name': gettext('People'), 'endpoint': '.people'},
+            {'name': gettext('Cards'), 'endpoint': '.cards'},
             {'name': gettext('Past Seasons'), 'endpoint': 'seasons'},
             {'name': gettext('Matchups'), 'endpoint': 'matchups'},
         ]},
@@ -85,7 +85,7 @@ def build_menu() -> List[Dict[str, Union[str, Dict[str, str]]]]:
     ]
     setup_links(menu)
     for item in menu:
-        item['current'] = item.get('endpoint', '').replace('seasons', '').replace('.', '') == current_template or current_template in [entry.get('endpoint', '') for entry in item.get('submenu', [])]
+        item['current'] = item.get('endpoint', '').replace('seasons', '').replace('.', '') == current_template or current_template in [entry.get('endpoint', '').replace('.', '') for entry in item.get('submenu', [])]
         item['has_submenu'] = item.get('submenu') is not None
     return menu
 


### PR DESCRIPTION
Now when you click them when you're viewing a season 12 page you'll stay in season 12 at the new location.

This fixes an issue where /decks/ and /metagame/ were not showing the submenu on mobile (because they were seasonized).
