### PR TITLE
Make Snow and Colorless symbol sort ordering stable, fix issues with sort_score

### DIFF
--- a/magic/mana.py
+++ b/magic/mana.py
@@ -180,7 +180,7 @@ def order_score(initial_symbols: Tuple[str, ...]) -> int:
     symbols = [symbol for symbol in initial_symbols if symbol not in ('C', 'S')]
     if not symbols:
         return 0
-    score = 0
+    score = 100  # Start at 100 so that subtracting for Colorless and Snow don't take us below 0.
     positions = ['W', 'U', 'B', 'R', 'G']
     current = positions.index(symbols[0])
     for symbol in symbols[1:]:
@@ -190,15 +190,23 @@ def order_score(initial_symbols: Tuple[str, ...]) -> int:
             distance += len(positions)
         score += distance
         current = position
-    return score * 10 + positions.index(symbols[0])
+    score = score * 10 + positions.index(symbols[0])
+    # Prefer Colorless and Snow at the end.
+    if 'C' in initial_symbols:
+        score -= initial_symbols.index('C')
+    if 'S' in initial_symbols:
+        score -= initial_symbols.index('S') * 2
+    return score
 
-# Gives an integer sort ordering for a set of colors already in min(order_score) ordering.
-# Use on unsorted lists of color symbols will produce undesirable results.
-def sort_score(symbols: Sequence[str]) -> int:
-    positions = [None, 'C', 'S', 'W', 'U', 'B', 'R', 'G']
-    score = 0
-    for i, symbol in enumerate(reversed(symbols), start=1):
-        score += positions.index(symbol) * 10 * i
+def sort_score(initial_symbols: Sequence[str]) -> int:
+    positions = ['C', 'S', 'W', 'U', 'B', 'R', 'G']
+    c = [symbol for symbol in initial_symbols if symbol in ['W', 'U', 'B', 'R', 'G']]
+    # The dominant factor in ordering is how many colors are in the deck. All 2 color decks sort after all 1 color decks, etc.
+    # Colorless and Snow are not considered a color but add a little to the score so that W+C or W+S sort after just W.
+    score = len(c) * pow(2, len(positions))
+    unique_symbols = set(initial_symbols)
+    for symbol in unique_symbols:
+        score += pow(2, positions.index(symbol))
     return score
 
 class InvalidManaCostException(ParseException):

--- a/magic/mana.py
+++ b/magic/mana.py
@@ -200,12 +200,12 @@ def order_score(initial_symbols: Tuple[str, ...]) -> int:
 
 def sort_score(initial_symbols: Sequence[str]) -> int:
     positions = ['C', 'S', 'W', 'U', 'B', 'R', 'G']
-    c = [symbol for symbol in initial_symbols if symbol in ['W', 'U', 'B', 'R', 'G']]
+    symbols = set(initial_symbols)
     # The dominant factor in ordering is how many colors are in the deck. All 2 color decks sort after all 1 color decks, etc.
     # Colorless and Snow are not considered a color but add a little to the score so that W+C or W+S sort after just W.
-    score = len(c) * pow(2, len(positions))
-    unique_symbols = set(initial_symbols)
-    for symbol in unique_symbols:
+    num_colors = len([symbol for symbol in symbols if symbol in ['W', 'U', 'B', 'R', 'G']])
+    score = num_colors * pow(2, len(positions))
+    for symbol in symbols:
         score += pow(2, positions.index(symbol))
     return score
 

--- a/magic/mana_test.py
+++ b/magic/mana_test.py
@@ -109,10 +109,26 @@ def test_order() -> None:
     assert mana.order(['S']) == ['S']
     assert mana.order(['U', 'G']) == ['G', 'U']
     assert mana.order(['G', 'W', 'U']) == ['G', 'W', 'U']
+    assert mana.order(['S', 'B', 'W']) == ['W', 'B', 'S']
+    assert mana.order(['S', 'G', 'R']) == ['R', 'G', 'S']
+    assert mana.order(['C', 'B', 'W']) == ['W', 'B', 'C']
+    assert mana.order(['C', 'G', 'R']) == ['R', 'G', 'C']
+    assert mana.order(['C', 'G', 'R', 'S']) == ['R', 'G', 'C', 'S']
 
 def test_sort_score() -> None:
     assert mana.sort_score(['G', 'W', 'U']) > mana.sort_score(['G', 'U'])
     assert mana.sort_score(['B', 'R', 'G']) > mana.sort_score(['B', 'R'])
+    assert mana.sort_score(['B', 'G']) > mana.sort_score(['G', 'W'])
+    assert mana.sort_score(['C']) > mana.sort_score([])
+    assert mana.sort_score(['W']) > mana.sort_score(['C'])
+    assert mana.sort_score(['W', 'C']) > mana.sort_score(['W'])
+    assert mana.sort_score(['W', 'S']) > mana.sort_score(['W', 'C'])
+    assert mana.sort_score(['W', 'S', 'C']) > mana.sort_score(['W', 'C'])
+    assert mana.sort_score(['U']) > mana.sort_score(['W', 'C'])
+    assert mana.sort_score(['B', 'R', 'G', 'S']) > mana.sort_score(['B', 'R', 'G'])
+    assert mana.sort_score(['B', 'R', 'G', 'S']) > mana.sort_score(['B', 'R', 'G', 'C'])
+    assert mana.sort_score(['G']) > mana.sort_score(['C', 'W'])
+    assert mana.sort_score(['W', 'U', 'B', 'R', 'G']) > mana.sort_score(['C', 'S', 'U', 'B', 'R', 'G'])
 
 def test_colorless() -> None:
     assert mana.colored_symbols(['C']) == {'required': ['C'], 'also': []}


### PR DESCRIPTION
Because we were ignoring Snow and Colorless entirely when deciding on an order
of mana symbols for display we were storing inconsistent values in
deck_cache.colors.

Separately our sort_score was not actually sorting the way we want colors
sorted using the display order as input and doing things like making
['W', 'G'] and ['G', 'B'] get the same score. Switch to a simpler system
that uses 2-to-the-power-of-position like unix file permissions and similar.
But put even more weight on the number of colors so that monocolor decks always
sort before 2 color decks and so on.

Fixes #9988.
