### PR TITLE
Float buttons right not left so they hug the right when they wrap under

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1747,7 +1747,7 @@ ul.buttons > li {
 }
 
 .banner ul.buttons > li {
-    float: left;
+    float: right;
 }
 
 /* When the buttons are links we want the whole button to be the link. */


### PR DESCRIPTION
This makes it so that the season chooser doesn't get obscured until somewhere
below 360px width and remains usable even at 320px width instead of disappearing
off the side of the screen.
