### PR TITLE
Support not: in card search (including not:permanent)

### DIFF
--- a/find/find_test.py
+++ b/find/find_test.py
@@ -178,6 +178,10 @@ def test_format_legality() -> None:
     do_functional_test(s, ['Progenitus', 'Teferi, Temporal Archmage'], ['Forest', 'Nettle Sentinel', 'Rofellos, Llanowar Emissary'])
     # s = 'is:reserved'
     # do_functional_test(s, [], [])
+    # s = 'is:brawler'
+    # do_functional_test(s, [], [])
+    s = 'is:companion'
+    do_functional_test(s, ['Lurrus of the Dream-Den', 'Treizeci, Sun of Serra'], ["Bear's Companion", 'K-9, Mark 1'])
 
 # USD/EUR/TIX prices
 # Artist, Flavor Text and Watermark

--- a/find/find_test.py
+++ b/find/find_test.py
@@ -192,11 +192,13 @@ def test_format_legality() -> None:
 @pytest.mark.functional
 def test_negating_conditions() -> None:
     s = '-fire c:r t:instant'
-    do_functional_test(s, [], [])
+    do_functional_test(s, ['Abrade'], ['Cast Into the Fire'])
     s = 'o:changeling -t:creature'
-    do_functional_test(s, [], [])
-    s = 'not:reprint e:c16'
-    do_functional_test(s, [], [])
+    do_functional_test(s, ['Nameless Inversion'], ['Chameleon Colossus'])
+    # s = 'not:reprint e:c16'
+    # do_functional_test(s, [], [])
+    s = 'not:permanent c:b cmc=1 Dark'
+    do_functional_test(s,['Darkness', 'Dark Ritual'], ['Darkest Hour'])
 
 # Regular Expressions
 

--- a/find/find_test.py
+++ b/find/find_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from find import search
-from magic import seasons
+from magic import seasons, fetcher
 from magic.database import db
 
 # Some of these tests only work hooked up to a cards db, and are thus marked functional. They are fast, though, and you should run them if editing card search.
@@ -191,7 +191,36 @@ def test_format_legality() -> None:
 # Tagger tags
 # Reprints
 # Languages
+
 # Shortcuts and Nicknames
+@pytest.mark.functional
+def test_shortcuts_and_nicknames() -> None:
+    # do_functional_test('is:colorshifted', [], [])
+    do_functional_test('is:bikeland', ['Canyon Slough'], ['Barren Moor', 'Savai Triome', 'Savai Crystal'], True)
+    do_functional_test('is:cycleland', ['Canyon Slough'], ['Barren Moor', 'Savai Triome', 'Savai Crystal'])
+    do_functional_test('is:bicycleland', ['Canyon Slough'], ['Barren Moor', 'Savai Triome', 'Savai Crystal'])
+    do_functional_test('is:bounceland', ['Dimir Aqueduct', 'Arid Archway', 'Dormant Volcano'], ['Mystic Gate'], True)
+    do_functional_test('is:karoo', ['Dimir Aqueduct', 'Arid Archway', 'Dormant Volcano'], ['Mystic Gate'])
+    do_functional_test('is:canopyland', ['Horizon Canopy', 'Fiery Islet'], ['City of Brass', 'Botanical Plaza', 'Scene of the Crime'], True)
+    do_functional_test('is:canland', ['Horizon Canopy', 'Fiery Islet'], ['City of Brass', 'Botanical Plaza', 'Scene of the Crime'])
+    do_functional_test('is:checkland', ['Drowned Catacomb', 'Hinterland Harbor'], ['Savage Lands'], True)
+    do_functional_test('is:dual', ['Plateau', 'Underground Sea'], ['Island', 'Overgrown Tomb'], True)
+    do_functional_test('is:fastland', ['Darkslick Shores'], ['Plains'], True)
+    do_functional_test('is:fetchland', ['Scalding Tarn', 'Flooded Strand'], ['City of Brass', 'Fiery Islet', 'Prismatic Vista'])
+    do_functional_test('is:filterland', ['Cascade Bluffs', 'Desolate Mire', 'Cascading Cataracts'], ['Tainted Wood'], True)
+    do_functional_test('is:gainland', ['Akoum Refuge', 'Dismal Backwater'], ['City of Brass', 'Glimmerpost'])
+    do_functional_test('is:painland', ['Brushland', 'Llanowar Wastes'], ['Cabal Pit', 'Elves of Deep Shadow', 'Caldera Lake'], True)
+    do_functional_test('is:scryland', ['Temple of Malady'], ['Fading Hope', 'Zhalfrin Void'], True)
+    do_functional_test('is:shadowland', ['Choked Estuary', 'Vineglimmer Snarl'], ['Secluded Glen', 'Counterbalance'], True)
+    do_functional_test('is:snarl', ['Choked Estuary', 'Vineglimmer Snarl'], ['Secluded Glen', 'Counterbalance'])
+    do_functional_test('is:shockland', ['Overgrown Tomb'], ['Boseiju, Who Shelters All', 'Tenacious Underdog'], True)
+    do_functional_test('is:slowland', ['Deathcap Glade', 'Shipwreck Marsh'], ['Lantern-Lit Cavern'], True)
+    do_functional_test('is:storageland', ['Bottomless Vault', 'Calciform Pools', 'Mage-Ring Network'], ['City of Shadows', 'Mercadian Bazaar', 'Storage Matrix'])
+    do_functional_test('is:creatureland', ['Treetop Village', 'Creeping Tar Pit', 'Restless Bivouac', "Mishra's Factory", 'Crawling Barrens'], ["Urza's Factory", "Thespian's Stage"], True)
+    do_functional_test('is:triland', ['Savage Lands'], ['Bant Charm', "Spara's Headquarters"])
+    do_functional_test('is:tangoland', ['Canopy Vista'], ['Glacial Fortress', 'Thran Portal', 'Blood Moon'], True)
+    do_functional_test('is:battleland', ['Canopy Vista'], ['Glacial Fortress', 'Thran Portal', 'Blood Moon'])
+    # do_functional_test('is:masterpiece, [], [])
 
 @pytest.mark.functional
 def test_negating_conditions() -> None:
