### PR TITLE
Make highlit table rows clickable, remove highlighting where that's wrong

### DIFF
--- a/decksite/templates/archetypetree.mustache
+++ b/decksite/templates/archetypetree.mustache
@@ -21,7 +21,7 @@
     <tbody>
         {{#archetypes}}
             {{^hide_archetype}}
-                <tr class="archetype archetype-{{depth}}{{#current}} current{{/current}}">
+                <tr class="archetype archetype-{{depth}}{{#current}} current{{/current}} clickable" data-href="{{url}}">
                     <td data-sort="{{sort}}" class="primary initial"><a href="{{url}}">{{name}}</a></td>
                     {{^is_matchups}}
                         <td class="n">{{num_decks}}</td>

--- a/decksite/templates/competitions.mustache
+++ b/decksite/templates/competitions.mustache
@@ -10,7 +10,7 @@
         <tbody>
             {{#competitions}}
                 {{#num_decks}}
-                    <tr>
+                    <tr data-href="{{competition_url}}" class="clickable">
                         <td><a href="{{competition_url}}">{{{name}}}</a></td>
                         <td class="n" data-sortInitialOrder="desc"><a href="{{competition_url}}">{{{num_decks}}}</a></td>
                         <td data-text="{{date_sort}}"><a href="{{competition_url}}">{{{display_date}}}</a></td>

--- a/decksite/templates/deck.mustache
+++ b/decksite/templates/deck.mustache
@@ -43,7 +43,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr>
+                <tr data-href="{{competition_url}}" class="clickable">
                     <td class="marginalia">{{{stars_safe}}}</td>
                     <td><a href="{{competition_url}}">{{competition_name}}</a></td>
                     <td class="n" ><a href="{{competition_url}}">{{> record}}</a></td>

--- a/decksite/templates/deckmatches.mustache
+++ b/decksite/templates/deckmatches.mustache
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
         {{#matches}}
-            <tr>
+            <tr data-href="{{opponent_deck_url}}" class="clickable">
                 {{#has_rounds}}
                     <td class="n" data-text="{{round}}">{{display_round}}</td>
                 {{/has_rounds}}

--- a/decksite/templates/deckrow.mustache
+++ b/decksite/templates/deckrow.mustache
@@ -1,4 +1,4 @@
-<tr>
+<tr data-href="{{url}}" class="clickable">
     <td class="marginalia">{{{stars_safe}}}</td>
     <td class="contains-mana-bar">{{{colors_safe}}}</td>
     <td><a {{#decklist}}title="{{decklist}}"{{/decklist}}href="{{url}}">{{{name}}}</a></td>

--- a/decksite/templates/editrules.mustache
+++ b/decksite/templates/editrules.mustache
@@ -26,7 +26,7 @@
             </thead>
             <tbody>
                 {{#doubled_decks}}
-                    <tr>
+                    <tr data-href="{{url}}" class="clickable">
                         <td class="contains-mana-bar">{{{colors_safe}}}</td>
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{archetype_url}}">{{archetype_name}}</a></td>
@@ -57,7 +57,7 @@
             </thead>
             <tbody>
                 {{#mistagged_decks}}
-                    <tr>
+                    <tr data-href="{{url}}" class="clickable">
                         <td class="contains-mana-bar">{{{colors_safe}}}</td>
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{archetype_url}}">{{archetype_name}}</a></td>
@@ -85,7 +85,7 @@
             </thead>
             <tbody>
                 {{#overlooked_decks}}
-                    <tr>
+                    <tr data-href="{{url}}" class="clickable">
                         <td class="contains-mana-bar">{{{colors_safe}}}</td>
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{archetype_url}}">{{archetype_name}}</a></td>

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -17,7 +17,7 @@
             </thead>
             <tbody>
                 {{#top_cards}}
-                    <tr>
+                    <tr data-href="{{url}}" class="clickable">
                         <td>{{> singlecard}}</td>
                         <td class="n">{{num_decks}}</td>
                         <td class="n">{{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}</td>

--- a/decksite/templates/personmatches.mustache
+++ b/decksite/templates/personmatches.mustache
@@ -15,7 +15,7 @@
         </thead>
         <tbody>
             {{#matches}}
-                <tr>
+                <tr data-href="{{log_url}}" class="clickable">
                     {{#show_hero}}<td><a href="{{person_url}}">{{person}}</a></td>{{/show_hero}}
                     <td><a href="{{deck_url}}">{{deck_name}}</a></td>
                     <td><a href="{{opponent_url}}">{{opponent}}</a></td>

--- a/decksite/templates/sorters.mustache
+++ b/decksite/templates/sorters.mustache
@@ -11,8 +11,8 @@
         </thead>
         <tbody>
             {{#people}}
-                <tr>
-                    <td class="person">{{name}}</td>
+                <tr data-href="{{url}}" class="clickable">
+                    <td class="person"><a href="{{url}}">{{name}}</a></td>
                     <td class="n">{{num_decks_sorted}}</td>
                     <td class="n">{{sorted_per_day}}</td>
                     <td data-text="{{date_sort}}">{{display_last_sorted}}</td>

--- a/logsite/templates/matchrow.mustache
+++ b/logsite/templates/matchrow.mustache
@@ -1,4 +1,4 @@
-<tr>
+<tr data-href="{{url}}" class="clickable">
     <td class="marginalia">{{{stars_safe}}}</td>
     <td><a href="{{url}}">{{{id}}}</a></td>
     {{#host}}

--- a/logsite/templates/people.mustache
+++ b/logsite/templates/people.mustache
@@ -10,7 +10,7 @@
         </thead>
         <tbody>
             {{#people}}
-                <tr>
+                <tr data-href="{{url}}" class="clickable">
                     <td class="marginalia">{{{stars_safe}}}</td>
                     <td><a href="{{url}}">{{name}}</a></td>
                     <td>{{num_matches}}</td>

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1222,11 +1222,12 @@ div.live {
 
 /* Highlight table rows on hover. */
 
-table:not(.calendar) tr:hover td:not(.marginalia) {
+tr.clickable:hover td:not(.marginalia) {
     background-color: var(--highlight);
+    cursor: pointer;
 }
 
-tr:hover td.marginalia {
+tr.clickable:hover td.marginalia {
     background-color: inherit;
 }
 

--- a/shared_web/static/js/cardtable.jsx
+++ b/shared_web/static/js/cardtable.jsx
@@ -22,7 +22,7 @@ const renderHeaderRow = (table) => (
 );
 
 const renderRow = (table, card) => (
-    <tr key={card.name}>
+    <tr key={card.name}  onClick={() => window.location.href = card.url} className="clickable">
         <td className="name">{renderCard(card)}</td>
         <td className="n">{card.numDecks}</td>
         <td className="n">{renderRecord(card)}</td>

--- a/shared_web/static/js/decktable.jsx
+++ b/shared_web/static/js/decktable.jsx
@@ -37,7 +37,7 @@ const renderHeaderRow = (table) => (
 );
 
 const renderRow = (table, deck) => (
-    <tr key={deck.id}>
+    <tr key={deck.id} onClick={() => window.location.href = deck.url} className="clickable">
         <td className="marginalia" dangerouslySetInnerHTML={{__html: deck.starsSafe}}></td>
         <td className="contains-mana-bar" dangerouslySetInnerHTML={{__html: deck.colorsSafe}} ></td>
         <td className="deck-name"><a title={deck.decklist || null} href={deck.url}>{deck.name}</a></td>

--- a/shared_web/static/js/headtoheadtable.jsx
+++ b/shared_web/static/js/headtoheadtable.jsx
@@ -12,7 +12,7 @@ const renderHeaderRow = (table) => (
 );
 
 const renderRow = (table, entry) => (
-    <tr key={entry.oppMtgoUsername}>
+    <tr key={entry.oppMtgoUsername}  onClick={() => window.location.href = entry.oppUrl} className="clickable">
         <td className="name"><a href={entry.oppUrl}>{entry.oppMtgoUsername}</a></td>
         <td className="n"><a href={entry.url}>{entry.numMatches}</a></td>
         <td className="n">{renderRecord({...entry,...{"showRecord": true}})}</td>

--- a/shared_web/static/js/leaderboardtable.jsx
+++ b/shared_web/static/js/leaderboardtable.jsx
@@ -19,7 +19,7 @@ const renderHeaderRow = (table) => (
 );
 
 const renderRow = (table, entry) => (
-    <tr key={entry.personId}>
+    <tr key={entry.personId}  onClick={() => window.location.href = entry.url} className="clickable">
         <td className="marginalia">{entry.position}</td>
         <td className="name"><a href={entry.url}>{entry.person}</a></td>
         { table.props.skinnyView

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -24,6 +24,7 @@ PD.init = function() {
     ]);
     $(".toggle-illegal").on("change", PD.toggleIllegalCards);
     PD.localizeTimes();
+    PD.initLinks();
     PD.initSignupDeckChooser();
     PD.initPersonalization();
     PD.renderCharts();
@@ -327,6 +328,14 @@ PD.toggleIllegalCards = function() {
 PD.localizeTimes = function() {
     PD.localizeTimeElements();
     PD.hideRepetitionInCalendar();
+};
+
+PD.initLinks = function() {
+    document.querySelectorAll("[data-href]").forEach((elem) => {
+        elem.addEventListener("click", () => {
+            window.location.href = elem.getAttribute("data-href");
+        });
+    });
 };
 
 PD.localizeTimeElements = function() {

--- a/shared_web/static/js/persontable.jsx
+++ b/shared_web/static/js/persontable.jsx
@@ -22,7 +22,7 @@ const renderHeaderRow = (table) => (
 );
 
 const renderRow = (table, person) => (
-    <tr key={person.id}>
+    <tr key={person.id} onClick={() => window.location.href = person.url} className="clickable">
         <td className="name"><a href={person.url}>{person.name}</a></td>
         <td className="n"><a href={person.url}>{person.numDecks}</a></td>
         <td className="n">{renderRecord(person)}</td>

--- a/shared_web/static/js/rotationtable.jsx
+++ b/shared_web/static/js/rotationtable.jsx
@@ -13,7 +13,7 @@ const renderHeaderRow = (table) => (
 );
 
 const renderRow = (table, card) => (
-    <tr key={card.name} className={"legality-" + card.status.toLowerCase().replaceAll(" ", "-")}>
+    <tr key={card.name} className={"legality-" + card.status.toLowerCase().replaceAll(" ", "-") + " clickable"} onClick={() => window.location.href = card.url}>
         <td>
             { card.hitInLastRun
                 ? <span title="Present in last run" className="last-run">↑</span>


### PR DESCRIPTION
There are a few here that need some work in the data part before we can link
them (/admin/bans, /admin/people/notes) and others that have inline form
elements that the simple js interferes with. But most every other table row
in the site that has a sensible default link now links to that place when
clicked anywhere that doesn't explicitly link somewhere else.
