### PR TITLE
Implement rotation_ex caching in a rollover-friendly way

### DIFF
--- a/magic/seasons.py
+++ b/magic/seasons.py
@@ -77,7 +77,7 @@ class RotationInfo():
         self.previous = self.calc_prev()
         self.next = self.calc_next()
 
-    def calc_next(self):
+    def calc_next(self) -> SetInfo:
         try:
             return min([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) > dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
         except ValueError:
@@ -89,7 +89,7 @@ class RotationInfo():
 
             return SetInfo('Unannounced Set', '???', '???', 'Unannounced', fake_enter_date, fake_exit_date, fake_enter_date_dt)
 
-    def calc_prev(self):
+    def calc_prev(self) -> SetInfo:
         return max([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) < dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
 
 

--- a/magic/seasons.py
+++ b/magic/seasons.py
@@ -1,10 +1,11 @@
 import datetime
-from typing import List, Optional, Union
+import functools
+from typing import List, Optional, Set, Union
 
 import attr
 
 from magic import fetcher
-from shared import dtutil, recursive_update
+from shared import dtutil, recursive_update, decorators
 from shared.pd_exception import DoesNotExistException, InvalidDataException
 
 WIS_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
@@ -61,12 +62,49 @@ class SetInfo():
                    enter_date_dt=dtutil.parse(json['enterDate']['exact'], WIS_DATE_FORMAT, dtutil.WOTC_TZ) if json['enterDate']['exact'] else dtutil.ts2dt(0),
                    )
 
-def init() -> List[SetInfo]:
+@attr.define()
+class RotationInfo():
+    next: SetInfo
+    previous: SetInfo
+
+    def __init__(self) -> None:
+        self.previous = self.calc_prev()
+        self.next = self.calc_next()
+
+    def validate(self) -> None:
+        if (self.next.enter_date_dt + ROTATION_OFFSET) > dtutil.now():
+            return
+        self.previous = self.calc_prev()
+        self.next = self.calc_next()
+
+    def calc_next(self):
+        try:
+            return min([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) > dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
+        except ValueError:
+            fake_enter_date_dt = last_rotation() + datetime.timedelta(days=90)
+            fake_exit_date_dt = last_rotation() + datetime.timedelta(days=90 + 365 + 365)
+            fake_exit_year = fake_exit_date_dt.year
+            fake_enter_date = DateType(fake_enter_date_dt.strftime(WIS_DATE_FORMAT), 'Unknown')
+            fake_exit_date = DateType(fake_exit_date_dt.strftime(WIS_DATE_FORMAT), f'Q4 {fake_exit_year}')
+
+            return SetInfo('Unannounced Set', '???', '???', 'Unannounced', fake_enter_date, fake_exit_date, fake_enter_date_dt)
+
+    def calc_prev(self):
+        return max([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) < dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
+
+
+@functools.lru_cache
+def sets() -> List[SetInfo]:
     info = fetcher.whatsinstandard()
     if info['deprecated']:
         print('Current whatsinstandard API version is DEPRECATED.')
     set_info = [SetInfo.parse(s) for s in info['sets']]
     return [release for release in set_info if release.enter_date.exact is not None]
+
+
+@functools.lru_cache
+def rotation_info() -> RotationInfo:
+    return RotationInfo()
 
 def current_season_code() -> str:
     return last_rotation_ex().code
@@ -90,20 +128,12 @@ def next_rotation() -> datetime.datetime:
     return next_rotation_ex().enter_date_dt + ROTATION_OFFSET
 
 def last_rotation_ex() -> SetInfo:
-    return max([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) < dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
+    rotation_info().validate()
+    return rotation_info().previous
 
 def next_rotation_ex() -> SetInfo:
-    try:
-        return min([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) > dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
-    except ValueError:
-        fake_enter_date_dt = last_rotation() + datetime.timedelta(days=90)
-        fake_exit_date_dt = last_rotation() + datetime.timedelta(days=90 + 365 + 365)
-        fake_exit_year = fake_exit_date_dt.year
-        fake_enter_date = DateType(fake_enter_date_dt.strftime(WIS_DATE_FORMAT), 'Unknown')
-        fake_exit_date = DateType(fake_exit_date_dt.strftime(WIS_DATE_FORMAT), f'Q4 {fake_exit_year}')
-
-        fake = SetInfo('Unannounced Set', '???', '???', 'Unannounced', fake_enter_date, fake_exit_date, fake_enter_date_dt)
-        return fake
+    rotation_info().validate()
+    return rotation_info().next
 
 def message() -> str:
     upcoming = next_rotation_ex()
@@ -153,10 +183,3 @@ def get_set_info(code: str) -> SetInfo:
         if setinfo.code == code:
             return setinfo
     raise DoesNotExistException('Could not find Set Info about {code}'.format(code=code))
-
-
-__SETS: List[SetInfo] = []
-def sets() -> List[SetInfo]:
-    if not __SETS:
-        __SETS.extend(init())
-    return __SETS

--- a/magic/seasons.py
+++ b/magic/seasons.py
@@ -67,30 +67,26 @@ class RotationInfo():
     next: SetInfo
     previous: SetInfo
 
-    def __init__(self) -> None:
-        self.previous = self.calc_prev()
-        self.next = self.calc_next()
-
     def validate(self) -> None:
         if (self.next.enter_date_dt + ROTATION_OFFSET) > dtutil.now():
             return
-        self.previous = self.calc_prev()
-        self.next = self.calc_next()
+        self.previous = calc_prev()
+        self.next = calc_next()
 
-    def calc_next(self) -> SetInfo:
-        try:
-            return min([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) > dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
-        except ValueError:
-            fake_enter_date_dt = last_rotation() + datetime.timedelta(days=90)
-            fake_exit_date_dt = last_rotation() + datetime.timedelta(days=90 + 365 + 365)
-            fake_exit_year = fake_exit_date_dt.year
-            fake_enter_date = DateType(fake_enter_date_dt.strftime(WIS_DATE_FORMAT), 'Unknown')
-            fake_exit_date = DateType(fake_exit_date_dt.strftime(WIS_DATE_FORMAT), f'Q4 {fake_exit_year}')
+def calc_next() -> SetInfo:
+    try:
+        return min([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) > dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
+    except ValueError:
+        fake_enter_date_dt = last_rotation() + datetime.timedelta(days=90)
+        fake_exit_date_dt = last_rotation() + datetime.timedelta(days=90 + 365 + 365)
+        fake_exit_year = fake_exit_date_dt.year
+        fake_enter_date = DateType(fake_enter_date_dt.strftime(WIS_DATE_FORMAT), 'Unknown')
+        fake_exit_date = DateType(fake_exit_date_dt.strftime(WIS_DATE_FORMAT), f'Q4 {fake_exit_year}')
 
-            return SetInfo('Unannounced Set', '???', '???', 'Unannounced', fake_enter_date, fake_exit_date, fake_enter_date_dt)
+        return SetInfo('Unannounced Set', '???', '???', 'Unannounced', fake_enter_date, fake_exit_date, fake_enter_date_dt)
 
-    def calc_prev(self) -> SetInfo:
-        return max([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) < dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
+def calc_prev() -> SetInfo:
+    return max([s for s in sets() if (s.enter_date_dt + ROTATION_OFFSET) < dtutil.now()], key=lambda s: s.enter_date_dt + ROTATION_OFFSET)
 
 
 @functools.lru_cache
@@ -104,7 +100,7 @@ def sets() -> List[SetInfo]:
 
 @functools.lru_cache
 def rotation_info() -> RotationInfo:
-    return RotationInfo()
+    return RotationInfo(calc_next(), calc_prev())
 
 def current_season_code() -> str:
     return last_rotation_ex().code

--- a/modo_bugs/repo.py
+++ b/modo_bugs/repo.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Dict, Optional
 
 from github import Github
@@ -6,7 +7,7 @@ from github.IssueComment import IssueComment
 from github.Project import Project
 from github.Repository import Repository
 
-from shared import configuration, decorators
+from shared import configuration
 from shared import redis_wrapper as redis
 from shared.pd_exception import OperationalException
 
@@ -14,13 +15,13 @@ from . import strings
 
 ISSUE_CODES: Dict[int, str] = {}
 
-@decorators.memoize
+@functools.lru_cache
 def get_github() -> Optional[Github]:
     if not configuration.get_str('github_user') or not configuration.get_str('github_password'):
         return None
     return Github(configuration.get_str('github_user'), configuration.get_str('github_password'))
 
-@decorators.memoize
+@functools.lru_cache
 def get_repo() -> Repository:
     gh = get_github()
     if gh is not None:

--- a/shared/decorators.py
+++ b/shared/decorators.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 def retry_after_calling(retry_func: Callable[[], None]) -> Callable[[FuncType[T]], FuncType[T]]:
     def decorator(decorated_func: FuncType[T]) -> FuncType[T]:
+        @functools.wraps(decorated_func)
         def wrapper(*args: List[Any], **kwargs: Dict[str, Any]) -> Any:
             try:
                 return decorated_func(*args, **kwargs)
@@ -28,16 +29,6 @@ def retry_after_calling(retry_func: Callable[[], None]) -> Callable[[FuncType[T]
                     raise
         return wrapper
     return decorator
-
-def memoize(obj: FuncType[T]) -> FuncType[T]:
-    cache = obj.cache = {}  # type: ignore
-
-    @functools.wraps(obj)
-    def memoizer(*args, **kwargs):  # type: ignore
-        if args not in cache:
-            cache[args] = obj(*args, **kwargs)
-        return cache[args]
-    return memoizer
 
 def lock(func: FuncType[T]) -> T:
     return func()


### PR DESCRIPTION
Not quite as fast as #9448, but much less buggy.

Still makes subsequent calls O(1)