### PR TITLE
Skip some CMB1 cards in whoosh indexing so Wasteland and Bind work correctly

### DIFF
--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -42,6 +42,10 @@ def test_results_from_queries() -> None:
     assert result.has_match()
     assert not result.is_ambiguous()
     assert result.get_best_match() == 'Llanowar Elves'
+    result = command.results_from_queries(['Wasteland'])[0][0]
+    assert result.has_match()
+    assert not result.is_ambiguous()
+    assert result.get_best_match() == 'Wasteland'
 
 
 def test_do_not_choke_on_unicode() -> None:

--- a/magic/whoosh_search_test.py
+++ b/magic/whoosh_search_test.py
@@ -70,7 +70,7 @@ class WhooshSearchTest(unittest.TestCase):
         self.finds_at_least('Efficient Constructor', 'Efficient Construction')
 
     def test_exact_match(self) -> None:
-        for card in ('Upheaval', 'Hellrider', 'Necropotence', 'Skullclamp', 'Mana Leak'):
+        for card in ('Upheaval', 'Hellrider', 'Necropotence', 'Skullclamp', 'Mana Leak', 'Wasteland'):
             self.best_match_is(card, card)
 
     def test_prefix_match(self) -> None:

--- a/magic/whoosh_write.py
+++ b/magic/whoosh_write.py
@@ -39,6 +39,9 @@ def update_index(index: FileIndex, cards: List[Card]) -> None:
             names.append(card.name)  # Split and aftermath cards
         if card.name.startswith('The '):
             names.append(card.name.replace('The ', ''))
+        if card.name == 'Waste Land' or card.name == 'Bind // Liberate':
+            # Skip a couple of CMB1 cards that counterfeit "real" cards.
+            continue
         for name in names:
             document = {}
             document['id'] = card.id


### PR DESCRIPTION
Fixes #7980.
Fixes #7661.
