### PR TITLE
Defend against stale signup form

### DIFF
--- a/decksite/form.py
+++ b/decksite/form.py
@@ -38,6 +38,8 @@ class DecklistForm(Form):
             self.has_recent_decks = len(self.recent_decks) > 0
         if mtgo_username is not None:
             self.mtgo_username = mtgo_username
+        elif not hasattr(self, 'mtgo_username'):
+            self.mtgo_username = ''
         self.decklist = form.get('decklist', '').strip()
         self.deck = Container()
         self.cards: DecklistType = {}


### PR DESCRIPTION
Seen a few 500s on the signup page hitting a nonexistent mtgo_username attr in
validation. Best theory is they have a stale page from when they were signed
in (no MTGO Username field) which they submit after signing out/clearing cookies
and this results.