@@ -202,7 +231,7 @@ def test_negating_conditions() -> None:
     # s = 'not:reprint e:c16'
     # do_functional_test(s, [], [])
     s = 'not:permanent c:b cmc=1 Dark'
-    do_functional_test(s,['Darkness', 'Dark Ritual'], ['Darkest Hour'])
+    do_functional_test(s, ['Darkness', 'Dark Ritual'], ['Darkest Hour'])
 
 # Regular Expressions
 
@@ -243,12 +272,22 @@ def test_regular_expressions_functional() -> None:
     # You can use forward slashes // instead of quotes with the type://, t:// oracle://, o://, flavor://, ft://, and name:// keywords to match those parts of a card using regular expressions.
     # ~ An automatic alias for the current card name or “this spell” if the card mentions itself.
     # \sm Short-hand for any mana symbol
+    do_functional_test(r'o:/\sm, {T}: Add/', ['Cascade Bluffs', "Arcum's Astrolabe", 'Azorius Signet'], ['Abundant Growth', 'Ancient Den'])
     # \sc Short-hand for any colored mana symbol
+    do_functional_test(r'o:/\sc, {T}: Add/', ['Cascade Bluffs'], ['Abundant Growth', 'Ancient Den', "Arcum's Astrolabe", 'Azorius Signet'])
     # \ss Short-hand for any card symbol
+    # do_functional_test(r'o:/\ss, {T}: Add/', ['Cascade Bluffs'],['Abundant Growth', 'Ancient Den', "Arcum's Astrolabe", 'Azorius Signet'])
     # \smr Short-hand for any repeated mana symbol. For example, {G}{G} matches \smr
+    # do_functional_test(r'o:Add /\smr/', ['Joraga Treespeaker'], ['Burning-Tree Emissary', 'Allosaurus Shepherd'])
     # \spt Short-hand for a X/X power/toughness expression
+    do_functional_test(r'o:/create an? \spt black and green/', ['Kin-Tree Invocation', 'Grakmaw, Skyclave Ravager', 'Creakwood Liege'], ['Restless Cottage', 'Pharika, God of Affliction'])
     # \spp  Short-hand for a +X/+X power/toughness expression
+    do_functional_test(r't:instant c<=gb cmc<=2 o:/gets \spp/', ['Giant Growth'], ['Nameless Inversion', 'Bile Blight'])
     # \smm  Short-hand for a -X/-X power/toughness expression
+    do_functional_test(r't:instant c<=gb cmc<=2 o:/gets \smm/', ['Darkblast'], ['Nameless Inversion', 'Giant Growth', 'Bile Blight'])
+    # \smp Short-hand for any Phyrexian card symbol, e.g. {P}, {W/P}, or {G/W/P}.
+    do_functional_test(r'rage fo:/\smp/', ['Rage Extractor'], ["Dragon's Rage Channeler", 'Rage Reflection'])
+
 
 # Exact Names
 
@@ -270,6 +309,13 @@ def test_nesting_conditions() -> None:
 
 
 # END Tests from https://scryfall.com/docs/syntax
