### PR TITLE
Speed up /seasons/all/cards by not loading all cards

### DIFF
--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -65,8 +65,7 @@ def cards(deck_type: Optional[str] = None) -> str:
     query = request.args.get('fq')
     if query is None:
         query = ''
-    all_cards = cs.load_cards(season_id=get_season_id(), tournament_only=tournament_only)
-    view = Cards(all_cards, query=query, tournament_only=tournament_only)
+    view = Cards(query=query, tournament_only=tournament_only)
     return view.page()
 
 @APP.route('/cards/<path:name>/')

--- a/decksite/views/cards.py
+++ b/decksite/views/cards.py
@@ -1,21 +1,19 @@
-from typing import List
 
 from flask import url_for
 
 from decksite.deck_type import DeckType
 from decksite.view import View
-from magic.models import Card
 
 
 class Cards(View):
-    def __init__(self, cards: List[Card], tournament_only: bool = False, query: str = '') -> None:
+    def __init__(self, tournament_only: bool = False, query: str = '') -> None:
         super().__init__()
         self.show_seasons = True
         self.show_tournament_toggle = True
         self.tournament_only = self.hide_source = tournament_only
         self.query = query
         self.toggle_results_url = url_for('.cards', deck_type=None if tournament_only else DeckType.TOURNAMENT.value)
-        self.cards = cards
+        self.has_cards = True
 
     def page_title(self) -> str:
         return 'Cards'

--- a/shared_web/base_view.py
+++ b/shared_web/base_view.py
@@ -9,7 +9,8 @@ from . import template
 class BaseView:
     def __init__(self) -> None:
         super().__init__()
-        self.content = ''
+        self.content: str = ''
+        self.has_cards: bool = False
 
     def home_url(self) -> str:
         return url_for('home')
@@ -49,7 +50,7 @@ class BaseView:
         return current_app.config['css_url'] or url_for('static', filename='css/pd.css', v=self.commit_id('shared_web/static/css/pd.css'))
 
     def tooltips_url(self) -> Optional[str]:
-        if not hasattr(self, 'cards'):
+        if not self.has_cards and not hasattr(self, 'cards'):
             return None
         return url_for('static', filename='js/tooltips.js', v=self.commit_id())
 


### PR DESCRIPTION
I had to introduce a mechanism to still get the mousover card images js to load.

This speeds my local version up from 2.5s to about 35ms
