### PR TITLE
Avoid an error when trying to sanitize Ratonhnhaké꞉ton

### DIFF
--- a/shared/text.py
+++ b/shared/text.py
@@ -7,6 +7,8 @@ def sanitize(s: str) -> str:
         s = s.encode('latin-1').decode('utf-8')
     except UnicodeDecodeError:
         pass
+    except UnicodeEncodeError:
+        pass
     return html.unescape(s)
 
 def unambiguous_prefixes(words: list[str]) -> list[str]:


### PR DESCRIPTION
I'm not too sure what happens here but this at least stops things exploding. We
can do more to accommodate the special colon of Ratonhnhaké꞉ton later if
necessary.
