### PR TITLE
Tweak art and flavor commands to accept set names as well as codes

### DIFF
--- a/decksite/views/deck.py
+++ b/decksite/views/deck.py
@@ -62,7 +62,7 @@ class Deck(View):
         return url_for('deck', deck_id=self.deck.id, _external=True)
 
     def og_description(self) -> str:
-        if self.public() and self.archetype_name:
+        if self.public() and self.archetype_name and self.reviewed:
             p = inflect.engine()
             archetype_s = titlecase.titlecase(p.a(self.archetype_name))
         else:

--- a/discordbot/commands/flavor.py
+++ b/discordbot/commands/flavor.py
@@ -20,7 +20,7 @@ class Flavour(Extension):
 
 def flavor_text(c: Card) -> str:
     for printing in oracle.get_printings(c):
-        if c.preferred_printing is not None and c.preferred_printing != printing.set_code:
+        if c.preferred_printing is not None and c.preferred_printing.lower() != printing.set_code.lower() and c.preferred_printing.lower() != printing.set_name.lower():
             continue
         if printing.flavor is not None:
             return '\n' + printing.flavor + '\n-**' + oracle.get_set(printing.set_id).name + '**'

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -6,7 +6,7 @@ from magic.database import db
 from magic.models import Card, Printing
 from shared import configuration, fetch_tools, guarantee
 from shared.container import Container
-from shared.database import sqlescape
+from shared.database import sqlescape, sqllikeescape
 from shared.pd_exception import (InvalidArgumentException, InvalidDataException,
                                  TooFewItemsException)
 
@@ -92,7 +92,7 @@ def get_printing(generalized_card: Card, setcode: str) -> Optional[Printing]:
     sql = 'SELECT ' + (', '.join('p.' + property for property in card.printing_properties())) + ', s.code AS set_code' \
         + ' FROM printing AS p' \
         + ' LEFT OUTER JOIN `set` AS s ON p.set_id = s.id' \
-        + ' WHERE card_id = %s AND s.code = %s'
+        + f' WHERE card_id = %s AND (s.code = %s OR s.name LIKE {sqllikeescape(setcode)})'
     rs = db().select(sql, [generalized_card.id, setcode])
     if rs:
         return [Printing(r) for r in rs][0]

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -79,7 +79,7 @@ def legal_cards(force: bool = False) -> List[str]:
     return LEGAL_CARDS
 
 def get_printings(generalized_card: Card) -> List[Printing]:
-    sql = 'SELECT ' + (', '.join('p.' + property for property in card.printing_properties())) + ', s.code AS set_code' \
+    sql = 'SELECT ' + (', '.join('p.' + property for property in card.printing_properties())) + ', s.code AS set_code, s.name AS set_name ' \
         + ' FROM printing AS p' \
         + ' LEFT OUTER JOIN `set` AS s ON p.set_id = s.id' \
         + ' WHERE card_id = %s '


### PR DESCRIPTION
- Hide the machine's archetype guesses from Discord embeds
- Accept set name as well as set code for /art command
- Allow choosing set for flavor text command by name as well as code
