### PR TITLE
Improvements to the archetype history chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,54 +1,114 @@
-.idea/
+# Most of this file is documented with the reasons something is ignored but I
+# don't remember or never knew what these few were for. Don't add here!
+/TestResults.xml
+ffmpeg.exe
+my_doodle.py
+test_results.xml
+/src/pystache/
+/configs/*
+/.hypothesis/
+
+## Our stuff
+
+# Configuration files
+config.json
+/*.config.json
+/.env
+
+# Various caches used by apps in the repo
+.is-spikey.txt
+/images/*.jpg
+/images/*.png
+.cache/
+# The old CMC charts. These are now dynamic with Chart.js and don't use pngs.
+decksite/images/*-cmc.png
+# Pretty sure this one is no longer in use but it's still in configuration.py
+.web_cache/
+
+# JS build output
+shared_web/static/dist/
+
+# Dev db output
+shared_web/static/dev-db.sql.gz
+
+# Search index
+whoosh_index/
+
+# Task locking
+/.task.lock
+
+# i18n
 *.mo
 *.po
+
+# modo-bugs makes its own checkout of the repo to do its thing
+/modo_bugs_repo/
+
+# Scripts
+/codecov.sh
+
+## Data stuff
+
+# Scryfall
+/scryfall-default-cards.json
+
+# MTGJSON
+AllCards-x.json
+AllSets.json
+
+## OS stuff
+
+# MacOS
+.DS_Store
+
+# Windows
+Thumbs.db
+
+## Programming language and framework stuff
+
+# Python
 *.py,cover
 *.pyc
-*.sqlite
-.DS_Store
-.cache/
-.coverage
-.is-spikey.txt
+
+# Node
+node_modules/
+
+# MyPy
 .mypy_cache
+.mypy_cache/
+
+# PyTest
 .pytest_cache/
+
+# Codecov
+.coverage
+coverage.xml
+
+# Old sqlite stuff that we really don't need any more
+spellfix.*
+sqlite3.h
+sqlite3ext.h
+*.sqlite
+/monkeytype.sqlite3
+meta.sqlite
+# Pretty sure these were the sqlite db names or something, probably not needed
+magic.db
+db
+decksite.db
+prices.db
+
+## IDE stuff
+
+# PyCharm
+.idea/
+
+# pyright, Python LSP
+pyrightconfig.json
+
+# VS Code
 .vs/
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
-.web_cache/
-/*.config.json
-.mypy_cache/
-/TestResults.xml
-/codecov.sh
-/images/*.jpg
-/images/*.png
-/modo_bugs_repo/
-/monkeytype.sqlite3
-AllCards-x.json
-AllSets.json
-Thumbs.db
-config.json
-coverage.xml
-db
-decksite.db
-decksite/images/*-cmc.png
-ffmpeg.exe
-magic.db
-meta.sqlite
-my_doodle.py
-node_modules/
-prices.db
-shared_web/static/dist/
-shared_web/static/dev-db.sql.gz
-spellfix.*
-sqlite3.h
-sqlite3ext.h
-test_results.xml
-whoosh_index/
-/scryfall-default-cards.json
-/.env
-/src/pystache/
-/configs/*
-/.hypothesis/
-/.task.lock

--- a/decksite/templates/archetype.mustache
+++ b/decksite/templates/archetype.mustache
@@ -13,11 +13,9 @@
     {{> livecardtable}}
 </section>
 {{#history_chart}}
-    <section>
+    <section class="history-chart">
         <h2>History</h2>
-        <div style="position: relative; width:80vw; max-width: 60rem">
-            <canvas class="chart" data-type="{{type}}" data-labels="{{labels}}" data-series="{{series}}" data-options="{{options}}"></canvas>
-        </div>
+        <canvas class="chart" data-type="{{type}}" data-labels="{{labels}}" data-series="{{series}}" data-options="{{options}}"></canvas>
     </section>
 {{/history_chart}}
 {{#show_record}}

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -356,7 +356,7 @@ nav {
 }
 
 header, main, footer, .status-bar {
-    padding: 0 32px 0 calc(96rem / 20); /* padding not margin because we want colors to bleed all the way to the edge of the window. */
+    padding: 0 var(--spacing-page-with-marginalia) 0 var(--spacing-page-with-marginalia); /* padding not margin because we want colors to bleed all the way to the edge of the window. */
 }
 
 /* Minimal spacing around the content on extra-small displays. */
@@ -513,6 +513,7 @@ This stuff is in transition. We've just made a start on having consistent spacin
 */
 
 :root {
+    --spacing-page-with-marginalia: calc(96rem / 20);
     --spacing-text: calc(8rem / 20);
 }
 

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2657,6 +2657,12 @@ p.detail .text {
     position: relative;
 }
 
+/*
+
+Metagame
+
+*/
+
 :root {
     --metagame-tile-side-border: calc(8rem / 20);
 }
@@ -2886,7 +2892,7 @@ From https://codepen.io/mallendeo/pen/eLIiG
 
 /*
 
-Language Switcher
+Language Switcher (Menu)
 
 The old menu used to use most of this, now it's just used by the language switcher.
 

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2986,6 +2986,17 @@ Used for Unique Cards Played and Cards Played First list on person detail page.
 
 /*
 
+Charts
+
+*/
+
+.history-chart {
+    max-width: 60rem;
+    width: 100%;
+}
+
+/*
+
 Tooltips
 
 We used tippedjs for tooltips but we don't want to load their CSS separately so here are the parts we need.


### PR DESCRIPTION
- **Balance margin (actually padding) between left and right on marginalia pages**
- **Better CSS docs**
- **Format tick marks for percentages in a sane fashion**
- **Mostly-document our gitignore**
