### PR TITLE
Surface issues with caching of applied rules when sorting decks

### DIFF
--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -19,7 +19,7 @@ class EditArchetypes(View):
         for d in self.queue:
             prepare.prepare_deck(d)
             d.archetype_url = url_for('.archetype', archetype_id=d.archetype_name)
-            if d.get('rule_archetype_name'):
+            if d.get('rule_archetype_id'):
                 d.rule_archetype_url = url_for('.archetype', archetype_id=d.rule_archetype_name)
                 d.archetypes = []
                 for a in self.archetypes:
@@ -27,6 +27,8 @@ class EditArchetypes(View):
                         d.archetypes.append({'id': a.id, 'name': a.name, 'selected': True})
                     else:
                         d.archetypes.append(a)
+            if d.get('rule_archetype_id') == 0:
+                d.rule_archetype_url = url_for('edit_rules')
             d.show_add_rule_prompt = d.similarity == '100%' and not d.get('rule_archetype_name')
         self.edit_rules_url = url_for('edit_rules')
         self.query = q


### PR DESCRIPTION
Sometimes for reasons unknown _applied_rules will not contain the correct
information. Rebuilding _applied_rules from scratch is very expensive.
However /admin/archetypes is already in the business of selecting from a kind
of "live" _applied_rules (just for the set of decks that have not yet been
classified) rather than using the cache table. So we piggy back off that to
find decks/rules that are in the funky state and display it inline in the deck
sorting table.

It's not entirely beautiful but it's practical.
