### PR TITLE
[download_scryfall_card_image] fix double-sided images when not JPG

### DIFF
--- a/magic/image_fetcher.py
+++ b/magic/image_fetcher.py
@@ -93,7 +93,7 @@ async def download_scryfall_png(c: Card) -> str | None:
 async def download_scryfall_card_image(c: Card, filepath: str, version: str = '') -> bool:
     try:
         if c.is_double_sided():
-            paths = [re.sub('.jpg$', '.a.jpg', filepath), re.sub('.jpg$', '.b.jpg', filepath)]
+            paths = [re.sub(f'.{version}$', f'.a.{version}', filepath), re.sub(f'.{version}$', f'.b.{version}', filepath)]
             await fetch_tools.store_async(scryfall_image(c, version=version), paths[0])
             if c.layout in layout.has_single_back():
                 await fetch_tools.store_async(scryfall_image(c, version=version, face='back'), paths[1])


### PR DESCRIPTION
For double-sided cards, both sides are downloaded then combined into a single image.  The filename generation assumed the extension was `.jpg` with the result that when it was `.png`, both images were written to the same path, and we got a merged image of two copies of the card back.