### PR TITLE
[docker] simplify dockerfile, add separate assets builder to compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,10 @@
-FROM python:3.10-bookworm AS python-build
-RUN pip install pipenv
-
-WORKDIR /pdm
-COPY Pipfile Pipfile.lock ./
-RUN pipenv sync
-
-
-FROM node:22-bookworm AS js-build
-
-WORKDIR /restore
-COPY package*.json ./
-RUN npm ci --verbose
-
-
 FROM python:3.10-bookworm
 RUN pip install pipenv
 
-COPY --from=python-build /usr/local/lib/python3.10/site-packages/ /usr/local/lib/python3.10/site-packages/
-COPY --from=python-build /root/.local/share/virtualenvs/ /root/.local/share/virtualenvs/
-COPY --from=js-build /restore/node_modules /pdm/node_modules
-
 WORKDIR /pdm
 
 COPY Pipfile Pipfile.lock ./
-RUN pipenv sync
+RUN pipenv sync --dev
 
 COPY dev.py run.py analysis/ decksite/ find/ logsite*/ magic/ maintenance/ shared*/ card_aliases.tsv hq_artcrops.json ./
 COPY ./.git/ ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - ./maintenance:/pdm/maintenance
       - ./shared:/pdm/shared
       - ./shared_web:/pdm/shared_web
+      - node_modules:/pdm/node_modules
+      - compiled_js:/pdm/shared_web/static/dist
 
   logsite:
     build: .
@@ -39,6 +41,26 @@ services:
       - ./logsite:/pdm/logsite
       - ./shared:/pdm/shared
       - ./shared_web:/pdm/shared_web
+      - node_modules:/pdm/node_modules
+      - compiled_js:/pdm/shared_web/static/dist
+
+  assets:
+    image: node:22-alpine
+    working_dir: /pdm
+    command:
+      - sh
+      - -c
+      - |
+        npm install
+        npm run babel
+        npm run watch
+    volumes:
+      - ./decksite/webpack.config.js:/pdm/decksite/webpack.config.js
+      - ./package.json:/pdm/package.json
+      - ./package-lock.json:/pdm/package-lock.json
+      - ./shared_web:/pdm/shared_web
+      - node_modules:/pdm/node_modules
+      - compiled_js:/pdm/shared_web/static/dist
 
   # discordbot:
   #   build: .
@@ -77,3 +99,5 @@ services:
 
 volumes:
   db_data:
+  node_modules:
+  compiled_js:


### PR DESCRIPTION
- remove the build stages from the dockerfile; since this is for development, a small image size isn't super important

- move the javascript handling (dependencies and react compilation) to a separate service which can run `npm run watch` and automatically recompile jsx