### PR TITLE
Performance improvement when generating _card_person_stats

### DIFF
--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -182,6 +182,8 @@ def preaggregate_card_person() -> None:
             d.person_id,
             season.season_id,
             ct.name
+        ORDER BY
+            NULL -- Tell the database that we don't need the results back in the GROUP BY order, any order will do.
     """.format(table=table,
                competition_join=query.competition_join(),
                season_join=query.season_join(),


### PR DESCRIPTION
This shows a mild performance improvmnt on local but a radical improvment on prod. From basically never completing (50 minutes and not finished) to just over three minutes.

Looking at the EXPLAIN output this removes "Using filesort" because the results are no longer being sorted in the order implied by the GROUP BY.

We should probably apply this to all preaggregation.
