### PR TITLE
Show 5-0s, top 8s and wins on competition detail pages when appropriate

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -41,6 +41,7 @@ def load_competition_archetypes(competition_id: int) -> list[Archetype]:
             IFNULL(SUM(dsum.wins), 0) AS wins,
             IFNULL(SUM(dsum.losses), 0) AS losses,
             IFNULL(SUM(dsum.draws), 0) AS draws,
+            SUM(IFNULL(dsum.wins, 0) - IFNULL(dsum.losses, 0)) AS record,
             SUM(CASE WHEN dsum.wins >= 5 AND dsum.losses = 0 AND d.source_id IN (SELECT id FROM source WHERE name = 'League') THEN 1 ELSE 0 END) AS perfect_runs,
             SUM(CASE WHEN dsum.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN dsum.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,

--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -17,6 +17,7 @@ def load_competition_cards(competition_id: int, order_by: str, limit: str) -> tu
             IFNULL(SUM(dsum.losses), 0) AS losses,
             IFNULL(SUM(dsum.draws), 0) AS draws,
             SUM(IFNULL(dsum.wins, 0) - IFNULL(dsum.losses, 0)) AS record,
+            SUM(CASE WHEN dsum.wins >= 5 AND dsum.losses = 0 AND d.source_id IN (SELECT id FROM source WHERE name = 'League') THEN 1 ELSE 0 END) AS perfect_runs,
             SUM(CASE WHEN dsum.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN dsum.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,
             IFNULL(ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1), '') AS win_percent,

--- a/decksite/templates/archetypetree.mustache
+++ b/decksite/templates/archetypetree.mustache
@@ -7,12 +7,14 @@
             {{/is_matchups}}
             <th data-sortInitialOrder="desc">Record</th>
             <th class="n" data-sortInitialOrder="desc">Win %</th>
-            {{^is_matchups}}<th class="n" data-sortInitialOrder="desc">
-                <abbr title="Tournament wins">①</abbr>
-            </th>{{/is_matchups}}
-            {{^is_matchups}}<th class="n" data-sortInitialOrder="desc">
-                <abbr title="Tournament top-8s">⑧</abbr>
-            </th>{{/is_matchups}}
+            {{^hide_tournament_results}}
+                <th class="n" data-sortInitialOrder="desc">
+                    <abbr title="Tournament wins">①</abbr>
+                </th>
+                <th class="n" data-sortInitialOrder="desc">
+                    <abbr title="Tournament top-8s">⑧</abbr>
+                </th>
+            {{/hide_tournament_results}}
             {{^is_matchups}}{{^hide_perfect_runs}}<th class="n" data-sortInitialOrder="desc">
                 <abbr title="League 5-0 runs">5–0s</abbr>
             </th>{{/hide_perfect_runs}}{{/is_matchups}}
@@ -28,8 +30,10 @@
                     {{/is_matchups}}
                     <td class="n">{{#show_record}}{{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}{{/show_record}}</td>
                     <td class="n">{{#show_record}}{{win_percent}}{{/show_record}}</td>
-                    {{^is_matchups}}<td class="n">{{#tournament_top8s}}{{tournament_wins}}{{/tournament_top8s}}</td>{{/is_matchups}}
-                    {{^is_matchups}}<td class="n">{{#tournament_top8s}}{{tournament_top8s}}{{/tournament_top8s}}</td>{{/is_matchups}}
+                    {{^hide_tournament_results}}
+                        <td class="n">{{#tournament_top8s}}{{tournament_wins}}{{/tournament_top8s}}</td>
+                        <td class="n">{{#tournament_top8s}}{{tournament_top8s}}{{/tournament_top8s}}</td>
+                    {{/hide_tournament_results}}
                     {{^is_matchups}}{{^hide_perfect_runs}}<td class="n">{{#perfect_runs}}{{perfect_runs}}{{/perfect_runs}}</td>{{/hide_perfect_runs}}{{/is_matchups}}
                 </tr>
             {{/hide_archetype}}

--- a/decksite/templates/livecardtable.mustache
+++ b/decksite/templates/livecardtable.mustache
@@ -5,6 +5,7 @@
     data-archetype-id="{{archetype.id}}"
     data-base-query="{{base_query}}"
     data-competition-id="{{competition_id}}"
+    data-league-only="{{#league_only}}1{{/league_only}}"
     data-person-id="{{person.id}}"
     data-season-id="{{season_id}}"
     data-tournament-only="{{#tournament_only}}1{{/tournament_only}}">

--- a/decksite/views/archetype.py
+++ b/decksite/views/archetype.py
@@ -14,6 +14,7 @@ from shared.pd_exception import DoesNotExistException
 
 class Matchups(TypedDict):
     is_matchups: bool
+    hide_tournament_results: bool
     archetypes: list[archs.Archetype]
 
 class Archetype(View):
@@ -30,6 +31,7 @@ class Archetype(View):
                 break
         self.matchups: Matchups = {
             'is_matchups': True,
+            'hide_tournament_results': True,
             'archetypes': copy.deepcopy(archetypes),  # Take a copy of the archetypes, so we can update their stats without interfering with the other section.
         }
         matchups_by_id = {m.id: m for m in matchups}

--- a/decksite/views/competition.py
+++ b/decksite/views/competition.py
@@ -22,6 +22,8 @@ class Competition(View):
         self.date = dtutil.display_date(competition.start_date)
         self.archetypes = archetypes
         self.show_archetype_tree = len(self.archetypes) > 0
+        self.hide_perfect_runs = self.tournament_only = competition.type != 'League'
+        self.league_only = self.hide_tournament_results = competition.type == 'League'
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self.competition, attr)

--- a/shared_web/static/js/cardtable.jsx
+++ b/shared_web/static/js/cardtable.jsx
@@ -40,14 +40,14 @@ const renderRow = (table, card) => (
                     ? card.tournamentWins
                     : ""
                 }
-                </td>
+            </td>
         }
         { table.props.leagueOnly
             ? null
             : <td className="n">
                 { card.tournamentTop8s > 0
-                ? card.tournamentTop8s
-                : ""
+                    ? card.tournamentTop8s
+                    : ""
                 }
             </td>
         }

--- a/shared_web/static/js/cardtable.jsx
+++ b/shared_web/static/js/cardtable.jsx
@@ -8,12 +8,18 @@ const renderHeaderRow = (table) => (
         <th className="n num-decks" onClick={table.sort.bind(table, "numDecks", "DESC")}># Decks</th>
         <th className="n card-record" onClick={table.sort.bind(table, "record", "DESC")}>Record</th>
         <th className="n win-percent" onClick={table.sort.bind(table, "winPercent", "DESC")}>Win %</th>
-        <th className="n tournament-wins" onClick={table.sort.bind(table, "tournamentWins", "DESC")}>
-            <abbr title="Tournament wins">①</abbr>
-        </th>
-        <th className="n tournament-top-8s" onClick={table.sort.bind(table, "tournamentTop8s", "DESC")}>
-            <abbr title="Tournament Top 8s">⑧</abbr>
-        </th>
+        { table.props.leagueOnly
+            ? null
+            : <th className="n tournament-wins" onClick={table.sort.bind(table, "tournamentWins", "DESC")}>
+                <abbr title="Tournament wins">①</abbr>
+            </th>
+        }
+        { table.props.leagueOnly
+            ? null
+            : <th className="n tournament-top-8s" onClick={table.sort.bind(table, "tournamentTop8s", "DESC")}>
+                <abbr title="Tournament Top 8s">⑧</abbr>
+            </th>
+        }
         { table.props.tournamentOnly
             ? null
             : <th className="n perfect-runs" onClick={table.sort.bind(table, "perfectRuns", "DESC")}><abbr title="League 5-0 runs">5–0s</abbr></th>
@@ -27,18 +33,24 @@ const renderRow = (table, card) => (
         <td className="n">{card.numDecks}</td>
         <td className="n">{renderRecord(card)}</td>
         <td className="n">{renderWinPercent(card)}</td>
-        <td className="n">
-            { card.tournamentWins > 0
-                ? card.tournamentWins
-                : ""
-            }
-        </td>
-        <td className="n">
-            { card.tournamentTop8s > 0
+        { table.props.leagueOnly
+            ? null
+            : <td className="n">
+                { card.tournamentWins > 0
+                    ? card.tournamentWins
+                    : ""
+                }
+                </td>
+        }
+        { table.props.leagueOnly
+            ? null
+            : <td className="n">
+                { card.tournamentTop8s > 0
                 ? card.tournamentTop8s
                 : ""
-            }
-        </td>
+                }
+            </td>
+        }
         { table.props.tournamentOnly
             ? null
             : <td className="n">


### PR DESCRIPTION
But not, for example, top 8s on a league detail page where it would always be 0
