### PR TITLE
Use our standard like escaping in queries always, add "fuzzy" option

### DIFF
--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -6,7 +6,7 @@ from decksite.deck_type import DeckType
 from decksite.tournament import CompetitionFlag
 from find import search
 from magic import rotation
-from shared.database import sqlescape
+from shared.database import sqlescape, sqllikeescape
 from shared.pd_exception import InvalidArgumentException
 
 # Form SQL WHERE, ORDER BY and LIMIT clauses, sometimes by making db queries.
@@ -249,10 +249,11 @@ def decks_where(args: dict[str, str], is_admin: bool, viewer_id: int | None) -> 
     return ') AND ('.join(parts)
 
 def text_where(field: str, q: str) -> str:
-    return f"{field} LIKE '%%" + q.replace("'", "''").replace('%', '\\%%') + "%%'"
+    return f'{field} LIKE {sqllikeescape(q)}'
+
 
 def text_match_where(field: str, q: str) -> str:
-    return f"{field} LIKE '%%" + '%%'.join(c.replace("'", "''").replace('%', '\\%%') for c in list(q)) + "%%'"
+    return f'{field} LIKE {sqllikeescape(q, fuzzy=True)}'
 
 def archetype_where(archetype_id: int) -> str:
     return f'd.archetype_id IN (SELECT descendant FROM archetype_closure WHERE ancestor = {archetype_id})'

--- a/shared/database.py
+++ b/shared/database.py
@@ -177,11 +177,15 @@ def sqlescape(s: ValidSqlArgumentDescription, force_string: bool = False, backsl
         return "'{escaped}'".format(escaped=encodable.replace("'", "''").replace('%', '%%'))
     raise InvalidArgumentException(f'Cannot sqlescape `{s}`')
 
-def sqllikeescape(s: str) -> str:
+def sqllikeescape(s: str, fuzzy: bool = False) -> str:
     if type(s) is not str:
         raise InvalidArgumentException('You can only use LIKE on strings')
-    s = s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+    joiner = '%' if fuzzy else ''
+    s = joiner.join(sqllikeescapesymbols(c) for c in list(s))
     return sqlescape(f'%{s}%', backslashed_escaped=True)
+
+def sqllikeescapesymbols(s: str) -> str:
+    return s.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
 
 def concat(parts: Iterable[str]) -> str:
     return 'CONCAT(' + ', '.join(parts) + ')'

--- a/shared/database_test.py
+++ b/shared/database_test.py
@@ -23,3 +23,6 @@ def test_sqllikeescape() -> None:
     assert sqllikeescape('%') == "'%%\\%%%%'"
     with pytest.raises(InvalidArgumentException):
         sqllikeescape({})  # type: ignore
+    hard = r'What % _chance_ of a \?'
+    assert sqllikeescape(hard) == r"'%%What \%% \_chance\_ of a \\?%%'"
+    assert sqllikeescape(hard, fuzzy=True) == r"'%%W%%h%%a%%t%% %%\%%%% %%\_%%c%%h%%a%%n%%c%%e%%\_%% %%o%%f%% %%a%% %%\\%%?%%'"


### PR DESCRIPTION
Having some separate code that has to know all the pitfalls seems like a bad
idea. No SQL injection possible here but we were failing to escape backslashes.

Now everything uses the same escaping code.
