### PR TITLE
Fix emoji on Safari and iOS/Chrome, fix font on iOS/Chrome charts

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -165,8 +165,8 @@ footer a:hover {
 /* Fonts */
 
 :root {
-    --heading-font-family: heading-caps, main-text, "Noto Emoji", Symbola, "Noto Sans CJK TC Regular", "Noto Sans Armenian", "Noto Sans Canadian Aboriginal", "Noto Sans Sinhala UI", "Noto Sans Thai", Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    --main-text-font-family: main-text, "Noto Emoji", Symbola, "Noto Sans CJK TC Regular", "Noto Sans Armenian", "Noto Sans Canadian Aboriginal", "Noto Sans Sinhala UI", "Noto Sans Thai", Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    --heading-font-family: "Noto Emoji", Symbola, "Noto Sans CJK TC Regular", "Noto Sans Armenian", "Noto Sans Canadian Aboriginal", "Noto Sans Sinhala UI", "Noto Sans Thai", heading-caps, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    --main-text-font-family: "Noto Emoji", Symbola, "Noto Sans CJK TC Regular", "Noto Sans Armenian", "Noto Sans Canadian Aboriginal", "Noto Sans Sinhala UI", "Noto Sans Thai", main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 @font-face {


### PR DESCRIPTION
Yeah, this was a confusing one. But this does seem to fix both things.

https://stackoverflow.com/questions/78433446/chrome-macos-and-firefox-macos-are-able-to-render-a-string-with-glyphs-from-two/78434346

Fixes #12446.
