### PR TITLE
Reinstate editing a deck's archetype from the deck detail page

### DIFF
--- a/decksite/auth.py
+++ b/decksite/auth.py
@@ -86,3 +86,6 @@ def check_perms() -> None:
         return
     session['admin'] = Permission.ADMIN in changes
     session['demimod'] = Permission.DEMIMOD in changes
+
+def has_demimod() -> bool:
+    return session.get('admin') or session.get('demimod')

--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -682,7 +682,7 @@ def person_notes(person_id: int) -> Response:
 def deck_embed(deck_id: int) -> Response:
     # Discord doesn't actually show this yet.  I've reached out to them for better documentation about what they do/don't accept.
     d = deck.load_deck(deck_id)
-    view = DeckEmbed(d, [], None, None)
+    view = DeckEmbed(d, [], None, None, [])
     width = 1200
     height = 500
     embed = {

--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -48,7 +48,8 @@ def metagame(deck_type: Optional[str] = None) -> str:
 def deck(deck_id: int) -> str:
     d = ds.load_deck(deck_id)
     ms = match.load_matches_by_deck(d)
-    view = Deck(d, ms, auth.person_id(), auth.discord_id())
+    ars = archs.load_archetypes(order_by='a.name') if auth.has_demimod() else []
+    view = Deck(d, ms, auth.person_id(), auth.discord_id(), ars)
     return view.page()
 
 @APP.route('/seasons/')

--- a/decksite/views/deck.py
+++ b/decksite/views/deck.py
@@ -5,6 +5,7 @@ import titlecase
 from flask import session, url_for
 
 from decksite import prepare
+from decksite.data.archetype import Archetype
 from decksite.view import View
 from magic import card, oracle
 from magic.models import Deck as DeckModel
@@ -13,7 +14,7 @@ from shared.container import Container
 
 
 class Deck(View):
-    def __init__(self, d: DeckModel, matches: List[Container], person_id: Optional[int] = None, discord_id: Optional[int] = None) -> None:
+    def __init__(self, d: DeckModel, matches: List[Container], person_id: Optional[int], discord_id: Optional[int], archetypes: List[Archetype]) -> None:
         super().__init__()
         self.deck = d
         prepare.prepare_deck(self.deck)
@@ -27,6 +28,8 @@ class Deck(View):
         self.person_id = person_id
         self.discord_id = discord_id
         self.is_deck_page = True
+        # To allow mods to change archetype from a dropdown on this page, will be empty for non-demimods
+        self.archetypes = archetypes
 
     def og_title(self) -> str:
         return self.deck.name if self.public() else '(Active League Run)'


### PR DESCRIPTION
This was removed thinking that it didn't hurt anything to improve performance
and it does in fact make the page take 0.07s instead of 0.6s on local for me
but the performance hit is now only for mods and not so bad to worry about I
think. Having the ability is very useful.
