### PR TITLE
20x speed up card detail page for heavily-played cards

### DIFF
--- a/decksite/templates/stats.mustache
+++ b/decksite/templates/stats.mustache
@@ -12,9 +12,11 @@
                 <th class="n">
                     <abbr title="Tournament top-8s">⑧</abbr>
                 </th>
-                <th class="n">
-                    <abbr title="League 5-0 runs">5–0s</abbr>
-                </th>
+                {{^tournament_only}}
+                    <th class="n">
+                        <abbr title="League 5-0 runs">5–0s</abbr>
+                    </th>
+                {{/tournament_only}}
                 {{#elo}}<th class="n">Elo</th>{{/elo}}
             </tr>
         </thead>


### PR DESCRIPTION
- Speed up competition detail page 30x by not unnecessarily loading decks
- Don't show a league 5-0s column if looking at tournament-only stats
- 20x speed up card detail page for heavily-played cards
