### PR TITLE
Switch from MTGO Traders to Cardhoarder as league sponsor

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -161,8 +161,7 @@ def post_matches() -> wrappers.Response:
 @APP.route('/admin/prizes/')
 def prizes() -> str:
     tournaments_with_prizes = comp.tournaments_with_prizes()
-    first_runs = lg.first_runs()
-    view = Prizes(tournaments_with_prizes, first_runs)
+    view = Prizes(tournaments_with_prizes)
     return view.page()
 
 @APP.route('/admin/rotation/')

--- a/decksite/resources.json
+++ b/decksite/resources.json
@@ -25,7 +25,7 @@
     "Card search": "https://scryfall.com/search/?q=f:pd",
     "Chat": "https://discord.gg/H6EHdHu",
     "Legal cards list": "http://pdmtgo.com/legal_cards.txt",
-    "Cardhoarder free loan program": "https://www.cardhoarder.com/free-loan-program-faq",
+    "Cardhoarder free loan program": "https://cardhoarder.com/free-loan-program-faq",
     "Magic Online guide": "https://docs.google.com/document/d/1GGvhaISyESrrvPAkauP5LWKAixh6rcH1Q2jfbfpUOoA/edit",
     "Official site": "http://pdmtgo.com/",
     "Reddit": "https://reddit.com/r/PennyDreadfulMTG/"

--- a/decksite/sql/68.sql
+++ b/decksite/sql/68.sql
@@ -1,0 +1,1 @@
+UPDATE sponsor SET url = 'https://cardhoarder.com/' WHERE name = 'Cardhoarder';

--- a/decksite/templates/faqsbody.mustache
+++ b/decksite/templates/faqsbody.mustache
@@ -35,8 +35,7 @@
             <p>{{_ Leagues last for roughly a month. You may enter any number of times but only one deck at a time.}}</p>
             <p>{{_ You play five matches per run. You can join the league at any time.}}</p>
             <p>{{_ To find a game sign up and then create a game in Constructed, Specialty, Freeform Tournament Practice with "Penny Dreadful League" as the comment.}}</p>
