### PR TITLE
Deck name sanitization improvement

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -226,7 +226,7 @@ def ucase_trailing_roman_numerals(name: str) -> str:
     return name
 
 def strip_leading_punctuation(name: str) -> str:
-    return re.sub(r'^[^\w"\']*', '', name, flags=re.IGNORECASE)
+    return re.sub(r'^[^\w"\'(]*', '', name, flags=re.IGNORECASE)
 
 # See #6041.
 def remove_leading_deck(name: str) -> str:

--- a/decksite/deck_name_test.py
+++ b/decksite/deck_name_test.py
@@ -112,6 +112,7 @@ TESTDATA: List[Tuple[str, str, Optional[List[str]], Optional[str]]] = [
     ('Fuck', 'Mono Blue Aggro', ['U'], 'Aggro'),
     ('Mono Black Reanimator', 'Mono Black Reanimator', ['B'], 'Mono Black Reanimator'),
     ('Mad Cat Lady pd league', 'Mad Cat Lady League', ['B'], 'Aggro'),
+    ("(NecropolisRegent's) The Emperor Protects", "(Necropolisregent's) the Emperor Protects", ['B'], 'Control'),
 ]
 
 @pytest.mark.parametrize('original_name,expected,colors,archetype_name', TESTDATA)


### PR DESCRIPTION
- Don't error if more than one pipe provided in card text
- Add a test for a deck name that failed once
- Fix a deck name sanitization
