### PR TITLE
Don't clear decksite rotation cache via web, be more direct

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -135,7 +135,6 @@ deny-imports =
     # maintenance can (and does) use anything
 
     rotation_script=analysis
-    rotation_script=decksite
     rotation_script=discordsite
     rotation_script=find
     rotation_script=logsite

--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import threading
 from typing import Any, cast
 
 from flask import Response, request, session, url_for
@@ -18,7 +17,7 @@ from decksite.data.achievements import Achievement
 from decksite.data.clauses import DEFAULT_GRID_PAGE_SIZE, DEFAULT_LIVE_TABLE_PAGE_SIZE
 from decksite.prepare import colors_html, prepare_archetypes, prepare_cards, prepare_decks, prepare_leaderboard, prepare_matches, prepare_people
 from decksite.views import DeckEmbed
-from magic import image_fetcher, layout, oracle, rotation, seasons, tournaments
+from magic import image_fetcher, layout, oracle, seasons, tournaments
 from magic.colors import find_colors
 from magic.models import Card, Deck
 from shared import configuration, dtutil, guarantee
@@ -634,19 +633,6 @@ def doorprize() -> Response:
 
     comp.set_doorprize(request.form['event'], request.form['winner'])
     return return_json({'success': True})
-
-@APP.route('/api/rotation/clear_cache')
-@APP.route('/api/rotation/clear_cache/')
-def rotation_clear_cache() -> Response:
-    hard = request.args.get('hard', '0') == '1'
-    thread = threading.Thread(target=clear_cache_task, args=(hard,))
-    thread.start()  # Start background thread
-    return return_json({'success': True})
-
-def clear_cache_task(hard: bool) -> None:
-    rotation.clear_redis()
-    rotation.rotation_redis_store()
-    rot.force_cache_update(hard=hard)
 
 @APP.route('/api/cards')
 @APP.route('/api/cards/')

--- a/decksite/data/rotation.py
+++ b/decksite/data/rotation.py
@@ -50,9 +50,8 @@ def load_rotation_summary() -> tuple[int, int]:
         return 0, 0
     return int(row['runs'] or 0), int(row['num_cards'] or 0)
 
-# To trigger manually without having to be in a python shell, hit /api/rotation/clear_cache in a browser.
-# If you have edited the existing Run_xxx.txt files you will need to run this in an interpreter with hard=True.
-# We don't do this for the API call because it will timeout once there are some reasonable number of runs.
+# If the latest rotation run screwed up try running this.
+# If you add a Run_xxx.txt file or mess with an existing one, you will need to run this with hard=True.
 @decorators.interprocess_locked('.rotation-cache.lock')
 def force_cache_update(hard: bool = False) -> None:
     season_id = seasons.next_season_num()

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -9,6 +9,7 @@ from collections import Counter
 
 import ftfy
 
+from decksite.data import rotation as rt
 from magic import card_price, fetcher, rotation, seasons
 from price_grabber.parser import PriceListType, parse_cardhoarder_prices
 from shared import configuration, decorators, dtutil, fetch_tools, repo, sentry, text
@@ -42,10 +43,9 @@ def run() -> None:
         return
 
     if n == 0:
-        rotation.clear_redis(clear_files=True)
         try:
-            url = f'{fetcher.decksite_url()}/api/rotation/clear_cache?hard=1'
-            fetch_tools.fetch(url)
+            rotation.clear_redis(clear_files=True)
+            rt.force_cache_update(hard=True)
         except Exception as c:
             print(c, flush=True)
 
@@ -63,8 +63,7 @@ def run() -> None:
         do_push()
 
     try:
-        url = f'{fetcher.decksite_url()}/api/rotation/clear_cache'
-        fetch_tools.fetch(url)
+        rt.force_cache_update()
     except Exception as c:
         print(c, flush=True)
 


### PR DESCRIPTION
Previously this was timing out when we got to later runs. So I made it run in
a thread not on user time. Which resulted in it crashing the webserver on local.

Here we block the progress of the rotation script to do this, which is not super
pleasing. But we catch all Exception and continue so it should be pretty hard
for this to break rotation.

And this way the bot should never be announcing things the site doesn't know yet
and other slightly race condition-y stuff.
