### PR TITLE
[download_scryfall_card_image] fix for dfc with version=border_crop

### DIFF
--- a/magic/image_fetcher.py
+++ b/magic/image_fetcher.py
@@ -96,7 +96,13 @@ async def download_scryfall_png(c: Card) -> str | None:
 async def download_scryfall_card_image(c: Card, filepath: str, version: str = '') -> bool:
     try:
         if c.is_double_sided():
-            paths = [re.sub(f'.{version}$', f'.a.{version}', filepath), re.sub(f'.{version}$', f'.b.{version}', filepath)]
+            split = os.path.splitext(filepath)
+
+            if f'.{version}' in filepath:
+                paths = [f'{split[0]}.a{split[1]}', f'{split[0]}.b{split[1]}']
+            else:
+                paths = [f'{split[0]}.{version}.a{split[1]}', f'{split[0]}.{version}.b{split[1]}']
+
             await fetch_tools.store_async(scryfall_image(c, version=version), paths[0])
             if c.layout in layout.has_single_back():
                 await fetch_tools.store_async(scryfall_image(c, version=version, face='back'), paths[1])


### PR DESCRIPTION
previously the code generating the pair of paths for dfcs assumed that `version` would be the extension and would be contained in `filepath`.  however, `version` can also be `border_crop`, so instead of calling a replace on `version` we split the filepath on the extension and insert the a/b strings.