### PR TITLE
Speed up competition detail page 30x by not unnecessarily loading decks

### DIFF
--- a/decksite/controllers/competitions.py
+++ b/decksite/controllers/competitions.py
@@ -18,7 +18,7 @@ def competitions() -> str:
 @APP.route('/competitions/<competition_id>/')
 @cached()
 def competition(competition_id: int) -> str:
-    view = Competition(comp.load_competition(competition_id))
+    view = Competition(comp.load_competition(competition_id, should_load_decks=False))
     return view.page()
 
 @APP.route('/tournaments/')

--- a/decksite/data/competition.py
+++ b/decksite/data/competition.py
@@ -39,8 +39,8 @@ def get_or_insert_competition(start_date: datetime.datetime,
     db().commit('insert_competition')
     return competition_id
 
-def load_competition(competition_id: int) -> Competition:
-    return guarantee.exactly_one(load_competitions('c.id = {competition_id}'.format(competition_id=sqlescape(competition_id)), should_load_decks=True))
+def load_competition(competition_id: int, should_load_decks: bool = True) -> Competition:
+    return guarantee.exactly_one(load_competitions('c.id = {competition_id}'.format(competition_id=sqlescape(competition_id)), should_load_decks=should_load_decks))
 
 def load_competitions(where: str = 'TRUE', having: str = 'TRUE', limit: str = '', season_id: Optional[int] = None, should_load_decks: Optional[bool] = False) -> List[Competition]:
     sql = """

--- a/decksite/views/competition.py
+++ b/decksite/views/competition.py
@@ -10,7 +10,6 @@ class Competition(View):
         super().__init__()
         self.competition = competition
         self.competitions = [self.competition]
-        self.decks = competition.decks
         self.hide_source = True
         self.has_external_source = competition.type != 'League'
         if competition.type == 'League':


### PR DESCRIPTION
We used to use these to show the deck table but we load that via js now.

Fixes #11287.