+
+@pytest.mark.function
+def test_colors_with_ints() -> None:
+    do_functional_test('ci=5 t:legendary -t:creature', ['Genju of the Realm', 'Legacy Weapon'], ['Coalition Victory', 'Garth One-Eye'])
+    do_functional_test('c=5 t:legendary -t:creature', ['Genju of the Realm'], ['Coalition Victory', 'Garth One-Eye', 'Legacy Weapon'])
+    do_functional_test('ci<4 ci>1 t:instant cmc=2', ['Abrupt Decay', "Assassin's Trophy", 'Agony Warp', 'Ancient Grudge', 'Resounding Roar'], ['Abeyance'])
+    do_functional_test('c<4 c>1 t:instant cmc=2', ['Abrupt Decay', "Assassin's Trophy", 'Agony Warp'], ['Abeyance', 'Ancient Grudge', 'Resounding Roar'])
 
 @pytest.mark.functional
 def test_past_seasons() -> None:
@@ -556,18 +602,6 @@ def test_is_commander() -> None:
     do_test('is:commander', "((type_line LIKE '%%legendary%%') AND ((type_line LIKE '%%creature%%') OR (REGEXP_REPLACE(oracle_text, '\\\\([^)]*\\\\)', '') LIKE CONCAT('%%', name, ' can be your commander%%'))) AND (c.id IN (SELECT card_id FROM card_legality WHERE format_id IN (4) AND legality <> 'Banned')))")
 
 @pytest.mark.functional()
-def test_is_triland_functional() -> None:
-    do_functional_test('is:triland', ['Savage Lands'], ['Bant Charm', "Spara's Headquarters"])
-
-@pytest.mark.functional()
-def test_is_checkland_functional() -> None:
-    do_functional_test('is:checkland', ['Drowned Catacomb', 'Hinterland Harbor'], ['Savage Lands'])
-
-@pytest.mark.functional()
-def test_is_gainland_functional() -> None:
-    do_functional_test('is:gainland', ['Akoum Refuge', 'Dismal Backwater'], ['City of Brass', 'Glimmerpost'])
-
-@pytest.mark.functional()
 def test_smart_quotes() -> None:
     do_functional_test('o:“Art rampage”', ['Our Market Research Shows That Players Like Really Long Card Names So We Made this Card to Have the Absolute Longest Card Name Ever Elemental'], [])
 
@@ -620,13 +654,18 @@ def test_parse_season() -> None:
         search.parse_season('foopd1')
     assert search.parse_season('pd1') == 'EMN'
 
-def do_functional_test(query: str, yes: list[str], no: list[str]) -> None:
+def do_functional_test(query: str, yes: list[str], no: list[str], check_scryfall: bool = False) -> None:
     results = search.search(query)
     found = [c.name for c in results]
     for name in yes:
         assert name in found
     for name in no:
         assert name not in found
+    if check_scryfall:
+        _, scryfall_names, _ = fetcher.search_scryfall(query)
+        print(scryfall_names)
+        print([c.name for c in results[:len(scryfall_names)]])
+        assert [c.name for c in results[:len(scryfall_names)]] == scryfall_names
 
 def do_test(query: str, expected: str) -> None:
     where = search.parse(search.tokenize(query))

