### PR TITLE
Don't allow commit to master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: requirements-txt-fixer
+    -   id: no-commit-to-branch
+        args: [-b, master]
     # -   id: pretty-format-json
     #     args:
     #     - --autofix


### PR DESCRIPTION
We already have branch protection at GitHub but this'll save me some `git reset
HEAD~1` action.
