### PR TITLE
Store Scryfall's oracle_id in cards db and emit it in /api/cardfeed

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -241,7 +241,7 @@ def cardfeed_api() -> Response:
         # Scryfall requested this naming convention for these layouts even though that is not our standard for them.
         if send_scryfall_two_names(c.layout):
             name = ' // '.join(c.names)
-        os.append({'name': name, 'rank': rank, 'legal': bool(c.pd_legal)})
+        os.append({'name': name, 'oracle_id': c.oracle_id, 'rank': rank, 'legal': bool(c.pd_legal)})
     r = {'cards': os}
     return return_camelized_json(r)
 

--- a/decksite/controllers/resources.py
+++ b/decksite/controllers/resources.py
@@ -1,4 +1,4 @@
-from flask import Response, make_response, request, redirect, url_for
+from flask import Response, make_response, redirect, request, url_for
 from werkzeug import wrappers
 
 from decksite import APP, SEASONS, auth, get_season_id
@@ -6,7 +6,8 @@ from decksite.cache import cached
 from decksite.data import playability
 from decksite.data import rotation as rtn
 from decksite.league import DeckCheckForm
-from decksite.views import Bugs, DeckCheck, LinkAccounts, Resources, Rotation, RotationChanges, RotationSpeculation
+from decksite.views import (Bugs, DeckCheck, LinkAccounts, Resources, Rotation, RotationChanges,
+                            RotationSpeculation)
 from magic import card, oracle
 from magic import rotation as rot
 

--- a/magic/abc/card_description.py
+++ b/magic/abc/card_description.py
@@ -22,6 +22,7 @@ class CardDescription(TypedDict, total=False):
     life_modifier: str
     loyalty: str
     mana_cost: str
+    oracle_id: str
     oracle_text: str
     power: str
     name: str
@@ -32,7 +33,7 @@ class CardDescription(TypedDict, total=False):
     type_line: str
     watermark: str
     flavor_name: NotRequired[str]
-    # …and parts we don't. Some of these are typed other than str because of the usage in mutliverse_test which uses real data from Scryfall.
+    # …and parts we don't. Some of these are typed other than str because of the usage in multiverse_test which uses real data from Scryfall.
     arena_id: str
     artist_ids: list[str]
     booster: bool
@@ -55,7 +56,6 @@ class CardDescription(TypedDict, total=False):
     multiverse_ids: list[int]
     nonfoil: bool
     object: str
-    oracle_id: str
     oversized: bool
     printed_name: str
     printed_text: str

--- a/magic/card.py
+++ b/magic/card.py
@@ -30,6 +30,7 @@ DATE = 'INTEGER'
 INTEGER = 'INTEGER'
 REAL = 'REAL'
 TEXT = 'LONGTEXT'
+UUID = 'CHAR(36)'
 VARCHAR = f'VARCHAR({MAX_LEN_VARCHAR})'
 
 BASE: ColumnDescription = {
@@ -81,12 +82,14 @@ def base_query_specific_properties() -> TableDescription:
 
 def card_properties() -> TableDescription:
     props = {}
-    for k in ['id', 'layout']:
+    for k in ['id', 'oracle_id', 'layout']:
         props[k] = copy.deepcopy(BASE)
     props['id']['type'] = INTEGER
     props['id']['nullable'] = False
     props['id']['primary_key'] = True
     props['id']['scryfall'] = False
+    props['oracle_id']['type'] = UUID
+    props['oracle_id']['unique'] = True
     props['layout']['nullable'] = False
     return props
 
@@ -144,6 +147,7 @@ def printing_properties() -> TableDescription:
         props[k]['scryfall'] = False
     props['id']['primary_key'] = True
     props['id']['nullable'] = False
+    props['system_id']['type'] = UUID
     props['reserved']['type'] = BOOLEAN
     props['card_id']['foreign_key'] = ('card', 'id')
     props['set_id']['foreign_key'] = ('set', 'id')

--- a/magic/database.py
+++ b/magic/database.py
@@ -9,7 +9,7 @@ from shared.database import Database, get_database
 from shared.pd_exception import DatabaseException
 
 # Bump this if you modify the schema.
-SCHEMA_VERSION = 108
+SCHEMA_VERSION = 109
 DATABASE = Container()
 
 def db() -> Database:

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -136,7 +136,6 @@ def base_query_lite() -> str:
 
 
 async def update_database_async(new_date: datetime.datetime) -> None:
-    sets, all_cards = [], []
     try:
         sets = await fetcher.all_sets_async()
         if os.path.exists('scryfall-default-cards.json'):
@@ -256,7 +255,7 @@ async def determine_values_async(printings: list[CardDescription], next_card_id:
             card_id = next_card_id
             next_card_id += 1
             cards[p['name']] = card_id
-            card_values.append({'id': card_id, 'layout': p['layout']})
+            card_values.append({'id': card_id, 'oracle_id': p['oracle_id'], 'layout': p['layout']})
 
             if is_meld_result(p):  # We don't make entries for a meld result until we know the card_ids of the front faces.
                 meld_result_printings.append(p)


### PR DESCRIPTION
This will help with issues like 'Pick Your Poison' and 'Red Herring' being two
different cards as happened earlier in the year.

Fixes #11974.
