### PR TITLE
Disable sentry for now as we're not currently using it

### DIFF
--- a/shared_web/flask_app.py
+++ b/shared_web/flask_app.py
@@ -10,14 +10,14 @@ from flask_restx import Api
 from github.GithubException import GithubException
 from werkzeug import exceptions, wrappers
 
-from shared import configuration, logger, repo, sentry
+from shared import configuration, logger, repo
 from shared.pd_exception import DoesNotExistException
 
 from . import api, localization, oauth
 from .api import generate_error, return_json
 from .views import InternalServerError, NotFound, Unauthorized
 
-sentry.init()
+# sentry.init()
 
 class PDFlask(Flask):
     def __init__(self, import_name: str) -> None:


### PR DESCRIPTION
I'm wondering if it's related to the errors we see in decksite log:

Fri Aug 23 01:00:34 2024 - Respawned uWSGI worker 1 (new pid: 1862566)
Fri Aug 23 01:00:34 2024 - spawned 1 offload threads for uWSGI worker 1
Sentry is attempting to send 1 pending events
Waiting up to 2 seconds
Press Ctrl-C to quit
corrupted size vs. prev_size while consolidating

Probably just close to one another because the memory issue causes us to try to send stuff to sentry, or something like that, but worth a try.
