### PR TITLE
Add UNIQUE constraint on permission_changes

### DIFF
--- a/decksite/sql/73.sql
+++ b/decksite/sql/73.sql
@@ -1,0 +1,1 @@
+ALTER TABLE permission_changes ADD CONSTRAINT unique_discord_id UNIQUE (discord_id);


### PR DESCRIPTION
It doesn't make sense that we should be changing someone's perms to two
different things, so prevent snafus with this.
git add