--- a/find/search.py
+++ b/find/search.py
@@ -416,6 +416,7 @@ def is_subquery(subquery_name: str) -> str:
     subqueries = {
         'commander': 't:legendary (t:creature OR o:"~ can be your commander") f:commander',
         'checkland': 't:land fo:"unless you control a" fo:"} or {"',
+        'companion': 'o:"Companion — "',
         'creatureland': 't:land o:"becomes a"',
         'fetchland': 't:land o:"Search your library for a " (o:"land card" or o:"plains card" or o:"island card" or o:"swamp card" or o:"mountain card" or o:"forest card" or o:"gate card")',
         'gainland': 't:land o:"When ~ enters the battlefield, you gain 1 life."',

--- a/find/search.py
+++ b/find/search.py
@@ -195,6 +195,8 @@ def parse_criterion(key: Token, operator: Token, term: Token) -> str:
         return mana_where(operator.value(), term.value())
     if key.value() == 'is':
         return is_subquery(term.value())
+    if key.value() == 'not':
+        return f'NOT ({is_subquery(term.value())})'
     if key.value() == 'playable' or key.value() == 'p':
         return playable_where(term.value())
     raise InvalidCriterionException

--- a/find/search.py
+++ b/find/search.py
@@ -211,6 +211,7 @@ def text_where(column: str, term: Token, exclude_parenthetical: bool = False) ->
         column = 'oracle_text'
     if term.is_regex():
         operator = 'REGEXP'
+        q = replace_scryfall_regex_extensions(q)
         escaped = sqlescape('(?m)' + q)
     else:
         operator = 'LIKE'
@@ -245,6 +246,11 @@ def math_where(column: str, operator: str, term: str) -> str:
 
 def color_where(subtable: str, operator: str, term: str) -> str:
     all_colors = {'w', 'u', 'b', 'r', 'g'}
+    try:
+        season_id = int(term)
+        return f'c.id IN (SELECT card_id FROM card_{subtable} GROUP BY card_id HAVING COUNT(card_id) {operator} {season_id})'
+    except ValueError:
+        pass
     if term in COLOR_COMBINATIONS_LOWER.keys():
         colors = set(COLOR_COMBINATIONS_LOWER[term])
     else:
@@ -414,25 +420,38 @@ def is_subquery(subquery_name: str) -> str:
     if subquery_name == 'hybrid':
         return "((mana_cost LIKE '%%/2%%') OR (mana_cost LIKE '%%/W%%') OR (mana_cost LIKE '%%/U%%') OR (mana_cost LIKE '%%/B%%') OR (mana_cost LIKE '%%/R%%') OR (mana_cost LIKE '%%/G%%'))"
     subqueries = {
+        'bikeland': 't:land o:"Cycling {2}" ci=2',
+        'bounceland': 't:land (o:"When ~ enters the battlefield, return a land you control to its owner\'s hand" OR o:/When ~ enters the battlefield, sacrifice it unless you return an untapped .* you control to its owner\'s hand/)',
+        'canopyland': 'o:"{T}, Pay 1 life: Add" o:"{1}, {T}, Sacrifice ~: Draw a card."',
         'commander': 't:legendary (t:creature OR o:"~ can be your commander") f:commander',
         'checkland': 't:land fo:"unless you control a" fo:"} or {"',
         'companion': 'o:"Companion — "',
-        'creatureland': 't:land o:"becomes a"',
-        'fetchland': 't:land o:"Search your library for a " (o:"land card" or o:"plains card" or o:"island card" or o:"swamp card" or o:"mountain card" or o:"forest card" or o:"gate card")',
+        'creatureland': 't:land -t:creature o:/becomes? a.* creature/ -"Argoth, Sanctum of Nature" -o:/target .* becomes/',
+        'dual': 't:land ci=2 -o:/./',
+        'fastland': 't:land o:"enters the battlefield tapped unless you control two or fewer other lands." -t:gate',
+        'fetchland': 't:land o:/{T}, Pay 1 life, Sacrifice ~: Search your library for an? [a-z]+ or [a-z]+ card, put it onto the battlefield, then shuffle./',
+        'filterland': r't:land (o:/\sm, {T}: Add \sc\sc/ OR o:/\sm, {T}: Add five mana in any combination of colors./)',
         'gainland': 't:land o:"When ~ enters the battlefield, you gain 1 life."',
-        'painland': 't:land o:"~ deals 1 damage to you."',
+        'painland': r't:land o:/Add \{.\} or \{.\}. ~ deals 1 damage to you./ -o:"~ enters the battlefield tapped"',
         'permanent': 't:artifact OR t:creature OR t:enchantment OR t:land OR t:planeswalker',
-        'slowland': """t:land o:"~ doesn't untap during your next untap step." """,
+        'scryland': 't:land "Temple of" o:"When ~ enters the battlefield, scry 1"',
+        'shadowland': "t:land o:/As ~ enters the battlefield, you may reveal an? [a-z]+ or [a-z]+ card from your hand. If you don't, ~ enters the battlefield tapped./",
+        'shockland': 't:land o:"As ~ enters the battlefield, you may pay 2 life. If you don\'t, it enters the battlefield tapped."',
+        'slowland': 't:land o:"~ enters the battlefield tapped unless you control two or more other lands."',
         # 205.2a The card types are artifact, battle, conspiracy, creature, dungeon, enchantment, instant, land, phenomenon, plane, planeswalker, scheme, sorcery, tribal, and vanguard. See section 3, “Card Types.”
         'spell': 't:artifact OR t:battle OR t:creature OR t:enchantment OR t:instant OR t:planeswalker OR t:sorcery',
-        'storageland': 'o:"storage counter"',
+        'storageland': 't:land o:"storage counter" (o:"You may choose not to untap ~ during your untap step." OR o:"{1}, {T}: Put a storage counter on ~")',
+        'tangoland': 't:land o:"~ enters the battlefield tapped unless you control two or more basic lands."',
         'triland': 't:land fo:": Add {" fo:"}, {" fo:"}, or {" fo:"enters the battlefield tapped" -fo:cycling',
     }
-    for k in list(subqueries.keys()):
-        if k.endswith('land'):
-            subqueries[k.replace('land', '')] = subqueries[k]
     subqueries['refuge'] = subqueries['gainland']
     subqueries['manland'] = subqueries['creatureland']
+    subqueries['bicycleland'] = subqueries['bikeland']
+    subqueries['cycleland'] = subqueries['bikeland']
+    subqueries['karoo'] = subqueries['bounceland']
+    subqueries['canland'] = subqueries['canopyland']
+    subqueries['battleland'] = subqueries['tangoland']
+    subqueries['snarl'] = subqueries['shadowland']
     query = subqueries.get(subquery_name, '')
     if query == '':
         raise InvalidSearchException(f'Did not recognize `{subquery_name}` as a value for `is:`')
@@ -473,6 +492,33 @@ def parse_season(term: str) -> str:
     except (AttributeError, IndexError, ValueError, DoesNotExistException):
         pass
     raise InvalidValueException(f"Could not get a Penny Dreadful season from '{term}'")
+
+def replace_scryfall_regex_extensions(q: str) -> str:
+    # Three char classes first because the other may be substrings of these …
+
+    # \smr Short-hand for any repeated mana symbol. For example, {G}{G} matches \smr
+    # q = q.replace(r'\smr', rf'({mana_symbol_pattern})\1')  # This \1 would mean neither we nor callers could ever use parens (for grouping, say) without noncapturing prefix before \smr. Might have to hardcode enumerate every combination?
+    # \smh Short-hand for any hybrid card symbol. Note that monocolor Phyrexian symbols aren’t considered hybrid.
+    q = q.replace(r'\smh', r'{[WUBRGP0-9]/[^P]}')
+    # \smp Short-hand for any Phyrexian card symbol, e.g. {P}, {W/P}, or {G/W/P}.
+    q = q.replace(r'\smp', r'{[WUBRGC/]*P}')
+    # \spt Short-hand for a X/X power/toughness expression
+    pt_pattern = r'([0-9]+|X)'
+    q = q.replace(r'\spt', f'{pt_pattern}/{pt_pattern}')
+    # \spp Short-hand for a +X/+X power/toughness expression
+    q = q.replace(r'\spp', rf'\+{pt_pattern}/\+{pt_pattern}')
+    # \smm Short-hand for a -X/-X power/toughness expression
+    q = q.replace(r'\smm', rf'-{pt_pattern}/-{pt_pattern}')
+
+    # … and then two char classes
+    # \sm # Short-hand for any mana symbol
+    mana_symbol_pattern = r'{([SWUBRGPCP0-9/]+)}'
+    q = q.replace(r'\sm', mana_symbol_pattern)
+    # \sc Short-hand for any colored mana symbol
+    q = q.replace(r'\sc', r'{[WUBRGP/]+}')
+    # \ss Short-hand for any card symbol
+    # q = q.replace(r'\ss', r'{[^}]+}')
+    return q
 
 class InvalidSearchException(ParseException):
     pass

--- a/find/tokens.py
+++ b/find/tokens.py
@@ -64,7 +64,7 @@ class Criterion(Token):
 
 class Key(Token):
     # Strict substrings of other operators must appear later in the list.
-    values = ['coloridentity', 'fulloracle', 'commander', 'supertype', 'toughness', 'identity', 'playable', 'produces', 'edition', 'subtype', 'loyalty', 'format', 'oracle', 'rarity', 'color', 'legal', 'power', 'super', 'mana', 'name', 'text', 'type', 'cmc', 'loy', 'pow', 'set', 'sub', 'tou', 'cid', 'ci', 'fo', 'id', 'mv', 'c', 'e', 'f', 'm', 'r', 's', 'o', 't', 'is', 'p']
+    values = ['coloridentity', 'fulloracle', 'commander', 'supertype', 'toughness', 'identity', 'playable', 'produces', 'edition', 'subtype', 'loyalty', 'format', 'oracle', 'rarity', 'color', 'legal', 'power', 'super', 'mana', 'name', 'text', 'type', 'cmc', 'loy', 'pow', 'set', 'sub', 'tou', 'cid', 'not', 'ci', 'fo', 'id', 'mv', 'c', 'e', 'f', 'm', 'r', 's', 'o', 't', 'is', 'p']
 
 
 class Operator(Token):


### PR DESCRIPTION
This is used in Scryfall's suggest search for Lurrus.

Fixes #11180.
