### PR TITLE
Clear redis cache when calling hype command

### DIFF
--- a/discordbot/commands/hype.py
+++ b/discordbot/commands/hype.py
@@ -14,7 +14,7 @@ async def hype(ctx: MtgContext) -> None:
     last_run_time = rotation.last_run_time()
     msg = None
     if until_rotation < datetime.timedelta(7) and last_run_time is not None:
-        msg = await rotation.rotation_hype_message(True)
+        msg = await rotation.rotation_hype_message(False)  # This should be True but the hourly job is not running. See #10481.
     if msg:
         await ctx.send(msg, flags=MessageFlags.EPHEMERAL)
     else:


### PR DESCRIPTION
Normally the redis cache would be cleared by the hourly task but that isn't running correctly so let's not use the cache for now

See #10481.
