### PR TITLE
Make /rotation much faster by introducing a decksite db caching layer

### DIFF
--- a/analysis/analysis.py
+++ b/analysis/analysis.py
@@ -89,7 +89,6 @@ def played_cards_by_person(person_id: int, season_id: int) -> list[Card]:
             name IS NOT NULL
     """.format(season_query=query.season_query(season_id))
     cs = [Container(r) for r in decksite_db().select(sql, [person_id])]
-    print(len(cs))
     cards = oracle.cards_by_name()
     for c in cs:
         c.update(cards[c.name])

--- a/decksite/controllers/resources.py
+++ b/decksite/controllers/resources.py
@@ -2,7 +2,7 @@ from flask import Response, make_response, request
 
 from decksite import APP, SEASONS, auth, get_season_id
 from decksite.cache import cached
-from decksite.data import playability
+from decksite.data import playability, rotation as rtn
 from decksite.league import DeckCheckForm
 from decksite.views import Bugs, DeckCheck, LinkAccounts, Resources, Rotation, RotationChanges
 from magic import card, oracle
@@ -11,7 +11,8 @@ from magic import card, oracle
 @cached()
 @APP.route('/rotation/')
 def rotation() -> str:
-    view = Rotation()
+    runs, num_cards = rtn.load_rotation_summary()
+    view = Rotation(runs, num_cards)
     return view.page()
 
 

--- a/decksite/data/playability.py
+++ b/decksite/data/playability.py
@@ -79,13 +79,7 @@ def season_playability(season_id: int) -> list[Container]:
 
 @retry_after_calling(preaggregate)
 def rank() -> dict[str, int]:
-    sql = """
-        SELECT
-            name,
-            ROW_NUMBER() OVER (ORDER BY playability DESC) as rank
-        FROM
-            _playability
-    """
+    sql = query.ranks()
     return {r['name']: r['rank'] for r in db().select(sql)}
 
 def preaggregate_season_count() -> None:

--- a/decksite/data/rotation.py
+++ b/decksite/data/rotation.py
@@ -1,0 +1,147 @@
+import functools
+from typing import Any
+from collections.abc import Callable
+
+from decksite.data import query, preaggregation
+from decksite.database import db
+from magic import oracle, rotation, seasons
+from magic.models import Card
+from shared import logger, decorators
+from shared.container import Container
+from shared.database import sqlescape
+from shared.decorators import FuncType, T
+from shared.pd_exception import OperationalException, DatabaseException
+
+# A decksite-level cache of rotation information, primarily to make /rotation much faster.
+
+# A decorator that skips execution of everything in this module if it's not currently rotation time.
+# To test all this stuff set always_show_rotation to True in config.json.
+def if_not_in_rotation(val: T) -> Callable[[FuncType[T]], FuncType[T]]:
+    def decorator(decorated_func: FuncType[T]) -> FuncType[T]:
+        @functools.wraps(decorated_func)
+        def wrapper(*args: list[Any], **kwargs: dict[str, Any]) -> T:
+            if not rotation.in_rotation():
+                return val
+            return decorated_func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+@if_not_in_rotation([])
+def load_rotation(where: str = 'TRUE', order_by: str = 'hits', limit: str = '') -> list[Card]:
+    sql = f"""
+        SELECT
+            name,
+            hits,
+            percent,
+            hits_needed,
+            percent_needed,
+            rank,
+            status,
+            hit_in_last_run
+        FROM
+            _rotation
+        WHERE
+            {where}
+        ORDER BY
+            {order_by}
+        {limit}
+    """
+    try:
+        cs = [Container(r) for r in db().select(sql)]
+    except DatabaseException as e:
+        logger.error('Failed to load rotation information', e)
+        return []
+    cards = oracle.cards_by_name()
+    for c in cs:
+        c.update(cards[c.name])
+    return cs
+
+@if_not_in_rotation(0)
+def load_rotation_count(where: str = 'TRUE') -> int:
+    return db().value(f'SELECT COUNT(*) FROM _rotation WHERE {where}')
+
+
+@if_not_in_rotation((0, 0))
+def load_rotation_summary() -> tuple[int, int]:
+    sql = 'SELECT MAX(hits) AS runs, COUNT(*) AS num_cards FROM _rotation'
+    try:
+        row = db().select(sql)[0]
+    except DatabaseException as e:
+        logger.error('Unable to get rotation information', e)
+        return 0, 0
+    return int(row['runs'] or 0), int(row['num_cards'] or 0)
+
+# This is expensive (more than 10s), don't call it on user time.
+# To trigger manually without having to be in a python shell, hit /api/rotation/clear_cache in a browser.
+@decorators.interprocess_locked('.rotation-cache.lock')
+@if_not_in_rotation(None)
+def force_cache_update() -> None:
+    season_id = seasons.next_season_num()
+    db().begin(f'rotation_runs_season_{season_id}')
+    # This is why this is so expensive – we start again from scratch every time.
+    # This does let us edit the Run_xxx.txt files which happens sometimes when things go wrong.
+    db().execute('DELETE FROM rotation_runs WHERE season_id = %s', [season_id])
+    update_rotation_runs()
+    db().commit(f'rotation_runs_season_{season_id}')
+    cache_rotation()
+
+@if_not_in_rotation(None)
+def update_rotation_runs() -> None:
+    season_id = seasons.next_season_num()
+    for path in rotation.files():
+        f = open(path)
+        number = rotation.run_number_from_path(path)
+        cs = [(number, line.strip()) for line in f.readlines()]
+        sql = 'INSERT IGNORE INTO rotation_runs (number, name, season_id) VALUES '
+        sql += ', '.join(f'({number}, {sqlescape(name)}, {season_id})' for number, name in cs)
+        db().execute(sql)
+
+@if_not_in_rotation(None)
+def cache_rotation() -> None:
+    table = '_rotation'
+    sql = f"""
+        SET @next_season_id = {seasons.next_season_num()};
+        SET @total_runs = {rotation.TOTAL_RUNS};
+        SELECT MAX(number) INTO @runs_completed FROM rotation_runs WHERE season_id = @next_season_id;
+        SET @runs_remaining = @total_runs - @runs_completed;
+        SET @hits_required = @total_runs / 2;
+        CREATE TABLE IF NOT EXISTS _new{table} (
+            name VARCHAR(190) NOT NULL PRIMARY KEY,
+            hits TINYINT UNSIGNED NOT NULL,
+            percent TINYINT UNSIGNED NOT NULL,
+            hits_needed TINYINT UNSIGNED NOT NULL,
+            percent_needed MEDIUMINT NOT NULL,
+            rank INT,
+            hit_in_last_run BOOL NOT NULL,
+            status VARCHAR(20) NOT NULL
+        ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci AS
+        SELECT
+            rr.name,
+            COUNT(*) AS hits,
+            ROUND(ROUND(COUNT(*) / @runs_completed, 2) * 100) AS percent,
+            GREATEST(0, @hits_required - COUNT(*)) AS hits_needed,
+            IF(@remaining_runs = 0, 0, ROUND((GREATEST(0, @hits_required - COUNT(*)) / @runs_remaining) * 100)) AS percent_needed,
+            p.rank,
+            SUM(IF(number IN (SELECT MAX(number) FROM _rotation_runs), 1, 0)) AS hit_in_last_run,
+            CASE
+                WHEN COUNT(*) >= @hits_required THEN 'Legal'
+                WHEN COUNT(*) + @total_runs - (SELECT MAX(number) FROM rotation_runs) >= @hits_required THEN 'Undecided'
+                ELSE 'Not Legal'
+            END AS status
+        FROM
+            rotation_runs AS rr
+        LEFT JOIN
+            ({query.ranks()}) AS p ON rr.name = p.name
+        WHERE
+            rr.season_id = @next_season_id
+        GROUP BY
+            name
+    """
+    where, msg = query.card_search_where('-f:pdall')
+    if msg:
+        emsg = "Unexpected error generating card search where: '{msg}'"
+        logger.error(emsg)
+        raise OperationalException(emsg)
+    preaggregation.preaggregate(table, sql)
+    sql = f'UPDATE _rotation SET rank = 0 WHERE {where}'
+    db().execute(sql)

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -27,6 +27,12 @@ def prepare_card(c: Card, tournament_only: bool = False, season_id: int | str | 
     set_legal_icons(c)
     if c.get('num_decks') is not None:
         c.show_record = c.get('wins') or c.get('losses') or c.get('draws')
+    if c.get('rank') == 0:
+        c.display_rank = 'NEW'
+    elif not c.get('rank'):
+        c.display_rank = '-'
+    else:
+        c.display_rank = str(c.rank)
 
 def prepare_card_urls(c: Card, tournament_only: bool = False, season_id: int | str | None = None) -> None:
     c.url = url_for_card(c, tournament_only, season_id)

--- a/decksite/sql/70.sql
+++ b/decksite/sql/70.sql
@@ -1,0 +1,8 @@
+CREATE TABLE rotation_runs (
+    number TINYINT UNSIGNED NOT NULL,
+    name VARCHAR(190),
+    season_id INT NOT NULL, -- Can't be a foreign key because season table won't next season when we want to use it
+    PRIMARY KEY (number, name, season_id),
+    INDEX idx_name (name),
+    INDEX idx_season_id (season_id)
+);

--- a/decksite/templates/rotation.mustache
+++ b/decksite/templates/rotation.mustache
@@ -1,7 +1,7 @@
 <section>
     <p>{{rotation_msg}}</p>
     {{#runs}}
-        <p>{{runs}} ({{runs_percent}}%) of 168 runs completed. {{num_cards}} cards have hits.</p>
+        <p>{{runs}} ({{runs_percent}}%) of {{total_runs}} runs completed. {{num_cards}} cards have hits.</p>
     {{/runs}}
 </section>
 {{#runs}}

--- a/decksite/views/rotation.py
+++ b/decksite/views/rotation.py
@@ -1,26 +1,19 @@
-import datetime
-
 from decksite.view import View
 from magic import rotation, seasons
-from shared import configuration, dtutil
+from shared import dtutil
 
 
 class Rotation(View):
-    def __init__(self) -> None:
+    def __init__(self, runs: int, num_cards: int) -> None:
         super().__init__()
-        until_rotation = seasons.next_rotation() - dtutil.now()
-        in_rotation = configuration.always_show_rotation.value
-        if until_rotation < datetime.timedelta(7):
-            in_rotation = True
+        self.runs = runs
+        self.runs_percent = rotation.runs_percentage(runs)
+        self.total_runs = rotation.TOTAL_RUNS
+        self.num_cards = num_cards
+        if runs > 0:
             self.rotation_msg = 'Rotation is in progress, ends ' + dtutil.display_date(seasons.next_rotation(), 2)
         else:
             self.rotation_msg = 'Rotation is ' + dtutil.display_date(seasons.next_rotation(), 2)
-        if in_rotation:
-            self.in_rotation = in_rotation
-            self.runs, self.runs_percent, self.cards = rotation.read_rotation_files()
-        else:
-            self.cards = []
-        self.num_cards = len(self.cards)
 
     def page_title(self) -> str:
         return 'Rotation'

--- a/discordbot/emoji.py
+++ b/discordbot/emoji.py
@@ -57,7 +57,7 @@ def info_emoji(c: Card, verbose: bool = False, show_legality: bool = True, no_ro
         else:
             s += ':no_entry_sign:'
         if rotation.in_rotation() and not no_rotation_hype:
-            rot_emoji = get_future_legality(c, legal)
+            rot_emoji = get_future_legality(c)
             s += rot_emoji
         if not legal and verbose and not rot_emoji:
             s += f' (not legal in {legality_format})'
@@ -66,7 +66,7 @@ def info_emoji(c: Card, verbose: bool = False, show_legality: bool = True, no_ro
         s += ':lady_beetle:'
     return s
 
-def get_future_legality(c: Card, legal: bool) -> str:
+def get_future_legality(c: Card) -> str:
     out_emoji = '<:rotating_out:702545628882010183>'
     for status, symbol in {'undecided': ':question:', 'legal': '<:rotating_in:702545611597021204>', 'notlegal': out_emoji}.items():
         if redis.sismember(f'decksite:rotation:summary:{status}', c.name):

--- a/find/find_test.py
+++ b/find/find_test.py
@@ -655,17 +655,15 @@ def test_parse_season() -> None:
     assert search.parse_season('pd1') == 'EMN'
 
 def do_functional_test(query: str, yes: list[str], no: list[str], check_scryfall: bool = False) -> None:
-    results = search.search(query)
-    found = [c.name for c in results]
+    found = search.search(query)
     for name in yes:
         assert name in found
     for name in no:
         assert name not in found
     if check_scryfall:
         _, scryfall_names, _ = fetcher.search_scryfall(query)
-        print(scryfall_names)
-        print([c.name for c in results[:len(scryfall_names)]])
-        assert [c.name for c in results[:len(scryfall_names)]] == scryfall_names
+        expected = set(scryfall_names)
+        assert expected == found  # If you're getting a test failure here but your query isn't wrong, per se, it's because you're checking scryfall on something with too many results.
 
 def do_test(query: str, expected: str) -> None:
     where = search.parse(search.tokenize(query))

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -45,7 +45,7 @@ async def init_async(force: bool = False) -> bool:
         print('Unable to connect to Scryfall.')
     return False
 
-def cached_base_query(where: str = '(1 = 1)') -> str:
+def cached_base_query(where: str = 'TRUE') -> str:
     return f'SELECT * FROM _cache_card AS c WHERE {where}'
 
 def base_query(where: str = '(1 = 1)') -> str:

--- a/magic/rotation_test.py
+++ b/magic/rotation_test.py
@@ -1,116 +1,48 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory, TemporaryFile
+
 import pytest
 
 from magic import rotation
 from magic.models import Card
+from shared import configuration
+from shared.pd_exception import InvalidDataException
 
 
-def test_hits_needed_score() -> None:
-    assert rotation.hits_needed_score(Card({'name': 'Test', 'status': 'Undecided', 'hits': 33})) == 135
-    assert rotation.hits_needed_score(Card({'name': 'Test', 'status': 'Undecided', 'hits': 1})) == 167
-    assert rotation.hits_needed_score(Card({'name': 'Test', 'status': 'Legal', 'hits': 84})) == 252
-    assert rotation.hits_needed_score(Card({'name': 'Test', 'status': 'Legal', 'hits': 130})) == 298
-    assert rotation.hits_needed_score(Card({'name': 'Test', 'status': 'Legal', 'hits': 168})) == 336
-    assert rotation.hits_needed_score(Card({'name': 'Test', 'status': 'Not Legal', 'hits': 83})) == 421
-    assert rotation.hits_needed_score(Card({'name': 'Test', 'status': 'Not Legal', 'hits': 1})) == 503
+def test_last_run_number() -> None:
+    # Mess with config so we can test this without relying on local settings
+    try:
+        real_legality_dir = configuration.get_str('legality_dir')
+    except InvalidDataException:
+        real_legality_dir = None
 
-def test_rotation_sort_func() -> None:
-    # First, set up the test data we are going to use. An imaginary scenario 120 runs in to the rotation process.
-    num_runs_so_far = 120
-    remaining_runs = rotation.TOTAL_RUNS - num_runs_so_far
-    target = rotation.TOTAL_RUNS / 2
-    cs = [
-        Card({'name': 'Sylvan Library', 'hit_in_last_run': True, 'hits': 30}),
-        Card({'name': 'Black Lotus', 'hit_in_last_run': True, 'hits': 10}),
-        Card({'name': 'Murderous Cut', 'hit_in_last_run': False, 'hits': 90}),
-        Card({'name': 'Wrenn and Six', 'hit_in_last_run': True, 'hits': 90}),
-        Card({'name': 'Abandon Hope', 'hit_in_last_run': True, 'hits': 90}),
-        Card({'name': 'Channel', 'hit_in_last_run': False, 'hits': 20}),
-        Card({'name': 'Brain in a Jar', 'hit_in_last_run': True, 'hits': 60}),
-        Card({'name': 'Firebolt', 'hit_in_last_run': False, 'hits': 40}),
-        Card({'name': 'Charming Prince', 'hit_in_last_run': True, 'hits': 80}),
-        Card({'name': 'Life from the Loam', 'hit_in_last_run': True, 'hits': 50}),
-        Card({'name': 'Fury Charm', 'hit_in_last_run': False, 'hits': 70}),
-        Card({'name': 'Dark Confidant', 'hit_in_last_run': True, 'hits': 100}),
-        Card({'name': 'Colossal Dreadmaw', 'hit_in_last_run': True, 'hits': 1}),
-    ]
-    for c in cs:
-        c.hits_needed = max(target - c.hits, 0)
-        c.percent_needed = str(round(round(c.hits_needed / remaining_runs, 2) * 100))
-        if c.hits_needed == 0:
-            c.status = 'Legal'
-        elif c.hits_needed < remaining_runs:
-            c.status = 'Undecided'
-        else:
-            c.status = 'Not Legal'
+    # If the dir doesn't exist we return None
+    configuration.CONFIG['legality_dir'] = 'total_gibberish'
+    assert rotation.last_run_number() is None
 
-    rotation.rotation_sort(cs, 'hitInLastRun', 'DESC')
-    # Hit in last run and still possible to make it, but not yet confirmed, most hits first.
-    assert cs[0].name == 'Charming Prince'
-    assert cs[1].name == 'Brain in a Jar'
-    assert cs[2].name == 'Life from the Loam'
-    # Followed by hit in last run and confirmed, least hits first.
-    assert cs[3].name == 'Abandon Hope'
-    assert cs[4].name == 'Wrenn and Six'
-    assert cs[5].name == 'Dark Confidant'
-    # Hit in last run but eliminated, most hits first.
-    assert cs[6].name == 'Sylvan Library'
-    assert cs[7].name == 'Black Lotus'
-    assert cs[8].name == 'Colossal Dreadmaw'
-    # No hit in last run but still possible to make it, most hits first.
-    assert cs[9].name == 'Fury Charm'
-    assert cs[10].name == 'Firebolt'
-    # No hit in last run but confirmed, least hits first
-    assert cs[11].name == 'Murderous Cut'
-    # No hit in last run, confirmed out, most hits first.
-    assert cs[12].name == 'Channel'
+    # If the dir exists, but it is empty, we return None
+    with TemporaryDirectory() as tmpdir:
+        configuration.CONFIG['legality_dir'] = tmpdir
+        assert rotation.last_run_number() is None
 
-    rotation.rotation_sort(cs, 'hits', 'DESC')
-    assert cs[0].name == 'Dark Confidant'
-    assert cs[1].name == 'Abandon Hope'
-    assert cs[2].name == 'Murderous Cut'
-    assert cs[3].name == 'Wrenn and Six'
-    assert cs[4].name == 'Charming Prince'
-    assert cs[5].name == 'Fury Charm'
-    assert cs[6].name == 'Brain in a Jar'
-    assert cs[7].name == 'Life from the Loam'
-    assert cs[8].name == 'Firebolt'
-    assert cs[9].name == 'Sylvan Library'
-    assert cs[10].name == 'Channel'
-    assert cs[11].name == 'Black Lotus'
-    assert cs[12].name == 'Colossal Dreadmaw'
+        # We ignore files that aren't named Run_xxx.txt
+        TemporaryFile(dir=tmpdir)
+        assert rotation.last_run_number() is None
 
-    rotation.rotation_sort(cs, 'hitsNeeded', 'ASC')
-    # First we expect the cards that are nearly there, closest first.
-    assert cs[0].name == 'Charming Prince'  # 80 / 120
-    assert cs[1].name == 'Fury Charm'       # 70 / 120
-    assert cs[2].name == 'Brain in a Jar'   # …
-    assert cs[3].name == 'Life from the Loam'
-    assert cs[4].name == 'Firebolt'
-    # Then cards that have made it, least hits first, to maximize the chance of showing cards that recently made it in near the top.
-    assert cs[5].name == 'Abandon Hope'
-    assert cs[6].name == 'Murderous Cut'
-    assert cs[7].name == 'Wrenn and Six'
-    assert cs[8].name == 'Dark Confidant'
-    # Then cards that have been eliminated, most hits first.
-    assert cs[9].name == 'Sylvan Library'
-    assert cs[10].name == 'Channel'
-    assert cs[11].name == 'Black Lotus'
-    assert cs[12].name == 'Colossal Dreadmaw'
+        # When there are run files we find the latest
+        for i in range(1, 4):
+            Path(tmpdir + f'/Run_00{i}.txt').touch()
+        assert rotation.last_run_number() == 3
 
-    rotation.rotation_sort(cs, 'name', 'ASC')
-    assert cs[0].name == 'Abandon Hope'
-    assert cs[1].name == 'Black Lotus'
-    assert cs[2].name == 'Brain in a Jar'
-    assert cs[3].name == 'Channel'
-    assert cs[4].name == 'Charming Prince'
-    assert cs[5].name == 'Colossal Dreadmaw'
-    assert cs[6].name == 'Dark Confidant'
-    assert cs[7].name == 'Firebolt'
-    assert cs[8].name == 'Fury Charm'
-    assert cs[9].name == 'Life from the Loam'
-    assert cs[10].name == 'Murderous Cut'
-    assert cs[11].name == 'Sylvan Library'
-    assert cs[12].name == 'Wrenn and Six'
+        # If there's an unexpected set of files we just return the highest
+        Path(tmpdir + '/Run_101.txt').touch()
+        Path(tmpdir + '/Run_020.txt').touch()
+        Path(tmpdir + '/Run_019.txt').touch()
+        assert rotation.last_run_number() == 101
+
+    # Clean up after ourselves
+    if real_legality_dir:
+        configuration.CONFIG['legality_dir'] = real_legality_dir
 
 @pytest.mark.functional
 def test_list_of_most_interesting() -> None:

--- a/magic/seasons.py
+++ b/magic/seasons.py
@@ -140,6 +140,9 @@ def current_season_num() -> int:
 def current_season_name() -> str:
     return f'Penny Dreadful {current_season_code()}'
 
+def next_season_num() -> int:
+    return current_season_num() + 1
+
 def season_num(code_to_look_for: str) -> int:
     try:
         return SEASONS.index(code_to_look_for) + 1


### PR DESCRIPTION
To facilitate this:

  * Create a _rotation table that holds exactly what /rotation needs, all pre-
    calculated (modulo card search which is done against cards db not decksite
    and cannot be known before query time because it involves user input).
    This table is built preaggregation-style from rotation_runs (see below).

  * Create a rotation_runs table that semipermanently holds the same information
    as the Run_xxx.txt rotation files. To make the Run_xxx.txt the arbiter of
    truth we do actually DELETE FROM for the current rotation run every time
    we re-cache rotation (in case we have manually edited the files) although
    we could remove the DELETE FROM and it would work entirely incrementally.
    I did it this way by analogy with how we treat redis. But we could move to
    the incremental style (which is much faster to get to a new _rotation,
    especially towards the end of the season when there's >2M rows to insert).
    If we did that we'd need to know that if we manually edit the rotation files
    we have to delete those runs from rotation_runs to see the effects on
    decksite. Safer but slower for now. rotation_runs never touches past season
    data so that will just sit there going forward. We could even backpopulate
    it if it were useful for anything.

  * Query _rotation in /api/rotation/cards and don't touch redis. Pulling the
    information out of redis involves passing a huge amount of data and then
    creating about 14,000 Container objects to then sort in-memory. This was
    taking at least 600ms and rising to many seconds if you click the "next
    page" icon over and over again quickly. Doing the query against the
    _rotation table we're able to apply the sort at query time and only
    manipulate pageSize number of objects in memory (thanks to the LIMIT). I
    haven't seen this take more than 300ms even with fairly complex scryfall
    queries involved, or queries that return large numbers of cards.

  * Hook up /api/rotation/clear_cache to a full rebuild of rotation_runs (for
    this season) and _rotation (in toto) so that when a rotation run finishes
    everything gets updated and not on user time.

  * Have search.search return a set of card names, not Card objects. We almost
    always just immediately use the output here in a SQL query WHERE clause
    using only the names. Where we don't we can easily vivify from oracle.CARDS.
    This is significant to performance because a search like `f:vintage` would
    create and update 27,000 Container objects. A set rather than a list because
    a search either matches a card or it doesn't and it makes lookup O(1). This
    may need to change back to a list if we introduce the concept of an order
    in searches, like Scryfall has.

  * Alter the Rotation view to have the information it needs passed in rather
    than calling the redis-backed stuff in the view. It gets it from _rotation
    and not from redis now.

  * In a surfeit of caution make all this stuff just kind of no-op if we're not
    currently in a rotation. I'm worried that otherwise we might start slurping
    up "last season's" files or something. This is probably unnecessary.

  * Move a little of the display prep for /rotation in prepare_card. Most cards
    don't have rotation information but I think it's probably nicer to treat
    these things as Cards not have a new thing RotationCard or similar but I'm
    not sure.

  * Update the definition of is:checkland because I found a bug.
