### PR TITLE
Added 'draws' to explain.py

### DIFF
--- a/discordbot/commands/explain.py
+++ b/discordbot/commands/explain.py
@@ -208,6 +208,14 @@ explanations: Dict[str, Tuple[str, Dict[str, str]]] = {
         """,
         {},
     ),
+    'draws': (
+        """
+        Penny Dreadful tournaments follow official Magic Online tournament rules and do not allow intentional draws, unlike some other player-run events.
+        """,
+        {
+            'More Tournament Info': fetcher.decksite_url('/tournaments/'),
+        },
+    ),
 }
 keys = sorted(explanations.keys())
 


### PR DESCRIPTION
Adds the /explain draws command for the pd bot to help quickly answer questions about intentional draws

https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/issues/11688