### PR TITLE
Fix /admin/matches in light mode when system in dark mode

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1968,6 +1968,7 @@ form {
 
 button, form, input, select, textarea {
     accent-color: var(--text);
+    background-color: inherit;
     color: inherit;
     font-family: var(--main-text-font-family);
     font-size: inherit;


### PR DESCRIPTION
Anywhere you set a color, also set a background color! This was black-on-black.
