### PR TITLE
Show admin menu for demimods

### DIFF
--- a/decksite/__init__.py
+++ b/decksite/__init__.py
@@ -82,7 +82,7 @@ def build_menu() -> list[dict[str, str | dict[str, str]]]:
             {'name': gettext('Community Guidelines'), 'endpoint': 'community_guidelines'},
             {'name': gettext('Contact Us'), 'endpoint': 'contact_us'},
         ]},
-        {'name': gettext('Admin'), 'admin_only': True, 'endpoint': 'admin_home', 'submenu': admin.admin_menu()},
+        {'name': gettext('Admin'), 'demimod_only': True, 'endpoint': 'admin_home', 'submenu': admin.admin_menu()},
     ]
     setup_links(menu)
     for item in menu:

--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -28,8 +28,14 @@ def admin_menu() -> list[dict[str, str]]:
     endpoints = sorted([rule.endpoint for rule in APP.url_map.iter_rules() if rule.methods and 'GET' in rule.methods and rule.rule.startswith('/admin')])
     for endpoint in endpoints:
         name = titlecase.titlecase(endpoint.replace('_', ' ')) if endpoint else 'Admin Home'
-        m.append({'name': name, 'endpoint': endpoint, 'url': url_for(endpoint)})
-    m.append({'name': gettext('Rotation Speculation'), 'endpoint': 'rotation_speculation'})
+        m.append({
+            'name': name,
+            'endpoint': endpoint,
+            'url': url_for(endpoint),
+            'admin_only': True,
+            'demimod_only': name == 'Edit Archetypes',
+        })
+    m.append({'name': gettext('Rotation Speculation'), 'endpoint': 'rotation_speculation', 'admin_only': True, 'demimod_only': False})
     return m
 
 @APP.route('/admin/')

--- a/decksite/templates/footer.mustache
+++ b/decksite/templates/footer.mustache
@@ -2,10 +2,10 @@
             </main>
             <footer>
                 {{#menu}}
-                    <section {{#admin_only}}class="admin"{{/admin_only}}>
+                    <section class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}">
                         <p><b><a class="menuitem" href="{{url}}">{{name}}</a></b></p>
                         {{#submenu}}
-                            <p><a {{#is_external}}class="external"{{/is_external}} href="{{url}}">{{name}}</a></p>
+                            <p class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}"><a {{#is_external}}class="external"{{/is_external}} href="{{url}}">{{name}}</a></p>
                         {{/submenu}}
                     </section>
                 {{/menu}}

--- a/decksite/templates/menu.mustache
+++ b/decksite/templates/menu.mustache
@@ -1,6 +1,6 @@
 <ul class="menu badges">
     {{#menu}}
-        <li class="{{#admin_only}}admin{{/admin_only}}">
+        <li class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}">
             {{#badge}}
                 <div class="badge-holder">
                     <span class="admin demimod badge {{badge_class}}"><a href="{{url}}">{{text}}</a></span>
@@ -14,7 +14,7 @@
                 <div class="submenu">
                     <ul>
                         {{#submenu}}
-                             <li><a class="item {{#current}}current{{/current}} {{#is_external}}external{{/is_external}}" href="{{url}}">{{name}}</a></li>
+                             <li class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}"><a class="item {{#current}}current{{/current}} {{#is_external}}external{{/is_external}}" href="{{url}}">{{name}}</a></li>
                         {{/submenu}}
                     </ul>
                 </div>


### PR DESCRIPTION
Hiding it entirely is dubiously desirable and harder to achieve so show just
the Edit Archetypes option to demimods.
