### PR TITLE
Restore full width of marginalia

### DIFF
--- a/find/search.py
+++ b/find/search.py
@@ -421,7 +421,7 @@ def is_subquery(subquery_name: str) -> str:
     subqueries = {
         'bikeland': 't:land o:"Cycling {2}" ci=2',
         'bounceland': 't:land (o:"When ~ enters the battlefield, return a land you control to its owner\'s hand" OR o:/When ~ enters the battlefield, sacrifice it unless you return an untapped .* you control to its owner\'s hand/)',
-        'canopyland': 'o:"{T}, Pay 1 life: Add" o:"{1}, {T}, Sacrifice ~: Draw a card."',
+        'canopyland': 'o:"{T}, Pay 1 life: Add {" o:"{1}, {T}, Sacrifice ~: Draw a card."',
         'commander': 't:legendary (t:creature OR o:"~ can be your commander") f:commander',
         'checkland': 't:land ci=2 fo:/unless you control an? (Plains|Island|Swamp|Mountain|Forest)/',
         'companion': 'o:"Companion — "',

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1021,7 +1021,7 @@ main table a:hover {
 }
 
 table.with-marginalia {
-    margin-left: -4.126em; /* Width of .marginalia + left-padding + right-padding */
+    margin-left: -5.126em; /* Width of .marginalia + left-padding + right-padding */
 }
 
 @media only screen and (max-width: 900px) {
@@ -2914,7 +2914,7 @@ The old menu used to use most of this, now it's just used by the language switch
 
 @media only screen and (min-width: 641px) and (max-width: 800px) {
     .language-menu {
-        padding: 0 1rem 0 3.845rem; /* (width of .marginalia (4em) + padding-left + padding-right) * font-size (0.75) */
+        padding: 0 1rem 0 4.845rem; /* (width of .marginalia (4em) + padding-left + padding-right) * font-size (0.75) */
     }
 }
 


### PR DESCRIPTION
I reduced this when I added the menu but it causes alignment issues between h2 section headings and tables with marginalia.

A three star deck will now be kind of too close to anything on the left but we can live with this for now. A new grid is coming soon, I think.
