### PR TITLE
[decksite/deck_name#file_name] add fallback if no safe characters

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -115,7 +115,12 @@ def file_name(d: Deck) -> str:
     safe_name = normalize(d).replace(' ', '-')
     safe_name = re.sub('--+', '-', safe_name, flags=re.IGNORECASE)
     safe_name = re.sub('[^0-9a-z-]', '', safe_name, flags=re.IGNORECASE)
-    return safe_name.strip('-')
+    safe_name = safe_name.strip('-')
+
+    if safe_name == '':
+        return 'untitled'
+    else:
+        return safe_name
 
 def replace_space_alternatives(name: str) -> str:
     name = name.replace('_', ' ')


### PR DESCRIPTION
previously, a deck name with no safe (i.e. ascii) characters would lead to `file_name()` returning an empty string, and the downloaded file being simply `txt`

addresses https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/issues/13238