### PR TITLE
Speed up person detail page

### DIFF
--- a/decksite/controllers/people.py
+++ b/decksite/controllers/people.py
@@ -28,14 +28,13 @@ def people() -> str:
 @cached()
 def person(mtgo_username: Optional[str] = None, person_id: Optional[int] = None) -> str:
     p = load_person(mtgo_username, person_id, season_id=get_season_id())
-    person_cards = cs.load_cards(person_id=p.id, season_id=get_season_id())
     person_archetypes = archs.load_archetypes(person_id=p.id, season_id=get_season_id())
     all_archetypes = archs.load_archetypes(season_id=get_season_id())
     trailblazer_cards = cs.trailblazer_cards(p.id)
     unique_cards = cs.unique_cards_played(p.id)
     your_cards = {'unique': unique_cards, 'trailblazer': trailblazer_cards}
     seasons_active = ps.seasons_active(p.id)
-    view = Person(p, person_cards, person_archetypes, all_archetypes, your_cards, seasons_active, get_season_id())
+    view = Person(p, person_archetypes, all_archetypes, your_cards, seasons_active, get_season_id())
     return view.page()
 
 @APP.route('/people/<mtgo_username>/achievements/')

--- a/decksite/views/person.py
+++ b/decksite/views/person.py
@@ -10,11 +10,10 @@ from decksite.data.achievements import Achievement
 from decksite.data.archetype import Archetype
 from decksite.view import View
 from magic import oracle, seasons
-from magic.models import Card
 
 
 class Person(View):
-    def __init__(self, person: ps.Person, cards: List[Card], archetypes: List[Archetype], all_archetypes: List[Archetype], your_cards: Dict[str, List[str]], seasons_active: Sequence[int], season_id: Optional[int]) -> None:
+    def __init__(self, person: ps.Person, archetypes: List[Archetype], all_archetypes: List[Archetype], your_cards: Dict[str, List[str]], seasons_active: Sequence[int], season_id: Optional[int]) -> None:
         super().__init__()
         self.all_archetypes = all_archetypes
         self.person = person
@@ -23,7 +22,6 @@ class Person(View):
         self.has_decks = len(person.decks) > 0
         self.archetypes = archetypes
         self.hide_person = True
-        self.cards = cards
         self.show_seasons = True
         self.displayed_achievements = [{'title': a.title, 'detail': titlecase.titlecase(a.display(self.person))} for a in Achievement.all_achievements if a.display(self.person)]
         self.achievements_url = url_for('.achievements')
@@ -63,7 +61,7 @@ class Person(View):
         self.has_trailblazer_cards = len(self.trailblazer_cards) > 0
         self.unique_cards = oracle.load_cards(your_cards['unique'])
         self.has_unique_cards = len(self.unique_cards) > 0
-        self.cards += self.trailblazer_cards + self.unique_cards
+        self.cards = self.trailblazer_cards + self.unique_cards
         self.seasons_active: List[Dict[str, object]] = []
         self.setup_active_seasons(seasons_active)
 


### PR DESCRIPTION
- Speed up signup by loading fewer decks
- Remove overzealosy deleted news template
- Fix broken logger logging
- Don't unnecessarily load cards on person detail page
