### PR TITLE
Support is:dfc and is:mdfc in card search, fix is:gainland

### DIFF
--- a/find/find_test.py
+++ b/find/find_test.py
@@ -110,6 +110,22 @@ def test_multi_faced_cards() -> None:
     do_functional_test(s, ['Hanweir Battlements', 'Hanweir Garrison'], ['Hanweir, the Writhing Township'])
     s = 'is:split'
     do_functional_test(s, ['Driven // Despair', 'Fire // Ice', 'Wear // Tear'], ['Budoka Gardener', 'Hanweir Garrison'])
+    s = 'is:flip'
+    do_functional_test(s, ['Budoka Gardener'], ['Hanweir Garrison', 'Fire // Ice'])
+    s = 'is:transform'
+    do_functional_test(s, ['Delver of Secrets', "Jace, Vryn's Prodigy"], ['Budoka Gardener', 'Hanweir Garrison', 'Fire // Ice'])
+    s = 'is:meld'
+    do_functional_test(s, ['Hanweir Garrison', 'Phyrexian Dragon Engine'], ['Budoka Gardener', 'Fire // Ice'])
+    s = 'is:leveler'
+    do_functional_test(s, ['Hexdrinker', 'Joraga Treespeaker'], ['Budoka Gardener', 'Fire // Ice'])
+    s = 'is:dfc'
+    do_functional_test(s, ['Delver of Secrets', 'Barkchannel Pathway'], ['Budoka Gardener', 'Fire // Ice'])
+    s = 'is:dfc -is:mdfc'
+    do_functional_test(s, ['Delver of Secrets'], ['Barkchannel Pathway'])
+    s = 'is:mdfc'
+    do_functional_test(s, ["Agadeem's Awakening", 'Bala Ged Recovery', 'Barkchannel Pathway'], ['Delver of Secrets', 'Budoka Gardener', 'Fire // Ice'])
+    s = 'is:mdfc AND is:dfc'
+    do_functional_test(s, ["Agadeem's Awakening", 'Bala Ged Recovery', 'Barkchannel Pathway'], ['Delver of Secrets', 'Budoka Gardener', 'Fire // Ice'])
 
 @pytest.mark.functional
 def test_spells_permanents_and_effects() -> None:

--- a/find/find_test.py
+++ b/find/find_test.py
@@ -558,6 +558,10 @@ def test_is_checkland_functional() -> None:
     do_functional_test('is:checkland', ['Drowned Catacomb', 'Hinterland Harbor'], ['Savage Lands'])
 
 @pytest.mark.functional()
+def test_is_gainland_functional() -> None:
+    do_functional_test('is:gainland', ['Akoum Refuge', 'Dismal Backwater'], ['City of Brass', 'Glimmerpost'])
+
+@pytest.mark.functional()
 def test_smart_quotes() -> None:
     do_functional_test('o:“Art rampage”', ['Our Market Research Shows That Players Like Really Long Card Names So We Made this Card to Have the Absolute Longest Card Name Ever Elemental'], [])
 

--- a/find/search.py
+++ b/find/search.py
@@ -416,7 +416,7 @@ def is_subquery(subquery_name: str) -> str:
         'checkland': 't:land fo:"unless you control a" fo:"} or {"',
         'creatureland': 't:land o:"becomes a"',
         'fetchland': 't:land o:"Search your library for a " (o:"land card" or o:"plains card" or o:"island card" or o:"swamp card" or o:"mountain card" or o:"forest card" or o:"gate card")',
-        'gainland': 't:land o:"When ~ enters the battlefield, you gain 1 life"',
+        'gainland': 't:land o:"When ~ enters the battlefield, you gain 1 life."',
         'painland': 't:land o:"~ deals 1 damage to you."',
         'permanent': 't:artifact OR t:creature OR t:enchantment OR t:land OR t:planeswalker',
         'slowland': """t:land o:"~ doesn't untap during your next untap step." """,

--- a/find/search.py
+++ b/find/search.py
@@ -398,6 +398,10 @@ def init_value_lookup() -> None:
             VALUE_LOOKUP['color_identity'] = d
 
 def is_subquery(subquery_name: str) -> str:
+    if subquery_name == 'dfc':
+        return "(c.layout IN ('transform', 'modal_dfc'))"
+    if subquery_name == 'mdfc':
+        subquery_name = 'modal_dfc'
     if subquery_name in layout.all_layouts():
         return f'(c.layout = {sqlescape(subquery_name)})'
     if subquery_name == 'spikey':


### PR DESCRIPTION
- **Make 'o' and 'oracle' behave as they do on Scryfall in search, remove 'text'**
- **Support searching past seasons or all seasons in scryfall-like search**
- **Support is:mdfc and is:dfc in card search**
- **is:gainland should not find Glimmerpost**
