### PR TITLE
Preload images for cards from top-left not bottom-right

### DIFF
--- a/shared_web/static/js/tooltips.js
+++ b/shared_web/static/js/tooltips.js
@@ -292,7 +292,7 @@ Deckbox._ = {
     },
 
     preloadImages: function() {
-        const cardElements = Array.from(document.querySelectorAll(".card")).reverse();
+        const cardElements = Array.from(document.querySelectorAll(".card"));
         for (let i = 0; i < cardElements.length; i++) {
             const link = cardElements[i];
             if (Deckbox._.needsTooltip(link)) {


### PR DESCRIPTION
When you're paginating furiously it's possible you'll start mousing over at
the bottom of the list but in general it's either the first page of results or
you're on a decklist and top makes more sense.
