### PR TITLE
[templates/deckmatches] don't make BYE rows js-clickable

### DIFF
--- a/decksite/templates/deckmatches.mustache
+++ b/decksite/templates/deckmatches.mustache
@@ -14,7 +14,7 @@
     </thead>
     <tbody>
         {{#matches}}
-            <tr data-href="{{opponent_deck_url}}" class="clickable">
+            <tr {{#opponent_deck_url}}data-href="{{opponent_deck_url}}" class="clickable"{{/opponent_deck_url}}>
                 {{#has_rounds}}
                     <td class="n" data-text="{{round}}">{{display_round}}</td>
                 {{/has_rounds}}


### PR DESCRIPTION
~~real HTML anchors are already generated for decks and users; adding the data-href and clickable class has the effect of making BYE entries take the user to the current URL plus False which of course 404s.~~

having `data-href` and the `clickable` class applied to a BYE row has the effect
of making those entries entries take the user to the current URL plus `False`
which of course 404s.

an example: https://pennydreadfulmagic.com/decks/259753/