### PR TITLE
Try and figure out where charts 404s are coming from

### DIFF
--- a/shared_web/flask_app.py
+++ b/shared_web/flask_app.py
@@ -63,7 +63,8 @@ class PDFlask(Flask):
         if request.path.startswith('/error/HTTP_BAD_GATEWAY'):
             return return_json(generate_error('BADGATEWAY', 'Bad Gateway'), status=502)
         referrer = ', referrer: ' + request.referrer if request.referrer else ''
-        logger.warning('404 Not Found ' + request.path + referrer)
+        remote_addr = ', remote_addr: ' + request.environ.get('REMOTE_ADDR', '') if request.environ.get('REMOTE_ADDR') else ''
+        logger.warning('404 Not Found ' + request.path + referrer + remote_addr)
         if request.path.startswith('/api/'):
             return return_json(generate_error('NOTFOUND', 'Endpoint not found'), status=404)
         view = NotFound(e)


### PR DESCRIPTION
We removed the image charts a long time ago but still get a lot of requests for them. Try and log where these requests originate so we can stop them.
