### PR TITLE
Revert "Disable sentry for now as we're not currently using it"

### DIFF
--- a/shared_web/flask_app.py
+++ b/shared_web/flask_app.py
@@ -10,14 +10,14 @@ from flask_restx import Api
 from github.GithubException import GithubException
 from werkzeug import exceptions, wrappers
 
-from shared import configuration, logger, repo
+from shared import configuration, logger, repo, sentry
 from shared.pd_exception import DoesNotExistException
 
 from . import api, localization, oauth
 from .api import generate_error, return_json
 from .views import InternalServerError, NotFound, Unauthorized
 
-# sentry.init()
+sentry.init()
 
 class PDFlask(Flask):
     def __init__(self, import_name: str) -> None:


### PR DESCRIPTION
We're still using it, it's just currently pointed at my personal account

Reverts PennyDreadfulMTG/Penny-Dreadful-Tools#13035