### PR TITLE
Add a way to do a "hard" cache reset for rotation from web (clear last season)

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -638,14 +638,15 @@ def doorprize() -> Response:
 @APP.route('/api/rotation/clear_cache')
 @APP.route('/api/rotation/clear_cache/')
 def rotation_clear_cache() -> Response:
-    thread = threading.Thread(target=clear_cache_task)
+    hard = request.args.get('hard', '0') == '1'
+    thread = threading.Thread(target=clear_cache_task, args=(hard,))
     thread.start()  # Start background thread
     return return_json({'success': True})
 
-def clear_cache_task() -> None:
+def clear_cache_task(hard: bool) -> None:
     rotation.clear_redis()
     rotation.rotation_redis_store()
-    rot.force_cache_update()
+    rot.force_cache_update(hard=hard)
 
 @APP.route('/api/cards')
 @APP.route('/api/cards/')

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -43,6 +43,11 @@ def run() -> None:
 
     if n == 0:
         rotation.clear_redis(clear_files=True)
+        try:
+            url = f'{fetcher.decksite_url()}/api/rotation/clear_cache?hard=1'
+            fetch_tools.fetch(url)
+        except Exception as c:
+            print(c, flush=True)
 
     all_prices = {}
     if not configuration.cardhoarder_urls.get():


### PR DESCRIPTION
And then use it when rotation runs = 0 so that a new season kicks off correctly
and we don't continue to see last season's info even though new rotation is
running fine.
