### PR TITLE
Return modo-bugs job to working order (except verification)

### DIFF
--- a/modo_bugs/scrape_forum.py
+++ b/modo_bugs/scrape_forum.py
@@ -36,6 +36,7 @@ def main() -> None:
                 bad.append(url)
 
     for url in bad:
+        print(f'Rejecting {url}')
         del known[url]
 
     with open('forums.json', 'w') as fp:

--- a/modo_bugs/untracked.py
+++ b/modo_bugs/untracked.py
@@ -6,19 +6,20 @@ def main() -> None:
     their_untracked_bugs = [bug for bug in their_bugs.values() if not bug['tracked'] and bug['status'] not in ['Fixed', 'Not A Bug', 'No Fix Planned', 'Could Not Reproduce']]
     our_bugs = fetch_tools.fetch_json('https://raw.githubusercontent.com/PennyDreadfulMTG/modo-bugs/master/bugs.json')
     our_untracked_bugs = [bug for bug in our_bugs if not bug['support_thread']]
-    print("= Possible missing linkage:\n")
+    print('= Possible missing linkage:\n')
     for our_bug in our_untracked_bugs:
         for their_bug in their_untracked_bugs:
             if our_bug['card'] in their_bug['title']:
-                print("Maybe\n", our_bug['description'], "\nis tracked by them as\n", their_bug['title'])
+                print('Maybe\n', our_bug['description'], '\nis tracked by them as\n', their_bug['title'])
                 print(their_bug['url'])
-                print(our_bug['url'] + "\n")
+                print(our_bug['url'] + '\n')
     print("= All of their bugs we aren't tracking:\n")
     for their_bug in their_untracked_bugs:
         print(f'[{their_bug["status"]}] {their_bug["title"]}\n{their_bug["url"]}\n')
     print("= All of our bugs they aren't tracking:\n")
     for our_bug in our_bugs:
         print(f'[{our_bug["card"]}] {our_bug["description"]}\n{our_bug["url"]}\n')
+
 
 if __name__ == '__main__':
     main()

--- a/modo_bugs/untracked.py
+++ b/modo_bugs/untracked.py
@@ -1,0 +1,24 @@
+from shared import fetch_tools
+
+
+def main() -> None:
+    their_bugs = fetch_tools.fetch_json('https://raw.githubusercontent.com/PennyDreadfulMTG/modo-bugs/master/forums.json')
+    their_untracked_bugs = [bug for bug in their_bugs.values() if not bug['tracked'] and bug['status'] not in ['Fixed', 'Not A Bug', 'No Fix Planned', 'Could Not Reproduce']]
+    our_bugs = fetch_tools.fetch_json('https://raw.githubusercontent.com/PennyDreadfulMTG/modo-bugs/master/bugs.json')
+    our_untracked_bugs = [bug for bug in our_bugs if not bug['support_thread']]
+    print("= Possible missing linkage:\n")
+    for our_bug in our_untracked_bugs:
+        for their_bug in their_untracked_bugs:
+            if our_bug['card'] in their_bug['title']:
+                print("Maybe\n", our_bug['description'], "\nis tracked by them as\n", their_bug['title'])
+                print(their_bug['url'])
+                print(our_bug['url'] + "\n")
+    print("= All of their bugs we aren't tracking:\n")
+    for their_bug in their_untracked_bugs:
+        print(f'[{their_bug["status"]}] {their_bug["title"]}\n{their_bug["url"]}\n')
+    print("= All of our bugs they aren't tracking:\n")
+    for our_bug in our_bugs:
+        print(f'[{our_bug["card"]}] {our_bug["description"]}\n{our_bug["url"]}\n')
+
+if __name__ == '__main__':
+    main()

--- a/modo_bugs/update.py
+++ b/modo_bugs/update.py
@@ -68,6 +68,8 @@ def main() -> None:
 
 def verification_numbers() -> None:
     print('Populating Verification Model')
+    print('Skipping this because GitHub projects does not work like this any more :(')
+    return
     project = repo.get_verification_project()
     for col in project.get_columns():
         if col.name == 'Needs Testing':

--- a/modo_bugs/verification.py
+++ b/modo_bugs/verification.py
@@ -7,6 +7,8 @@ from . import repo
 
 
 def main() -> None:
+    print('Verification is currently disabled because GitHub projects does not support this any more')
+    return
     manifest = requests.get('http://mtgo.patch.daybreakgames.com/patch/mtg/live/client/MTGO.application')
     tree = etree.fromstring(manifest.content)
     identity = tree.find('{urn:schemas-microsoft-com:asm.v1}assemblyIdentity')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+asyncio_default_fixture_loop_scope = function
 addopts = -l -ra --durations=2 --cov=./ --cov-report= --junitxml=TestResults.xml
 markers =
     functional: functional tests


### PR DESCRIPTION
- **Workaround issues with github projects and modo-bugs**
- **Avoid warning from test runs by providing required param**
- **A little bit more output when we skip a bug during collection**