-            <p>{{_ Top 8 finishers on each month's league leaderboard win credit with [MTGO Traders](https://www.mtgotraders.com/).}}</p>
-            <p>{{_ When you complete a five match league run for the first time ever you will get 1 tik credit with [MTGO Traders](https://www.mtgotraders.com/) (at the end of the month).}}</p>
+            <p>{{_ Top 8 finishers on each month's league leaderboard win credit with [Cardhoarder](https://cardhoarder.com/).}}</p>
             <p><a href="{{current_league_url}}">{{_ Current League}}</a></o>
             <p><a href="{{league_info_url}}">{{_ More Info}}</a></p>
             <p><a href="{{league_signup_url}}">{{_ Sign Up}}</a></p>
@@ -45,7 +44,7 @@
     <li>
         <p class="question"><a href="#">{{_ How do I enter a tournament?}}</a></p>
         <div class="details">
-            <p>{{_ We have {num_tournaments} free-to-enter weekly tournaments with prizes from [Cardhoarder](https://www.cardhoarder.com/).}}</p>
+            <p>{{_ We have {num_tournaments} free-to-enter weekly tournaments with prizes from [Cardhoarder](https://cardhoarder.com/).}}</p>
             <p>{{_ They are hosted on [Gatherling](https://gatherling.com/) along with a lot of other player-run Magic Online events.}}</p>
             <p><a href="{{tournaments_info_url}}">{{_ More Info}}</a></p>
             <p><a class="external" href="https://gatherling.com/">{{_ Sign Up}}</a></p>

--- a/decksite/templates/footer.mustache
+++ b/decksite/templates/footer.mustache
@@ -10,12 +10,8 @@
                 </section>
             {{/menu}}
             <section>
-                <p>Penny Dreadful tournaments are sponsored by <a class="external" href="https://www.cardhoarder.com/">Cardhoarder</a>.</p>
-                <p><a href="https://www.cardhoarder.com/"><img class="sponsor-logo" src="{{cardhoarder_logo_url}}" alt=""></a></p>
-            </section>
-            <section>
-                <p>The Penny Dreadful league is sponsored by <a class="external" href="https://www.mtgotraders.com/">MTGO Traders</a>.</p>
-                <p><a href="https://www.mtgotraders.com/"><img class="sponsor-logo" src="{{mtgotraders_logo_url}}" alt=""></a></p>
+                <p>Penny Dreadful tournaments and league are sponsored by <a class="external" href="https://cardhoarder.com/">Cardhoarder</a>.</p>
+                <p><a href="https://cardhoarder.com/"><img class="sponsor-logo" src="{{cardhoarder_logo_url}}" alt=""></a></p>
             </section>
             <section>
                 <p>Popup card images courtesy of <a href="https://deckbox.org/">deckbox.org</a>.</p>

--- a/decksite/templates/kickoff.mustache
+++ b/decksite/templates/kickoff.mustache
@@ -2,7 +2,7 @@
     <section>
         <ul>
             <li>Early season tournament</li>
-            <li>Over 150 tix in prizes</li>
+            <li>Over 100 tix in prizes</li>
             <li>Free entry</li>
             <li>{{{date_info_safe}}}</li>
             <li>Sign up is on <a class="external force-link-style" href="https://gatherling.com/">Gatherling</a></li>
@@ -28,6 +28,6 @@
                 {{/prizes}}
             </tbody>
         </table>
-        <p>Prizes from our sponsor <a class="external" href="https://www.cardhoarder.com/">Cardhoarder</a> in credit.</p>
+        <p>Prizes from our sponsor <a class="external" href="https://cardhoarder.com/">Cardhoarder</a> in credit.</p>
     </section>
 </article>

--- a/decksite/templates/kickoffnotice.mustache
+++ b/decksite/templates/kickoffnotice.mustache
@@ -1,1 +1,1 @@
-<p><a href="{{url}}">The Season Kick Off is on {{date}} with free entry and over $150 in prizes to 32nd place!</a></p>
+<p><a href="{{url}}">The Season Kick Off is on {{date}} with free entry and over 100 tix in prizes to 32nd place!</a></p>

--- a/decksite/templates/leagueinfo.mustache
+++ b/decksite/templates/leagueinfo.mustache
@@ -5,8 +5,6 @@
 
     <p><b>{{_ You can [sign up]({signup_url}) at any time.}}</b></p>
 
-    <p>{{_ When you complete a five match league run for the first time ever you will get 1 tik credit with MTGO Traders (at the end of the month). This credit will appear when you trade with one of their bots on Magic Online.}}</p>
-
     <p>{{_ A league run is five matches against five different decks/opponents.}}</p>
 
     <p>{{_ Your deck stays the same through a run but you can change decks for each run (or not if you want to play again with the same deck).}}</p>
@@ -31,7 +29,7 @@
 
     <section>
         <h2>{{_ Prizes}}</h2>
-            <p>{{_ At the end of each month, the top eight players of that month's league scoreboard will get credit with MTGO Traders (6/4/3/2/1/1/1/1). This credit will appear when you trade with one of their bots on Magic Online.}}</p>
+            <p>{{_ At the end of each month, the top eight players of that month's league scoreboard will get credit with Cardhoarder (6/4/3/2/1/1/1/1). This credit will appear when you trade with one of their bots on Magic Online.}}</p>
             <p>{{_ For each match you won, you get one point. For each perfect (5-0) run you have, you get an extra point.}}</p>
             <p>{{_ You can enter the league as many times as you want.}}</p>
     </section>

--- a/decksite/templates/pd500.mustache
+++ b/decksite/templates/pd500.mustache
@@ -28,7 +28,7 @@
                     {{/prizes}}
             </tbody>
         </table>
-        <p>Prizes from our sponsor <a class="external" href="https://www.cardhoarder.com/">Cardhoarder</a> in credit.</p>
+        <p>Prizes from our sponsor <a class="external" href="https://cardhoarder.com/">Cardhoarder</a> in credit.</p>
     </section>
     <section>
         <h2>Byes</h2>

--- a/decksite/templates/prizes.mustache
+++ b/decksite/templates/prizes.mustache
@@ -6,11 +6,3 @@
         <p>{{n}} competitions</p>
     </section>
 {{/weeks}}
-{{#months}}
-    <section>
-        <h2>{{competition_name}}</h2>
-        {{#people}}
-            {{mtgo_username}}<br>
-        {{/people}}
-    </section>
-{{/months}}

--- a/decksite/templates/signup.mustache
+++ b/decksite/templates/signup.mustache
@@ -5,7 +5,6 @@
 {{/is_closed}}
 {{^is_closed}}
     <section>
-        <p>{{TT_MTGOTRADERS_SIGNUP_TIK}}</p>
         {{#signed_up_msg_safe}}
             <p class="error">{{{signed_up_msg_safe}}}</p>
         {{/signed_up_msg_safe}}

--- a/decksite/templates/tournaments.mustache
+++ b/decksite/templates/tournaments.mustache
@@ -1,7 +1,7 @@
 <article>
     <section>
         {{> tournamentcalendar}}
-        <p>{{_ There are {num_tournaments} weekly Penny Dreadful tournaments hosted on [Gatherling.com](https://gatherling.com). They are all free to enter and some offer prizes from [Cardhoarder](https://www.cardhoarder.com/). Be sure to also check out the [league](/league/) for a play-when-you-like competition.}}</p>
+        <p>{{_ There are {num_tournaments} weekly Penny Dreadful tournaments hosted on [Gatherling.com](https://gatherling.com). They are all free to enter and some offer prizes from [Cardhoarder](https://cardhoarder.com/). Be sure to also check out the [league](/league/) for a play-when-you-like competition.}}</p>
         <p>{{_ Each tournament series has a [leaderboard]({leaderboards_url}).}}</p>
         <p>The second-last Penny Dreadful Saturdays of each season is replaced by <a href="{{ pd500_url }}">The Penny Dreadful 500</a> high-stakes tournament.</p>
     </section>
@@ -37,7 +37,7 @@
                 {{/prizes}}
             </tbody>
         </table>
-        <p>Prizes from our sponsor <a class="external" href="https://www.cardhoarder.com/">Cardhoarder</a> in credit. Prizes will be credited within a few days of the Friday following the tournament. After that the credit will appear when you trade with one of their bots on Magic Online and on their website.</p>
+        <p>Prizes from our sponsor <a class="external" href="https://cardhoarder.com/">Cardhoarder</a> in credit. Prizes will be credited within a few days of the Friday following the tournament. After that the credit will appear when you trade with one of their bots on Magic Online and on their website.</p>
     </section>
     <section>
         {{> bugpolicy}}

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -48,7 +48,6 @@ class View(BaseView):
         self.show_seasons: bool = False
         self.legal_formats: Optional[List[str]] = None
         self.cardhoarder_logo_url = url_for('static', filename='images/cardhoarder.png')
-        self.mtgotraders_logo_url = url_for('static', filename='images/mtgotraders.png')
         self.is_person_page: Optional[bool] = None
         self.next_tournament_name = None
         self.next_tournament_time = None

--- a/decksite/views/deck.py
+++ b/decksite/views/deck.py
@@ -105,7 +105,7 @@ class Deck(View):
             name = entry.name
             cs[name] = cs.get(name, 0) + entry['n']
         deck_s = '||'.join([str(v) + ' ' + card.to_mtgo_format(k).replace('"', '') for k, v in cs.items()])
-        return 'https://www.cardhoarder.com/decks/upload?deck={deck}'.format(deck=fetch_tools.escape(deck_s))
+        return 'https://cardhoarder.com/decks/upload?deck={deck}'.format(deck=fetch_tools.escape(deck_s))
 
 class DeckEmbed(Deck):
     pass

--- a/decksite/views/kickoff.py
+++ b/decksite/views/kickoff.py
@@ -15,7 +15,7 @@ class KickOff(View):
             display_time = dtutil.display_date_with_date_and_year(kick_off_date)
             self.date_info_safe = f'The next Season Kick Off is on <time datetime="{kick_off_date}" data-format="dddd MMMM Do LT z">{display_time}</time>'
         self.faqs_url = url_for('faqs')
-        self.cardhoarder_loan_url = 'https://www.cardhoarder.com/free-loan-program-faq'
+        self.cardhoarder_loan_url = 'https://cardhoarder.com/free-loan-program-faq'
         self.tournaments_url = url_for('tournaments')
         self.discord_url = url_for('discord')
         self.prizes = tournaments.kick_off_prizes()

--- a/decksite/views/league_info.py
+++ b/decksite/views/league_info.py
@@ -18,7 +18,7 @@ class LeagueInfo(View):
         self.bugs_url = url_for('tournaments', _anchor='bugs')
 
     def page_title(self) -> str:
-        return 'MTGO Traders League'
+        return 'Cardhoarder League'
 
     def discord_url(self) -> str:
         return 'https://discord.gg/Yekrz3s'  # Invite directly into #league channel

--- a/decksite/views/pd500.py
+++ b/decksite/views/pd500.py
@@ -21,7 +21,7 @@ class PD500(View):
             display_time = dtutil.display_date_with_date_and_year(pd500_date)
             self.date_info_safe = f'The next Penny Dreadful 500 is on <time datetime="{pd500_date}" data-format="dddd MMMM Do LT z">{display_time}</time>'
         self.faqs_url = url_for('faqs')
-        self.cardhoarder_loan_url = 'https://www.cardhoarder.com/free-loan-program-faq'
+        self.cardhoarder_loan_url = 'https://cardhoarder.com/free-loan-program-faq'
         self.tournaments_url = url_for('tournaments')
         self.discord_url = url_for('discord')
         self.prizes = tournaments.pd500_prizes()

--- a/decksite/views/prizes.py
+++ b/decksite/views/prizes.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List
 
 from dateutil.relativedelta import FR, relativedelta
 
-from decksite.data.person import Person
 from decksite.view import View
 from magic import tournaments
 from magic.models import Competition
@@ -12,7 +11,7 @@ from shared.container import Container
 
 
 class Prizes(View):
-    def __init__(self, competitions: List[Competition], first_runs: List[Person]) -> None:
+    def __init__(self, competitions: List[Competition]) -> None:
         super().__init__()
         self.weeks: List[Container] = []
         weeks = split_by_week(competitions)
@@ -27,13 +26,6 @@ class Prizes(View):
             body = '\n'.join([c.name for c in week.get('competitions', [])]) + '\n\n'
             body += '\n'.join(['{username} {prize}'.format(username=k, prize=prizes[k]) for k in sorted(prizes) if prizes[k] > 0])
             self.weeks.append(Container({'subject': subject, 'body': body, 'n': len(week.get('competitions', []))}))
-        self.months: List[Dict[str, Any]] = []
-        current_competition_id = None
-        for p in first_runs:
-            if current_competition_id != p.competition_id:
-                self.months.append({'competition_name': p.competition_name, 'people': []})
-                current_competition_id = p.competition_id
-            self.months[-1]['people'].append(p)
 
     def page_title(self) -> str:
         return 'Prizes'

--- a/decksite/views/prizes.py
+++ b/decksite/views/prizes.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Dict, List
+from typing import Dict, List
 
 from dateutil.relativedelta import FR, relativedelta
 

--- a/decksite/views/signup.py
+++ b/decksite/views/signup.py
@@ -20,9 +20,6 @@ class SignUp(DecklistForm):
     def page_title(self) -> str:
         return '{league} Sign Up'.format(league=self.league['name'])
 
-    def TT_MTGOTRADERS_SIGNUP_TIK(self) -> str:
-        return gettext('When you complete a five match league run for the first time ever you will get 1 tik credit with MTGO Traders (at the end of the month). This credit will appear when you trade with one of their bots on Magic Online.')
-
     def TT_MTGO_USERNAME(self) -> str:
         return gettext('Magic Online Username')
 

--- a/discordbot/commands/explain.py
+++ b/discordbot/commands/explain.py
@@ -71,8 +71,7 @@ explanations: Dict[str, Tuple[str, Dict[str, str]]] = {
         Leagues last for roughly a month. You may enter any number of times but only one deck at a time.
         You play five matches per run. You can join the league at any time.
         To find a game sign up and then create a game in Constructed, Specialty, Freeform Tournament Practice with "Penny Dreadful League" as the comment.
-        Top 8 finishers on each month's league leaderboard win credit with MTGO Traders.
-        When you complete a five match league run for the first time ever you will get 1 tik credit with MTGO Traders (at the end of the month).
+        Top 8 finishers on each month's league leaderboard win credit with Cardhoarder.
         """,
         {
             'More Info': fetcher.decksite_url('/league/'),

--- a/magic/tournaments.py
+++ b/magic/tournaments.py
@@ -162,17 +162,28 @@ def pd500_prize(f: int) -> int:
         return 10
     return 0
 
+# Kick Off prizes changed for Season 32. You can't use this func to get accurate historical data. If you ever need that
+# you will have to complicate this function to understand that in seasons 1-7 there was no kick off and in seasons 18-31
+# the prizes were:
+#
+#   1st 25
+#   2nd 20
+#   3rd–4th 15
+#   5th–8th 10
+#   9th–16th    5
+#   17th–24th   2
+#   25th–32nd   1
 def kick_off_prize(f: int) -> int:
     if f == 1:
-        return 25
-    if f == 2:
         return 20
-    if f <= 4:
+    if f == 2:
         return 15
-    if f <= 8:
+    if f <= 4:
         return 10
+    if f <= 8:
+        return 7
     if f <= 16:
-        return 5
+        return 3
     if f <= 24:
         return 2
     if f <= 32:

--- a/magic/tournaments_test.py
+++ b/magic/tournaments_test.py
@@ -47,7 +47,7 @@ def test_kick_off_prizes() -> None:
     prizes = tournaments.kick_off_prizes()
     assert len(prizes) == 7
     assert prizes[2]['finish'] == '3rd–4th'
-    assert prizes[2]['prize'] == 15
+    assert prizes[2]['prize'] == 10
     assert prizes[5]['finish'] == '17th–24th'
     assert prizes[5]['prize'] == 2
 
@@ -69,7 +69,7 @@ def test_prizes_by_finish() -> None:
     prizes = tournaments.prizes_by_finish(COMPETITIONS['kick_off'])
     assert len(prizes) == 32
     assert prizes[2]['finish'] == '3rd'
-    assert prizes[2]['prize'] == 15
+    assert prizes[2]['prize'] == 10
     assert prizes[18]['finish'] == '19th'
     assert prizes[18]['prize'] == 2
     prizes = tournaments.prizes_by_finish(COMPETITIONS['normal'])
@@ -81,19 +81,19 @@ def test_prizes_by_finish() -> None:
 
 def test_prize() -> None:
     assert 10 == tournaments.prize(COMPETITIONS['pd500'], Deck({'finish': 12}))
-    assert 5 == tournaments.prize(COMPETITIONS['kick_off'], Deck({'finish': 15}))
+    assert 3 == tournaments.prize(COMPETITIONS['kick_off'], Deck({'finish': 15}))
     assert 3 == tournaments.prize(COMPETITIONS['normal'], Deck({'finish': 2}))
 
 def test_prize_by_finish() -> None:
     assert 10 == tournaments.prize_by_finish(COMPETITIONS['pd500'], 12)
-    assert 5 == tournaments.prize_by_finish(COMPETITIONS['kick_off'], 15)
+    assert 3 == tournaments.prize_by_finish(COMPETITIONS['kick_off'], 15)
     assert 3 == tournaments.prize_by_finish(COMPETITIONS['normal'], 2)
 
 def test_pd500_prize() -> None:
     assert 10 == tournaments.pd500_prize(12)
 
 def test_kick_off_prize() -> None:
-    assert 5 == tournaments.kick_off_prize(15)
+    assert 3 == tournaments.kick_off_prize(15)
 
 def test_normal_prize() -> None:
     assert 3 == tournaments.normal_prize(2)

--- a/price_grabber/parser.py
+++ b/price_grabber/parser.py
@@ -3,7 +3,7 @@ import re
 import traceback
 from typing import Dict, List, Tuple
 
-from magic import card, card_price, multiverse
+from magic import card, multiverse
 from magic.database import db
 from shared import logger
 from shared.pd_exception import DatabaseException, InvalidDataException
@@ -24,22 +24,6 @@ def parse_cardhoarder_prices(s: str) -> PriceListType:
         if int(quantity) > 0 and not mtgo_set.startswith('CH-') and mtgo_set != 'VAN' and mtgo_set != 'EVENT' and not re.search(r'(Booster|Commander Deck|Commander:|Theme Deck|Draft Pack|Duel Decks|Reward Pack|Intro Pack|Tournament Pack|Premium Deck Series:|From the Vault)', name):
             details.append((name, p, mtgo_set))
     return [(name_lookup(name), html.unescape(p.strip()), mtgo_set) for name, p, mtgo_set in details if name_lookup(name) is not None]
-
-def parse_mtgotraders_prices(s: str) -> PriceListType:
-    details = []
-    for line in s.splitlines():
-        if line.count('|') != 7:
-            raise InvalidDataException('Bad line (mtgotraders): {line}'.format(line=line))
-        mtgo_set, rarity, premium, name, number, p, image_path, in_stock_str = line.split('|')
-        in_stock_str = in_stock_str.replace('<br>', '')
-        assert in_stock_str in ('Yes', 'No')
-        in_stock = in_stock_str == 'Yes'
-        if name.endswith('(a)') or name.endswith('(b)'):  # Guildgates
-            name = name[:-4]
-        name = repair_name(name)
-        if float(p) <= card_price.MAX_PRICE_TIX and in_stock and not is_exceptional_name(name):
-            details.append((name, p, mtgo_set))
-    return [(name_lookup(name), p, mtgo_set) for name, p, mtgo_set in details if name_lookup(name) is not None]
 
 def repair_name(name: str) -> str:
     if name == 'Tura Kenner':

--- a/price_grabber/price_grabber.py
+++ b/price_grabber/price_grabber.py
@@ -28,13 +28,8 @@ def fetch() -> None:
             s = ftfy.fix_encoding(s)
             timestamps.append(dtutil.parse_to_ts(s.split('\n', 1)[0].replace('UPDATED ', ''), '%Y-%m-%dT%H:%M:%S+00:00', dtutil.CARDHOARDER_TZ))
             all_prices[url] = parser.parse_cardhoarder_prices(s)
-    url = configuration.get_str('mtgotraders_url')
-    if url:
-        s = fetch_tools.fetch(url)
-        timestamps.append(dtutil.dt2ts(dtutil.now()))
-        all_prices['mtgotraders'] = parser.parse_mtgotraders_prices(s)
     if not timestamps:
-        raise TooFewItemsException('Did not get any prices when fetching {urls} ({all_prices})'.format(urls=itertools.chain(configuration.cardhoarder_urls.get(), [configuration.get_str('mtgotraders_url')]), all_prices=all_prices))
+        raise TooFewItemsException('Did not get any prices when fetching {urls} ({all_prices})'.format(urls=itertools.chain(configuration.cardhoarder_urls.get()), all_prices=all_prices))
     count = store(min(timestamps), all_prices)
     cleanup(count)
 

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Set
 import ftfy
 
 from magic import card_price, fetcher, rotation, seasons
-from price_grabber.parser import PriceListType, parse_cardhoarder_prices, parse_mtgotraders_prices
+from price_grabber.parser import PriceListType, parse_cardhoarder_prices
 from shared import configuration, decorators, dtutil, fetch_tools
 from shared import redis_wrapper as redis
 from shared import repo, sentry, text
@@ -50,10 +50,6 @@ def run() -> None:
         s = fetch_tools.fetch(url)
         s = ftfy.fix_encoding(s)
         all_prices[url] = parse_cardhoarder_prices(s)
-    url = configuration.get_str('mtgotraders_url')
-    if url:
-        s = fetch_tools.fetch(url)
-        all_prices['mtgotraders'] = parse_mtgotraders_prices(s)
 
     run_number = process(all_prices)
     if run_number == rotation.TOTAL_RUNS:

--- a/shared/configuration.py
+++ b/shared/configuration.py
@@ -102,7 +102,6 @@ DEFAULTS: Dict[str, Any] = {
     'logsite_database': 'pdlogs',
     'magic_database': 'cards',
     'modo_bugs_dir': 'modo_bugs_repo',
-    'mtgotraders_url': 'http://www.mtgotraders.com/pennydreadfull.php',
     'not_pd': '',
     'pdbot_api_token': lambda: ''.join(random.SystemRandom().choice(string.ascii_letters + string.digits) for _ in range(32)),
     'poeditor_api_key': None,

--- a/shared_web/translations/messages.pot
+++ b/shared_web/translations/messages.pot
@@ -1,319 +1,336 @@
 # Translations template for Penny-Dreadful-Tools.
-# Copyright (C) 2019 ORGANIZATION
+# Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the
 # Penny-Dreadful-Tools project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Penny-Dreadful-Tools 0.0.0\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-11-23 20:43+1100\n"
+"POT-Creation-Date: 2024-01-25 17:21-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.5.3\n"
+"Generated-By: Babel 2.12.1\n"
 
-#: decksite/__init__.py:36
+#: decksite/__init__.py:42
 msgid "Rotation Tracking"
 msgstr ""
 
-#: decksite/__init__.py:38
+#: decksite/__init__.py:44
 msgid "Rotation Changes"
 msgstr ""
 
-#: decksite/__init__.py:39
-msgid "Rotation Speculation"
-msgstr ""
-
-#: decksite/__init__.py:40
+#: decksite/__init__.py:45
 msgid "Deck Check"
 msgstr ""
 
-#: decksite/__init__.py:41
+#: decksite/__init__.py:46
 msgid "Discord Chat"
 msgstr ""
 
-#: decksite/__init__.py:42
+#: decksite/__init__.py:47
 msgid "External Links"
 msgstr ""
 
-#: decksite/__init__.py:43 decksite/views/link_accounts.py:36
+#: decksite/__init__.py:48 decksite/views/link_accounts.py:35
 msgid "Link Accounts"
 msgstr ""
 
-#: decksite/__init__.py:44
+#: decksite/__init__.py:49
 msgid "Bugs"
 msgstr ""
 
-#: decksite/__init__.py:47
+#: decksite/__init__.py:52
 msgid "Metagame"
 msgstr ""
 
-#: decksite/__init__.py:48 decksite/data/achievements.py:623
+#: decksite/__init__.py:53
+msgid "Meta"
+msgstr ""
+
+#: decksite/__init__.py:54 decksite/data/achievements.py:628
 msgid "Decks"
 msgstr ""
 
-#: decksite/__init__.py:49 decksite/data/achievements.py:651
+#: decksite/__init__.py:55 decksite/data/achievements.py:656
 msgid "Archetypes"
 msgstr ""
 
-#: decksite/__init__.py:50
+#: decksite/__init__.py:56
 msgid "People"
 msgstr ""
 
-#: decksite/__init__.py:51
+#: decksite/__init__.py:57
 msgid "Cards"
 msgstr ""
 
-#: decksite/__init__.py:52
+#: decksite/__init__.py:58
 msgid "Past Seasons"
 msgstr ""
 
-#: decksite/__init__.py:53
+#: decksite/__init__.py:59
 msgid "Matchups"
 msgstr ""
 
-#: decksite/__init__.py:55 decksite/templates/tournamentcalendar.mustache:1
+#: decksite/__init__.py:61 decksite/templates/tournamentcalendar.mustache:1
 msgid "League"
 msgstr ""
 
-#: decksite/__init__.py:56
+#: decksite/__init__.py:62
 msgid "League Info"
 msgstr ""
 
-#: decksite/__init__.py:57 decksite/templates/faqsbody.mustache:1
-#: decksite/views/signup.py:34
+#: decksite/__init__.py:63 decksite/templates/faqsbody.mustache:1
+#: decksite/views/signup.py:36
 msgid "Sign Up"
 msgstr ""
 
-#: decksite/__init__.py:58 decksite/views/report.py:22
+#: decksite/__init__.py:64 decksite/views/report.py:21
 msgid "Report"
 msgstr ""
 
-#: decksite/__init__.py:59 decksite/templates/leagueinfo.mustache:1
+#: decksite/__init__.py:65 decksite/templates/leagueinfo.mustache:1
 msgid "Records"
 msgstr ""
 
-#: decksite/__init__.py:60 decksite/templates/leagueinfo.mustache:1
+#: decksite/__init__.py:66 decksite/templates/leagueinfo.mustache:1
 msgid "Retire"
 msgstr ""
 
-#: decksite/__init__.py:62
+#: decksite/__init__.py:68
 msgid "Competitions"
 msgstr ""
 
-#: decksite/__init__.py:63
+#: decksite/__init__.py:69
 msgid "Competition Results"
 msgstr ""
 
-#: decksite/__init__.py:64
+#: decksite/__init__.py:70
 msgid "Tournament Info"
 msgstr ""
 
-#: decksite/__init__.py:65
+#: decksite/__init__.py:71
 msgid "Leaderboards"
 msgstr ""
 
-#: decksite/__init__.py:66
+#: decksite/__init__.py:72
 msgid "Gatherling"
 msgstr ""
 
-#: decksite/__init__.py:67
+#: decksite/__init__.py:73
 msgid "Achievements"
 msgstr ""
 
-#: decksite/__init__.py:68
+#: decksite/__init__.py:74
 msgid "Hosting"
 msgstr ""
 
-#: decksite/__init__.py:70
+#: decksite/__init__.py:76
 msgid "Resources"
 msgstr ""
 
-#: decksite/__init__.py:71 decksite/views/about_pdm.py:16
-#: logsite/views/about.py:16
+#: decksite/__init__.py:77 decksite/views/about_pdm.py:15
+#: logsite/views/about.py:15
 msgid "About"
 msgstr ""
 
-#: decksite/__init__.py:72
+#: decksite/__init__.py:78
 msgid "What is Penny Dreadful?"
 msgstr ""
 
-#: decksite/__init__.py:73
+#: decksite/__init__.py:79
 msgid "About pennydreadfulmagic.com"
 msgstr ""
 
-#: decksite/__init__.py:74
+#: decksite/__init__.py:80
 msgid "FAQs"
 msgstr ""
 
-#: decksite/__init__.py:75 decksite/templates/communityguidelines.mustache:1
+#: decksite/__init__.py:81
 msgid "Community Guidelines"
 msgstr ""
 
-#: decksite/__init__.py:77
+#: decksite/__init__.py:82
+msgid "Contact Us"
+msgstr ""
+
+#: decksite/__init__.py:84
 msgid "Admin"
 msgstr ""
 
-#: decksite/view.py:320
+#: decksite/view.py:255
 #, python-format
 msgid "%(num)d active league run"
 msgid_plural "%(num)d active league runs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/view.py:327 logsite/templates/about.mustache:1
+#: decksite/view.py:262 logsite/templates/about.mustache:1
 msgid "Help us translate the site into your language"
 msgstr ""
 
-#: decksite/data/achievements.py:161
+#: decksite/controllers/admin.py:34
+msgid "Rotation Speculation"
+msgstr ""
+
+#: decksite/data/achievements.py:159
 #, python-format
 msgid " once"
 msgid_plural " %(num)d times"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:162
+#: decksite/data/achievements.py:160
 #, python-format
 msgid "1 player"
 msgid_plural "%(num)d players"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:291
+#: decksite/data/achievements.py:288
 msgid "Seasons"
 msgstr ""
 
-#: decksite/data/achievements.py:333 decksite/templates/home.mustache:1
+#: decksite/data/achievements.py:330 decksite/templates/home.mustache:1
 #: decksite/templates/tournamentcalendar.mustache:1
 msgid "Tournaments"
 msgstr ""
 
-#: decksite/data/achievements.py:336
+#: decksite/data/achievements.py:333
 #, python-format
 msgid "1 tournament entered"
 msgid_plural "%(num)d tournaments entered"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:347
+#: decksite/data/achievements.py:344 decksite/data/achievements.py:804
 msgid "Victories"
 msgstr ""
 
-#: decksite/data/achievements.py:350
+#: decksite/data/achievements.py:347 decksite/data/achievements.py:807
 #, python-format
 msgid "1 victory"
 msgid_plural "%(num)d victories"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:364
+#: decksite/data/achievements.py:361
 msgid "Entries"
 msgstr ""
 
-#: decksite/data/achievements.py:367
+#: decksite/data/achievements.py:364
 #, python-format
 msgid "1 league entry"
 msgid_plural "%(num)d league entries"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:378 decksite/data/achievements.py:392
+#: decksite/data/achievements.py:375 decksite/data/achievements.py:389
 msgid "Runs"
 msgstr ""
 
-#: decksite/data/achievements.py:381
+#: decksite/data/achievements.py:378
 #, python-format
 msgid "1 perfect run"
 msgid_plural "%(num)d perfect runs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:395
+#: decksite/data/achievements.py:392
 #, python-format
 msgid "1 flawless run"
 msgid_plural "%(num)d flawless runs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:449
+#: decksite/data/achievements.py:447
 msgid "Crushes"
 msgstr ""
 
-#: decksite/data/achievements.py:451
+#: decksite/data/achievements.py:450
 #, python-format
 msgid "1 perfect run crush"
 msgid_plural "%(num)d perfect run crushes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:494
+#: decksite/data/achievements.py:495
 msgid "grudges repaid"
 msgstr ""
 
-#: decksite/data/achievements.py:496
+#: decksite/data/achievements.py:498
 #, python-format
 msgid "1 grudge repaid"
 msgid_plural "%(num)d grudges repaid"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:561
+#: decksite/data/achievements.py:565
 msgid "defeats avenged"
 msgstr ""
 
-#: decksite/data/achievements.py:563
+#: decksite/data/achievements.py:568
 #, python-format
 msgid "1 defeat avenged"
 msgid_plural "%(num)d defeats avenged"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:626
+#: decksite/data/achievements.py:631
 #, python-format
 msgid "1 deck played by others"
 msgid_plural "%(num)d decks played by others"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:654
+#: decksite/data/achievements.py:659
 #, python-format
 msgid "1 archetype pioneered"
 msgid_plural "%(num)d archetypes pioneered"
 msgstr[0] ""
 msgstr[1] ""
 
-#: decksite/data/achievements.py:697 decksite/data/achievements.py:738
-#: decksite/data/achievements.py:759 decksite/data/achievements.py:771
+#: decksite/data/achievements.py:702 decksite/data/achievements.py:744
+#: decksite/data/achievements.py:766 decksite/data/achievements.py:778
 #, python-format
 msgid "1 season"
 msgid_plural "%(num)d different seasons"
 msgstr[0] ""
 msgstr[1] ""
 
+#: decksite/data/achievements.py:790
+msgid "Top 8s"
+msgstr ""
+
+#: decksite/data/achievements.py:793
+#, python-format
+msgid "1 Top 8"
+msgid_plural "%(num)d Top 8s"
+msgstr[0] ""
+msgstr[1] ""
+
 #: decksite/templates/about.mustache:1
 msgid ""
-"**The cheapest format ever played.** Every deck in the format costs less "
-"than a dollar."
+"**The cheapest format ever played.** Play for a fraction of the cost of "
+"other formats."
 msgstr ""
 
 #: decksite/templates/about.mustache:1
 msgid ""
-"**A brewer's paradise.** A card pool as big as Modern with gems (and "
-"jank) waiting to be discovered."
+"**A brewer's paradise.** A card pool sometimes as big as Modern with gems"
+" (and jank) waiting to be discovered."
 msgstr ""
 
 #: decksite/templates/about.mustache:1
 msgid ""
-"**A diverse format** with countless different archetypes. Winners of past"
-" tournaments include Reanimator, Red Deck Wins, Heroic, Aristocrats, "
-"Demonic Rising, Abzan Midrange, Elves, Grenzo Combo, Dragon Control and "
-"Vampires in one season alone."
+"**A diverse format** with countless different archetypes. Winners of last"
+" season's tournaments include:"
 msgstr ""
 
 #: decksite/templates/aboutpdm.mustache:1 logsite/templates/about.mustache:1
@@ -336,8 +353,8 @@ msgstr ""
 
 #: decksite/templates/bugpolicy.mustache:1
 msgid ""
-"Do not play cards with game-breaking bugs (exception: cards that are only"
-" bugged in multiplayer games)."
+"Do not play cards with game-breaking bugs (exception: cards that are not "
+"bugged in two player games)."
 msgstr ""
 
 #: decksite/templates/bugpolicy.mustache:1
@@ -351,6 +368,12 @@ msgstr ""
 msgid ""
 "Gaining advantage from a bug intentionally will result in "
 "disqualification."
+msgstr ""
+
+#: decksite/templates/bugpolicy.mustache:1
+msgid ""
+"Only the player playing a bugged card can ever receive a penalty relating"
+" to that card."
 msgstr ""
 
 #: decksite/templates/bugpolicy.mustache:1
@@ -391,7 +414,7 @@ msgstr ""
 
 #: decksite/templates/bugpolicy.mustache:1
 msgid ""
-"In the case where a bugged interaction only becomes known to a player "
+"In the case where an undocumented bugged interaction only becomes known "
 "during a competitive match, at the Tournament Organizer's discretion, a "
 "game loss or match loss may be imposed rather than a disqualification."
 msgstr ""
@@ -449,9 +472,8 @@ msgstr ""
 
 #: decksite/templates/communityguidelines.mustache:1
 msgid ""
-"We respect the Wizards of the Coast [\"Commitment to Each "
-"Other\"](https://magic.wizards.com/en/articles/archive/news/commitment-"
-"each-other-building-community-together-2017-12-19)."
+"We respect the Wizards of the Coast [Code of Conduct & Community "
+"Guidelines](https://company.wizards.com/en/legal/code-conduct)."
 msgstr ""
 
 #: decksite/templates/communityguidelines.mustache:1
@@ -482,6 +504,14 @@ msgid ""
 "Discord moderator."
 msgstr ""
 
+#: decksite/templates/contactus.mustache:1
+msgid "The best way to get help is by joining the [Discord](/discord/)"
+msgstr ""
+
+#: decksite/templates/contactus.mustache:1
+msgid "Email contact: bakert@gmail.com"
+msgstr ""
+
 #: decksite/templates/faqsbody.mustache:1
 msgid "How do I get started with Magic Online?"
 msgstr ""
@@ -497,7 +527,9 @@ msgid "Which cards are legal?"
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
-msgid "Card legality is set quarterly based on which cards are 1¢ at that time."
+msgid ""
+"Card legality is set quarterly based on which cards are {max_price_text} "
+"or less at that time."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
@@ -514,6 +546,12 @@ msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
 msgid "How do I find or brew a decklist?"
+msgstr ""
+
+#: decksite/templates/faqsbody.mustache:1
+msgid ""
+"Minimum 60 cards. Any number of basic lands. Max four of any other legal "
+"card. Sideboard of up to fifteen cards."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
@@ -571,15 +609,8 @@ msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
 msgid ""
-"Top 8 finishers on each month's league leaderboard win credit with [MTGO "
-"Traders](https://www.mtgotraders.com/)."
-msgstr ""
-
-#: decksite/templates/faqsbody.mustache:1
-msgid ""
-"When you complete a five match league run for the first time ever you "
-"will get 1 tik credit with [MTGO Traders](https://www.mtgotraders.com/) "
-"(at the end of the month)."
+"Top 8 finishers on each month's league leaderboard win credit with "
+"[Cardhoarder](https://cardhoarder.com/)."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
@@ -597,7 +628,7 @@ msgstr ""
 #: decksite/templates/faqsbody.mustache:1
 msgid ""
 "We have {num_tournaments} free-to-enter weekly tournaments with prizes "
-"from [Cardhoarder](https://www.cardhoarder.com/)."
+"from [Cardhoarder](https://cardhoarder.com/)."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
@@ -608,43 +639,30 @@ msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
 msgid ""
-"What happens if a card goes above 1¢? How does rotation work? When is the"
-" next rotation? How long are cards legal for?"
+"What happens if a card goes above {max_price_text}? How does rotation "
+"work? When is the next rotation? How long are cards legal for?"
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
 msgid ""
-"Legality is determined at the release of a Standard-legal set on Magic "
-"Online."
+"Legality is determined a week after the release of a Standard-legal set "
+"on Magic Online."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
 msgid ""
-"Prices are checked every hour for a week. Anything 1c or less for half or"
-" more of all checks is legal for the season."
-msgstr ""
-
-#: decksite/templates/faqsbody.mustache:1
-msgid ""
-"Cards from the just-released set are added (nothing removed) a couple of "
-"weeks later via a supplemental rotation after prices have settled a "
-"little."
+"Prices are checked every hour for a week. Anything {max_price_text} or "
+"less for half or more of all checks is legal for the season."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
 msgid "Any version of a card on the legal cards list is legal."
 msgstr ""
 
-#: decksite/templates/home.mustache:1
-msgid "Top Cards"
-msgstr ""
-
-#: decksite/templates/home.mustache:1
-msgid "More cards…"
-msgstr ""
-
-#: decksite/templates/leagueinfo.mustache:1
-msgid "MTGO Traders League"
+#: decksite/templates/kickoff.mustache:1
+#: decksite/templates/leagueinfo.mustache:1 decksite/templates/pd500.mustache:1
+#: decksite/templates/tournaments.mustache:1
+msgid "Prizes"
 msgstr ""
 
 #: decksite/templates/leagueinfo.mustache:1
@@ -659,13 +677,6 @@ msgstr ""
 
 #: decksite/templates/leagueinfo.mustache:1
 msgid "You can [sign up]({signup_url}) at any time."
-msgstr ""
-
-#: decksite/templates/leagueinfo.mustache:1 decksite/views/signup.py:19
-msgid ""
-"When you complete a five match league run for the first time ever you "
-"will get 1 tik credit with MTGO Traders (at the end of the month). This "
-"credit will appear when you trade with one of their bots on Magic Online."
 msgstr ""
 
 #: decksite/templates/leagueinfo.mustache:1
@@ -728,14 +739,9 @@ msgid "Please note the [rules about playing cards with bugs]({bugs_url})."
 msgstr ""
 
 #: decksite/templates/leagueinfo.mustache:1
-#: decksite/templates/tournaments.mustache:1
-msgid "Prizes"
-msgstr ""
-
-#: decksite/templates/leagueinfo.mustache:1
 msgid ""
 "At the end of each month, the top eight players of that month's league "
-"scoreboard will get credit with MTGO Traders (6/4/3/2/1/1/1/1). This "
+"scoreboard will get credit with Cardhoarder (6/4/3/2/1/1/1/1). This "
 "credit will appear when you trade with one of their bots on Magic Online."
 msgstr ""
 
@@ -774,6 +780,11 @@ msgid "Matches should use 25 minute timers."
 msgstr ""
 
 #: decksite/templates/leagueinfo.mustache:1
+#: decksite/templates/tournaments.mustache:1
+msgid "Matches must Allow Watchers so the PDBot can join them."
+msgstr ""
+
+#: decksite/templates/leagueinfo.mustache:1
 msgid "Signup Form"
 msgstr ""
 
@@ -794,15 +805,11 @@ msgid "Date"
 msgstr ""
 
 #: decksite/templates/tournaments.mustache:1
-msgid "Cardhoarder Tournaments"
-msgstr ""
-
-#: decksite/templates/tournaments.mustache:1
 msgid ""
 "There are {num_tournaments} weekly Penny Dreadful tournaments hosted on "
 "[Gatherling.com](https://gatherling.com). They are all free to enter and "
-"some offer prizes from [Cardhoarder](https://www.cardhoarder.com/). Be "
-"sure to also check out the [league](/league/) for a play-when-you-like "
+"some offer prizes from [Cardhoarder](https://cardhoarder.com/). Be sure "
+"to also check out the [league](/league/) for a play-when-you-like "
 "competition."
 msgstr ""
 
@@ -850,9 +857,9 @@ msgstr ""
 msgid ""
 "If a player starts a sideboarded game with less than 60 cards (quite "
 "possible due to a known Magic Online bug) and either player notices "
-"before the end of turn 2 and either player wants to restart the game, the"
-" game will be restarted. The result of any game played beyond turn 2 with"
-" less than 60 cards in maindeck will stand."
+"before the end of turn 2 and the player with a legal deck wants to "
+"restart the game, the game will be restarted. The result of any game "
+"played beyond turn 2 with less than 60 cards in maindeck will stand."
 msgstr ""
 
 #: decksite/templates/tournaments.mustache:1
@@ -865,6 +872,12 @@ msgstr ""
 msgid ""
 "Please do not double queue Penny Dreadful tournaments with other "
 "tournaments nor double queue in the league."
+msgstr ""
+
+#: decksite/templates/tournaments.mustache:1
+msgid ""
+"Spectating other matches is allowed – do not write anything in chat "
+"except !record."
 msgstr ""
 
 #: decksite/templates/tournaments.mustache:1
@@ -897,76 +910,73 @@ msgstr ""
 
 #: decksite/templates/tournaments.mustache:1
 msgid ""
-"If a player realizes they have the wrong deck before the match begins fix"
-" the deck and recreate the match. If the player with the right deck won "
-"the die roll in match 1 then they should be put on the play in match 2."
+"If a player realizes they have the wrong deck before the match begins "
+"they should take a screenshot of their opening hand as proof. Fix the "
+"deck and recreate the match. The player who had the wrong deck must give "
+"the choice of play or draw to their opponent."
 msgstr ""
 
 #: decksite/templates/tournaments.mustache:1
 msgid ""
-"If a player realizes they have the wrong deck mid-game they receive a "
-"game loss for that game. The match should be recreated with the right "
-"deck and games conceded to get the match into the right state."
+"If a player (or PDBot) realizes they have the wrong deck mid-game they "
+"receive a game loss for that game. The match should be recreated with the"
+" right deck and games conceded to get the match into the right state."
 msgstr ""
 
-#: decksite/views/deck_check.py:12 decksite/views/signup.py:28
+#: decksite/views/deck_check.py:11 decksite/views/signup.py:30
 msgid "Decklist"
 msgstr ""
 
-#: decksite/views/deck_check.py:15 decksite/views/signup.py:31
+#: decksite/views/deck_check.py:14 decksite/views/signup.py:33
 msgid "Enter or upload your decklist"
 msgstr ""
 
-#: decksite/views/deck_check.py:18 decksite/views/signup.py:37
+#: decksite/views/deck_check.py:17 decksite/views/signup.py:39
 msgid "Your Recent Decks"
 msgstr ""
 
-#: decksite/views/deck_check.py:21 decksite/views/signup.py:40
+#: decksite/views/deck_check.py:20 decksite/views/signup.py:42
 msgid "Select a recent deck to start from there"
 msgstr ""
 
-#: decksite/views/deck_check.py:24
+#: decksite/views/deck_check.py:23
 msgid "Check your deck"
 msgstr ""
 
-#: decksite/views/home.py:51
+#: decksite/views/home.py:59
 msgid "Recent Top League Decks"
 msgstr ""
 
-#: decksite/views/home.py:53
+#: decksite/views/home.py:61
 msgid "Current League…"
 msgstr ""
 
-#: decksite/views/home.py:62
+#: decksite/views/home.py:70
 msgid "Latest Tournament Top 8"
 msgstr ""
 
-#: decksite/views/home.py:64
+#: decksite/views/home.py:72
 msgid "View Tournament…"
 msgstr ""
 
-#: decksite/views/home.py:71
+#: decksite/views/home.py:79
 msgid "Latest Decks"
 msgstr ""
 
-#: decksite/views/home.py:73
+#: decksite/views/home.py:81
 msgid "More Decks…"
 msgstr ""
 
-#: decksite/views/report.py:25
+#: decksite/views/report.py:24
 msgid "Your Deck"
 msgstr ""
 
-#: decksite/views/signup.py:22
+#: decksite/views/signup.py:24
 msgid "Magic Online Username"
 msgstr ""
 
-#: decksite/views/signup.py:25
+#: decksite/views/signup.py:27
 msgid "Deck Name"
-msgstr ""
-
-#: logsite/templates/about.mustache:1
-msgid "About PDBot"
 msgstr ""
 
 #: logsite/templates/about.mustache:1
@@ -976,18 +986,11 @@ msgid ""
 "information."
 msgstr ""
 
-#: logsite/templates/charts.mustache:1
-msgid "Recent Activity"
-msgstr ""
-
-#: logsite/templates/home.mustache:1
-msgid "Latest Matches"
-msgstr ""
-
 #: logsite/templates/home.mustache:1
 msgid "More matches…"
 msgstr ""
 
-#: logsite/views/charts.py:23
+#: logsite/views/charts.py:22
 msgid "Stats"
 msgstr ""
+

--- a/shared_web/translations/messages.pot
+++ b/shared_web/translations/messages.pot
@@ -993,4 +993,3 @@ msgstr ""
 #: logsite/views/charts.py:22
 msgid "Stats"
 msgstr ""
-


### PR DESCRIPTION
Also update cardhoarder URLs to drop www as that's what they seem to prefer.
