### PR TITLE
Add more depth to the stack we use to hash errors

### DIFF
--- a/shared/repo.py
+++ b/shared/repo.py
@@ -53,7 +53,7 @@ def create_issue(content: str,
         issue_hash = hashlib.sha1(''.join(pretty).encode()).hexdigest()
         body += f'Exception_hash: {issue_hash}\n'
     elif repo_name == 'PennyDreadfulMTG/perf-reports':
-        stack = traceback.extract_stack()[:-3]
+        stack = traceback.extract_stack()[:-6]
         pretty = traceback.format_list(stack)
         if request:
             pretty.append(request.full_path)


### PR DESCRIPTION
It seems like one particular hash comes up over and over again and we never
log anything because that issue already has 2500 comments (github max).

I think if we add more context here we'll escape just "you are in
repo.create_issue" and get different hashes. I think.
