### PR TITLE
Only show archetype table once on competition detail page

### DIFF
--- a/decksite/templates/competition.mustache
+++ b/decksite/templates/competition.mustache
@@ -9,9 +9,9 @@
         {{> liveleaderboardtable}}
     </section>
 {{/has_leaderboard}}
-{{#archetypes}}
+{{#show_archetype_tree}}
     <section>
         <h2>Archetypes</h2>
         {{> archetypetree}}
     </section>
-{{/archetypes}}
+{{/show_archetype_tree}}

--- a/decksite/views/competition.py
+++ b/decksite/views/competition.py
@@ -20,6 +20,7 @@ class Competition(View):
             self.has_leaderboard = True
         self.date = dtutil.display_date(competition.start_date)
         self.archetypes = archetypes
+        self.show_archetype_tree = len(self.archetypes) > 0
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self.competition, attr)


### PR DESCRIPTION
- **Show meta on competition detail page**
- **Only show archetype table once on competition detail page**
