### PR TITLE
Provide a way for actions happening not-on-user time to skip perf checks

### DIFF
--- a/shared/perf.py
+++ b/shared/perf.py
@@ -1,3 +1,4 @@
+import os
 import time
 from collections.abc import Callable
 from typing import Any
@@ -11,6 +12,8 @@ def start() -> float:
     return time.perf_counter()
 
 def check(start_time: float, kind: str, detail: Any, location: str) -> None:
+    if os.getenv('SKIP_PERF_CHECKS'):
+        return
     run_time = time.perf_counter() - start_time
     limit = configuration.get_float(kind)
     if limit is not None and run_time > limit:


### PR DESCRIPTION
We'll use this in cron jobs to avoid unnecessary perf warnings.
