### PR TITLE
Try and get github errors unique enough that they don't all get dropped

### DIFF
--- a/shared/repo.py
+++ b/shared/repo.py
@@ -57,6 +57,7 @@ def create_issue(content: str,
         pretty = traceback.format_list(stack)
         if request:
             pretty.append(request.full_path)
+        pretty.append(title)
         issue_hash = hashlib.sha1(''.join(pretty).encode()).hexdigest()
         body += f'Location Hash: {issue_hash}\n'
 


### PR DESCRIPTION
We have a couple issues open with 2500 comments (the max) and we fail to report
a lot of stuff because our system decides they are the "same" even though they
are not. Add title of issue to differentiate more.
