### PR TITLE
Bring logs into line with new menu style

### DIFF
--- a/logsite/templates/footer.mustache
+++ b/logsite/templates/footer.mustache
@@ -1,4 +1,8 @@
-        </main>
+            </main>
+        </div> {{! .page }}
+        <nav>
+            {{> menu}}
+        </nav>
         {{> jsdependencies}}
         <script defer src="/static/js/tipped.min.js"></script> {{* The latest, open source (pro) version of Tipped is not on any CDN. }}
         <script defer src="{{js_url}}"></script>

--- a/logsite/templates/header.mustache
+++ b/logsite/templates/header.mustache
@@ -18,12 +18,11 @@
         {{/og_title}}
     </head>
     <body>
-        <header>
-            {{> language_switcher}}
-            <h1><a href="{{home_url}}">PDBot Stats</a></h1>
-        </header>
-        <nav>
-            {{> menu}}
-        </nav>
-        <main>
-            <h1>{{page_title}}</h1>
+        <div class="page">
+            <header>
+                <div class="hamburger">☰</div>
+                {{> language_switcher}}
+                <h1><a href="{{home_url}}">PDBot Stats</a></h1>
+            </header>
+            <main>
+                <h1>{{page_title}}</h1>

--- a/logsite/templates/menu.mustache
+++ b/logsite/templates/menu.mustache
@@ -1,7 +1,7 @@
 <ul class="menu badges">
     {{#menu}}
         <li>
-            <a class="menuitem" href="{{url}}">{{name}}</a>
+            <a class="item" href="{{url}}">{{name}}</a>
             {{#badge}}
                 <span class="badge"><a href="{{url}}">{{text}}</a></span>
             {{/badge}}

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -328,6 +328,7 @@ html, body {
     display: flex;
     height: 100vh;
     overflow: hidden;
+    width: 100%;
 }
 
 nav, .page {


### PR DESCRIPTION
Add a 100% width to .page because only the footer having a bunch of sections is ensuring this currently (which isn't true on logs).
