### PR TITLE
Refactor matches handling

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -674,7 +674,7 @@ def person_notes(person_id: int) -> Response:
 def deck_embed(deck_id: int) -> Response:
     # Discord doesn't actually show this yet.  I've reached out to them for better documentation about what they do/don't accept.
     d = deck.load_deck(deck_id)
-    view = DeckEmbed(d, None, None)
+    view = DeckEmbed(d, [], None, None)
     width = 1200
     height = 500
     embed = {

--- a/decksite/controllers/league.py
+++ b/decksite/controllers/league.py
@@ -6,7 +6,7 @@ from werkzeug import wrappers
 from decksite import APP, auth
 from decksite import league as lg
 from decksite.cache import cached
-from decksite.data import deck as ds
+from decksite.data import deck as ds, match
 from decksite.data import person as ps
 from decksite.league import ReportForm, RetireForm, SignUpForm
 from decksite.views import LeagueInfo, Report, Retire, SignUp
@@ -76,7 +76,10 @@ def add_report() -> Response:
 def retire(form: Optional[RetireForm] = None, deck_id: Optional[int] = None) -> str:
     if form is None:
         form = RetireForm(request.form, deck_id, session.get('id'))
-    view = Retire(form)
+    ms = []
+    if len(form.decks) == 1:
+        ms = match.load_matches_by_deck(form.decks[0])
+    view = Retire(form, ms)
     return view.page()
 
 

--- a/decksite/templates/matchups.mustache
+++ b/decksite/templates/matchups.mustache
@@ -50,8 +50,5 @@
     </section>
 {{/show_decks}}
 {{#show_matches}}
-    <section>
-        <h2>Matches</h2>
-        {{> matchestable}}
-    </section>
+    {{> personmatches}}
 {{/show_matches}}

--- a/decksite/templates/personmatches.mustache
+++ b/decksite/templates/personmatches.mustache
@@ -3,6 +3,7 @@
     <table>
         <thead>
             <tr>
+                {{#show_hero}}<th>Person</th>{{/show_hero}}
                 <th>Deck</th>
                 <th>Opponent</th>
                 <th>Opponent's Deck</th>
@@ -15,6 +16,7 @@
         <tbody>
             {{#matches}}
                 <tr>
+                    {{#show_hero}}<td><a href="{{person_url}}">{{person}}</a></td>{{/show_hero}}
                     <td><a href="{{deck_url}}">{{deck_name}}</a></td>
                     <td><a href="{{opponent_url}}">{{opponent}}</a></td>
                     <td>

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -62,6 +62,7 @@ class View(BaseView):
         self.is_home_page = False
         self.show_filters_toggle = False
         self.tournament_rounds_info: List[Dict[str, Union[int, str]]] = []
+        self.matches: List[Container] = []
 
     def season_id(self) -> int:
         return get_season_id()
@@ -178,6 +179,12 @@ class View(BaseView):
     def show_legal_seasons(self) -> bool:
         return get_season_id() == 0
 
+    def has_matches(self) -> bool:
+        return len(self.matches) > 0
+
+    def has_rounds(self) -> bool:
+        return self.has_matches() and self.matches[0].get('round')
+
     def prepare(self) -> None:
         self.prepare_decks()
         self.prepare_cards()
@@ -235,7 +242,7 @@ class View(BaseView):
             self.legal_formats = list(map(add_season_num, sorted(self.legal_formats, key=legality.order_score)))  # type: ignore
 
     def prepare_matches(self) -> None:
-        prepare.prepare_matches(getattr(self, 'matches', []))
+        prepare.prepare_matches(getattr(self, 'matches', []), self.has_rounds())
 
     def prepare_active_runs(self, o: Any) -> None:
         decks = getattr(o, 'decks', [])

--- a/decksite/views/retire.py
+++ b/decksite/views/retire.py
@@ -1,18 +1,18 @@
+from typing import List
+
 from flask import url_for
 
-from decksite.data import match
 from decksite.data.form import Form
 from decksite.views.league_form import LeagueForm
+from shared.container import Container
 
 
 class Retire(LeagueForm):
-    def __init__(self, form: Form) -> None:
+    def __init__(self, form: Form, matches: List[Container]) -> None:
         super().__init__(form)
         self.logout_url = url_for('logout', target='retire')
-        if len(form.decks) == 1:
-            self.show_matches = True
-            self.matches = match.load_matches_by_deck(form.decks[0], should_load_decks=True)
-            self.has_matches = len(self.matches) > 0
+        self.matches = matches
+        self.show_matches = len(matches) > 0
         self.report_url = url_for('report')
 
     def page_title(self) -> str:


### PR DESCRIPTION
We were doing very similar things to prepare_matches in the Deck view - let's just do it in one place

Also, remove the concept of loading matches with decks - we don't need that anywhere and it's more expensive

Also, display matches on /matchups/ as that code was already there and only need a little tweak to get working

Also, don't load matches inside the Retire view, do it in the controller instead
