### PR TITLE
Better error handlling and better search feedback in live card search

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -198,7 +198,8 @@ def cards2_api() -> Response:
         {
             'page': <int>,
             'objects': [<card>],
-            'total': <int>
+            'total': <int>,
+            'message': <str>,
         }
     """
     order_by = query.cards_order_by(request.args.get('sortBy'), request.args.get('sortOrder'))
@@ -208,11 +209,11 @@ def cards2_api() -> Response:
     tournament_only = request.args.get('deckType') == 'tournament'
     season_id = seasons.season_id(str(request.args.get('seasonId')), None)
     q = request.args.get('q', '').strip()
-    additional_where = query.card_search_where(q) if q else 'TRUE'
+    additional_where, message = query.card_search_where(q) if q else ('TRUE', '')
     cs = card.load_cards(additional_where=additional_where, order_by=order_by, limit=limit, archetype_id=archetype_id, person_id=person_id, tournament_only=tournament_only, season_id=season_id)
     prepare_cards(cs, tournament_only=tournament_only, season_id=season_id)
     total = card.load_cards_count(additional_where=additional_where, archetype_id=archetype_id, person_id=person_id, season_id=season_id)
-    r = {'page': page, 'total': total, 'objects': cs}
+    r = {'page': page, 'total': total, 'objects': cs, 'message': message}
     resp = return_camelized_json(r)
     resp.set_cookie('page_size', str(page_size))
     return resp

--- a/decksite/data/query.py
+++ b/decksite/data/query.py
@@ -230,12 +230,13 @@ def archetype_where(archetype_id: int) -> str:
 def card_where(name: str) -> str:
     return 'd.id IN (SELECT deck_id FROM deck_card WHERE card = {name})'.format(name=sqlescape(name))
 
-def card_search_where(q: str) -> str:
+# Returns two values, a SQL WHERE clause and a message about that clause (possibly an error message) suitable for display.
+def card_search_where(q: str) -> Tuple[str, str]:
     try:
         cs = search.search(q)
-        return 'TRUE' if len(cs) == 0 else 'name IN (' + ', '.join(sqlescape(c.name) for c in cs) + ')'
-    except search.InvalidSearchException:
-        return 'TRUE'  # Do not apply malformed queries. Future improvement: ignore invalid parts and match the valid parts.
+        return 'FALSE' if len(cs) == 0 else 'name IN (' + ', '.join(sqlescape(c.name) for c in cs) + ')', ''
+    except search.InvalidSearchException as e:
+        return 'FALSE', str(e)
 
 def tournament_only_clause() -> str:
     return "ct.name = 'Gatherling'"

--- a/decksite/data/query_test.py
+++ b/decksite/data/query_test.py
@@ -16,15 +16,17 @@ def test_decks_where() -> None:
 
 def test_card_search_where() -> None:
     tests = {
-        'Tasigur, the Golden Fang': "name IN ('Tasigur, the Golden Fang')",
+        'Tasigur, the Golden Fang': ("name IN ('Tasigur, the Golden Fang')", ''),
         # This test will not pass until we support `banned`.
         # 'banned:vintage cmc=6 c:g': "name IN ('Rebirth')",
         # The following tests might be flakey because database order matters
-        'f:modern c:r "of the" moon': "name IN ('Call of the Full Moon', 'Magus of the Moon')",
-        'f:modern c:r cmc=3 o:"nonbasic lands are mountains"': "name IN ('Blood Moon', 'Magus of the Moon')",
+        'f:modern c:r "of the" moon': ("name IN ('Call of the Full Moon', 'Magus of the Moon')", ''),
+        'f:modern c:r cmc=3 o:"nonbasic lands are mountains"': ("name IN ('Blood Moon', 'Magus of the Moon')", ''),
+        'c:bm': ('FALSE', "Using 'm' with other colors is not supported, use 'color>b' instead"),
     }
-    for q, expected in tests.items():
-        assert expected == query.card_search_where(q)
+    for q, (expected, message) in tests.items():
+        assert (expected, message) == query.card_search_where(q)
+
 
 def test_limit() -> None:
     args = {'page': '1', 'pageSize': '150'}

--- a/find/search.py
+++ b/find/search.py
@@ -225,7 +225,7 @@ def color_where(subtable: str, operator: str, term: str) -> str:
     if 'c' in colors and len(colors) > 1:
         raise InvalidValueException('A card cannot be colorless and colored')
     if 'm' in colors and len(colors) > 1:
-        raise InvalidValueException(f"Using 'm' with other colors is not supported, use '{subtable}>{term}' instead")
+        raise InvalidValueException(f"Using 'm' with other colors is not supported, use '{subtable}>{term.replace('m', '')}' instead")
     if operator == ':' and subtable == 'color_identity':
         operator = '<='
     required: Set[str] = set()
@@ -331,7 +331,7 @@ def value_lookup(table: str, value: str) -> Union[int, str]:
     if table in VALUE_LOOKUP and value in VALUE_LOOKUP[table]:
         return VALUE_LOOKUP[table][value]
     if table in VALUE_LOOKUP:
-        raise InvalidValueException(f"Invalid value '{value}' for {table} {VALUE_LOOKUP}")
+        raise InvalidValueException(f"Invalid value '{value}' for {table}")
     return value
 
 def init_value_lookup() -> None:

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -808,6 +808,16 @@ div.live {
     margin-bottom: 1em; /* Same as `main table`'s margin-bottom so that top table extras are the same distance from the table as the pagination at the bottom. */
 }
 
+.live .table-header .message {
+    margin-left: 1rem;
+    margin-right: 1rem;
+    flex-grow: 1; /* The message can take up all the space that the search box and the pageSize dropdown do not. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap; /* It's only ever allowed to be one line. */
+    width: 0; /* We don't want this element to make the table wider than it would otherwise be. */
+}
+
 /*
 
 Force a consistent size of each column in react tables otherwise things "jump" as you paginate.
@@ -1651,7 +1661,8 @@ button, form, input, select, textarea {
     font-size: inherit;
 }
 
-textarea, input[type=text], select, button {
+/* .message has the same padding as form elements here because it is text that appears on a line with two of them. */
+textarea, input[type=text], select, button, .live .table-header .message {
     padding: 0.1em 0.4rem 0.1em 0.4rem;
 }
 

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -20,7 +20,9 @@ export class Table extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            error: "",
             loadedOnce: false,
+            message: "",
             objects: [],
             page: 0,
             pageSize: parseInt(props.pageSize, 10),
@@ -72,26 +74,16 @@ export class Table extends React.Component {
             .then(
                 (response) => {
                     if (params.q === this.state.q) { // Don't update the table if this isn't the latest query.
-                        this.setState({"objects": response.data.objects, "total": response.data.total, "loadedOnce": true}); PD.initTables();
+                        this.setState({"objects": response.data.objects, "total": response.data.total, "error": "", "message": response.data.message, "loadedOnce": true}); PD.initTables();
                     }
                 },
-                (error) => { this.setState({ error }); }
+                (error) => { this.setState({"objects": [], "total": 0,  "error": error.message, "message": "", "loadedOnce": true }); }
             );
-    }
-
-    // eslint-disable-next-line class-methods-use-this
-    renderError(error) {
-        return (
-            <p className="error">Unable to load: {error}</p>
-        );
     }
 
     render() {
         if (this.state.objects.length === 0 && !this.state.loadedOnce) {
             return <div className="loading"><span className="spinner"></span> <span className="text">Loading…</span></div>;
-        }
-        if (this.state.error) {
-            return this.renderError(JSON.stringify(this.state.error));
         }
         const { objects } = this.state;
         const pageSizeChanged = (e) => {
@@ -121,6 +113,14 @@ export class Table extends React.Component {
                             : null
                         }
                     </span>
+                    { this.state.error
+                        ? <span className="message error" title={this.state.error}>{this.state.error}</span>
+                        : null
+                    }
+                    { this.state.message
+                        ? <span className="message" title={this.state.message}>{this.state.message}</span>
+                        : null
+                    }
                     <span>
                         { this.state.total > 20
                             ? <form className="inline" onSubmit={(e) => { e.preventDefault(); }}>


### PR DESCRIPTION
- Remove all vestigates of pylint
- Fix import sorting
- Fix unused imports for decksite and enable flake8 checking
- This was clearly fixed before but the rule wasn't re-enabled
- Remove unused rule suppression
- Consistent spacing
- Remove old print statement
- Go back to checking bad module imports, this time with flake8
- Run npm audit fix to fix some js library issues
- Run npm audit fix --force to fix some node package issues
- Download urllib3 until bug is fixed
- Better error handlling and better search feedback in live card search
