### PR TITLE
Look for companions in sideboard and not main deck in archetype rules

### DIFF
--- a/decksite/sql/74.sql
+++ b/decksite/sql/74.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rule_card ADD COLUMN sideboard BOOL;
+UPDATE rule_card SET sideboard = FALSE;


### PR DESCRIPTION
A companion essentially IS a maindeck card, so let's treat it much the same
way in the rules system. This messes a little with a couple of existing rules
but not in any important way. And it'd let us do something like "Gruul Obosh"
or make sure Permanent Vacation has Lurrus and not Yorion and that kind of
thing.

We still don't have the ability (via the UI) to actually care about the
sideboard and I think that's fine. We can build it if we need it now that rules
support caring about sideboards.
