### PR TITLE
Don't blank out a deck name because it uses the same color word twice

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -184,7 +184,7 @@ def normalize_colors(name: str, colors: list[str]) -> str:
     pattern = r'(^| )' + word + '( |$)'
     name = re.sub(pattern, ' ' + true_color + ' ', name).strip()
     for color_word in color_words[1:]:
-        name = name.replace(color_word, '')
+        name = name.replace(color_word, '', 1)
     if len(canonical_colors) == 1 and len(colors) == 1 and name.startswith(true_color) and not any(abbrev for abbrev in ABBREVIATIONS.values() if name.lower().startswith(abbrev.lower())) and word.lower() != 'colorless':
         name = f'Mono {name}'
     return re.sub(' +', ' ', name.strip())

--- a/decksite/deck_name_test.py
+++ b/decksite/deck_name_test.py
@@ -310,6 +310,9 @@ TESTDATA: list[tuple[str, str, list[str] | None, str | None, int]] = [
     ('Greasefag', 'Orzhov Greasefang', ['W', 'B'], 'Greasefang', 33),
     ('🏴‍☠️', '🏴‍☠️', ['U', 'R'], 'Pirates', 33),
     ('S36 Human v1 1', 'Human v1.1', ['W'], 'Mono White Humans', 36),
+    ('Blue', 'Mono Blue Tempo', ['U'], 'Mono Blue Tempo', 37),
+    ('U BLUE', 'Mono Blue Tempo', ['U'], 'Mono Blue Tempo', 37),
+    ('Blue-Red Uber-Control', 'Izzet Uber-Control', ['U', 'R'], 'Izzet Control', 37),
 ]
 
 def test_replace_space_alternatives() -> None:


### PR DESCRIPTION
In general, don't replace more than one color word where our intent is just to
replace one.
