### PR TITLE
[deck_name#file_name] use anyascii to generate safe filenames

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -2,6 +2,7 @@ import re
 from collections import OrderedDict
 
 import titlecase
+from anyascii import anyascii
 from better_profanity import profanity
 
 from magic import mana
@@ -114,7 +115,7 @@ def normalize(d: Deck) -> str:
 def file_name(d: Deck) -> str:
     safe_name = normalize(d).replace(' ', '-')
     safe_name = re.sub('--+', '-', safe_name, flags=re.IGNORECASE)
-    safe_name = re.sub('[^0-9a-z-]', '', safe_name, flags=re.IGNORECASE)
+    safe_name = re.sub(':', '', anyascii(safe_name), flags=re.IGNORECASE)
     return safe_name.strip('-')
 
 def replace_space_alternatives(name: str) -> str:


### PR DESCRIPTION
HTTP headers (like content-disposition) don't like non-ASCII, but instead of simply removing every nonconforming character, we can use anyascii to convert them.

Finish by stripping the colons that it adds around emoji names.

Fixes https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/issues/13238

Replaces https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/pull/13490