### PR TITLE
To prevent ligatures like the pride flag getting mangled, do not merge fonts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ decksite/images/*-cmc.png
 shared_web/static/dist/
 
 # Font subsetting output
-shared_web/static/fonts/symbols.woff2
+shared_web/static/fonts/*.woff2
 
 # Dev db output
 shared_web/static/dev-db.sql.gz

--- a/Pipfile
+++ b/Pipfile
@@ -106,6 +106,7 @@ manabase-solver = "*"
 brotli = "*"
 scipy = "*"
 regex = "*"
+grapheme = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "711597f03fce21b0e995ca0d6d54fbc91bfed9e246294ddbd401adaf0b978b22"
+            "sha256": "4747ece6a841a951c4175142c1f79d77a1b10f6df3a2a1f0feab49dce44de27c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1085,6 +1085,13 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.69.2"
+        },
+        "grapheme": {
+            "hashes": [
+                "sha256:44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
         },
         "httplib2": {
             "hashes": [

--- a/decksite/templates/header.mustache
+++ b/decksite/templates/header.mustache
@@ -3,7 +3,9 @@
     <head>
         <meta charset="utf-8">
         <title>{{title}}</title>
-        <link rel="preload" href="{{font_url}}" as="font" type="font/woff2" crossorigin="anonymous">
+        {{#font_urls}}
+            <link rel="preload" href="{{.}}" as="font" type="font/woff2" crossorigin="anonymous">
+        {{/font_urls}}
         <link rel="stylesheet" type="text/css" href="{{css_url}}">
         <link rel="stylesheet" type="text/css" href="/banner/banner.css">
         <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/keyrune@latest/css/keyrune.css">

--- a/maintenance/fonts.py
+++ b/maintenance/fonts.py
@@ -5,12 +5,12 @@ import sys
 import tempfile
 import unicodedata
 
+import grapheme
 from fontTools import subset
 from fontTools.merge import Merger, Options
 from fontTools.ttLib import TTFont
 from fontTools.ttLib.scaleUpem import scale_upem
 from fontTools.ttLib.woff2 import compress
-from regex import regex
 
 from decksite.database import db
 from magic import oracle
@@ -60,6 +60,10 @@ PREFER = {
 GraphemeToFontMapping = dict[str, list[str]]
 FontInfo = list[tuple[str, str, set[str], set[str], str]]
 
+def get_font_name(path: str) -> str:
+    return os.path.basename(path).replace('-Regular', '').replace('.ttf', '').replace(' ', '')
+
+
 def ad_hoc(*args: str) -> None:
     show_mode = 'show' in args
     options_mode = 'options' in args
@@ -84,7 +88,7 @@ def ad_hoc(*args: str) -> None:
     metrics: dict[str, int] = {}
     used_fonts = []
     for path in get_font_paths():
-        name = os.path.basename(path).replace('-Regular', '').replace('.ttf', '').replace(' ', '')
+        name = get_font_name(path)
         font = TTFont(path)
         if not metrics:
             metrics = get_vertical_metrics(font)
@@ -103,21 +107,19 @@ def ad_hoc(*args: str) -> None:
             # Force them to have the same vertical metrics as main-text to prevent wild line height and other issues.
             adjusted = adjust_vertical_metrics(subsetted, metrics)
             used_fonts.append((name, adjusted))
-            encoded = encode(adjusted)
+            woff2_path = os.path.join('shared_web', 'static', 'fonts', f'{name}.woff2')
+            _, ttf_path = tempfile.mkstemp(suffix='.ttf')
+            adjusted.save(ttf_path)
+            compress(ttf_path, woff2_path)
+            with open(woff2_path, 'rb') as f:
+                encoded = encode(TTFont(f))
             css = font_face(name, encoded)
         if options_mode or needed_found_graphemes:
             font_info.append((name, path, found_graphemes, needed_found_graphemes, css))
         if not options_mode and not remaining_graphemes:
             break
-    merged = merge_fonts([f[1] for f in used_fonts])
-    _, ttf_path = tempfile.mkstemp(suffix='.ttf')
-    merged.save(ttf_path)
-    woff2_path = os.path.join('shared_web', 'static', 'fonts', 'symbols.woff2')
-    compress(ttf_path, woff2_path)
     if show_mode:
-        with open(woff2_path, 'rb') as f:
-            encoded = encode(TTFont(f))
-        print_css(font_info, deck_names, encoded)
+        print_css(font_info, deck_names)
     elif options_mode:
         print_options(graphemes_to_fonts, font_info)
     print_report(font_info, remaining_graphemes)
@@ -125,8 +127,8 @@ def ad_hoc(*args: str) -> None:
 def card_name_graphemes() -> tuple[set[str], set[str]]:
     seen, names = set(), set()
     for name in oracle.cards_by_name().keys():
-        for grapheme in regex.findall(r'\X', name):
-            seen.add(grapheme)
+        for g in grapheme.graphemes(name):
+            seen.add(g)
             names.add(name)
     return seen, names
 
@@ -136,10 +138,10 @@ def deck_name_graphemes() -> tuple[set[str], set[str]]:
     seen, names = set(), set()
     for row in rs:
         name = row['normalized_name']
-        for grapheme in regex.findall(r'\X', name):
-            if grapheme not in seen:
-                print(f"{grapheme} {named(grapheme)} ({points(grapheme)}) from {row['deck_id']} ({name})", file=sys.stderr)
-                seen.add(grapheme)
+        for g in grapheme.graphemes(name):
+            if g not in seen:
+                print(f'{g} {named(g)} ({points(g)}) from {row["deck_id"]} ({name})', file=sys.stderr)
+                seen.add(g)
                 names.add(name)
     return seen, names
 
@@ -164,15 +166,15 @@ def get_font_paths() -> list[str]:
 def find_graphemes(font: TTFont, name: str, options_mode: bool, to_find: set[str]) -> set[str]:
     found = set()
     for table in font['cmap'].tables:
-        for grapheme in to_find:
-            has_preferred = PREFER.get(grapheme)
-            if not options_mode and has_preferred and PREFER.get(grapheme) != name:
+        for g in to_find:
+            has_preferred = PREFER.get(g)
+            if not options_mode and has_preferred and PREFER.get(g) != name:
                 continue
-            for c in grapheme:
+            for c in g:
                 if ord(c) not in table.cmap.keys():
                     break
             else:
-                found.add(grapheme)
+                found.add(g)
     return found
 
 def subset_font(font: TTFont, graphemes: set[str]) -> TTFont:
@@ -186,10 +188,10 @@ def subset_font(font: TTFont, graphemes: set[str]) -> TTFont:
         args = [
             tmp_in,
             f'--text={text}',
-            '--no-layout-closure',
             f'--output-file={tmp_out}',
             '--flavor=woff2',
         ]
+
         subset.main(args)
         subsetted_font = TTFont(tmp_out)
         return subsetted_font
@@ -277,11 +279,15 @@ def font_face(name: str, encoded: str) -> str:
 }}
     """
 
-def print_css(font_info: FontInfo, deck_names: set[str], encoded_merged_font: str) -> None:
-    ff = font_face('symbols', encoded_merged_font)
+def print_css(font_info: FontInfo, deck_names: set[str]) -> None:
+    css = '\n'.join(css for _, _, _, _, css in font_info if css)
     sample_graphemes = [(name, ''.join(f'<span title="{points(grapheme)}">{html.escape(grapheme)}</span>' for grapheme in sorted(used))) for name, _, _, used, _ in font_info]
     samples = ''.join(f'<p>{html.escape(name)} {sample}</p>' for name, sample in sample_graphemes)
     deck_name_samples = '\n'.join(f'<p>{html.escape(name)}</p>' for name in deck_names)
+
+    font_names = [get_font_name(path) for path in get_font_paths()]
+    font_stack = ', '.join(font_names + ['fantasy'])
+
     print(f"""
         <!DOCTYPE html>
         <html lang="en">
@@ -290,7 +296,7 @@ def print_css(font_info: FontInfo, deck_names: set[str], encoded_merged_font: st
                 <title>Penny Dreadful Font Test</title>
                 <style>
                     * {{
-                        font-family: symbols, main-text, fantasy; /* fantasy as base font so we can use js to detect misses, see below. */
+                        font-family: {font_stack}; /* fantasy as base font so we can use js to detect misses, see below. */
                         font-size: 20px;
                     }}
 
@@ -299,12 +305,7 @@ def print_css(font_info: FontInfo, deck_names: set[str], encoded_merged_font: st
                         src: url('file://{os.path.abspath(get_font_paths()[0])}');
                     }}
 
-                    /* BEGIN COPY AND PASTE OUTPUT FOR pd.css */
-
-{ff}
-
-                    /* END COPY AND PASTE OUTPUT FOR pd.css */
-
+                    {css}
                 </style>
             </head>
             <body>
@@ -364,7 +365,7 @@ def print_options(grapheme_to_fonts: GraphemeToFontMapping, font_info: FontInfo)
         print(f"""
             @font-face {{
                 font-family: '{name}';
-                src: url('file://{path}') format('truetype');
+                src: url('file://{os.path.abspath(path)}') format('truetype');
             }}
         """)
     print("""
@@ -372,12 +373,12 @@ def print_options(grapheme_to_fonts: GraphemeToFontMapping, font_info: FontInfo)
             </head>
             <body>
     """)
-    for grapheme in sorted(grapheme_to_fonts):
-        if 'main-text' in grapheme_to_fonts[grapheme]:
+    for g in sorted(grapheme_to_fonts):
+        if 'main-text' in grapheme_to_fonts[g]:
             continue
-        print(f'<p><span style="width: 40em; display: inline-block; text-align: right;">{html.escape(named(grapheme))} ({html.escape(points(grapheme))})</span> ')
-        for name in grapheme_to_fonts[grapheme]:
-            print(f'<span title="{html.escape(name)}" style="font-family: {html.escape(name)}">{html.escape(grapheme)}</span>')
+        print(f'<p><span style="width: 40em; display: inline-block; text-align: right;">{html.escape(named(g))} ({html.escape(points(g))})</span> ')
+        for name in grapheme_to_fonts[g]:
+            print(f'<span title="{html.escape(name)}" style="font-family: {html.escape(name)}">{html.escape(g)}</span>')
         print('</p>')
     print("""
             </body>

--- a/shared_web/base_view.py
+++ b/shared_web/base_view.py
@@ -46,12 +46,17 @@ class BaseView:
     def git_branch(self) -> str:
         return current_app.config['branch']
 
-    def font_url(self) -> str:
-        try:
-            mtime = int(os.path.getmtime('shared_web/static/fonts/symbols.woff2'))
-        except OSError:
-            mtime = 0
-        return url_for('static', filename='fonts/symbols.woff2', v=mtime)
+    def font_urls(self) -> list[str]:
+        font_names = ['NotoEmoji', 'NotoSansLiving', 'NotoSansJP', 'NotoSansSC', 'NotoSansHistorical', 'NotoSansSymbols', 'NotoSansSymbols2', 'SegoeUISymbol', 'Symbola']
+        urls = []
+        for name in font_names:
+            try:
+                path = f'shared_web/static/fonts/{name}.woff2'
+                mtime = int(os.path.getmtime(path))
+            except OSError:
+                mtime = 0
+            urls.append(url_for('static', filename=f'fonts/{name}.woff2', v=mtime))
+        return urls
 
     def css_url(self) -> str:
         return current_app.config['css_url'] or url_for('static', filename='css/pd.css', v=self.commit_id('shared_web/static/css/pd.css'))

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -174,11 +174,54 @@ footer a:hover {
 }
 
 /* Fonts */
-
 :root {
-    --heading-font-family: symbols, heading-caps, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    /* If you make changes here also change the Chart.js fontFamily in pd.js */
-    --main-text-font-family: symbols, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    --heading-font-family: NotoEmoji, NotoSansLiving, NotoSansJP, NotoSansSC, NotoSansHistorical, NotoSansSymbols, NotoSansSymbols2, SegoeUISymbol, Symbola, heading-caps, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    --main-text-font-family: NotoEmoji, NotoSansLiving, NotoSansJP, NotoSansSC, NotoSansHistorical, NotoSansSymbols, NotoSansSymbols2, SegoeUISymbol, Symbola, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+@font-face {
+    font-family: 'NotoEmoji';
+    src: url('/static/fonts/NotoEmoji.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'NotoSansLiving';
+    src: url('/static/fonts/NotoSansLiving.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'NotoSansJP';
+    src: url('/static/fonts/NotoSansJP.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'NotoSansSC';
+    src: url('/static/fonts/NotoSansSC.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'NotoSansHistorical';
+    src: url('/static/fonts/NotoSansHistorical.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'NotoSansSymbols';
+    src: url('/static/fonts/NotoSansSymbols.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'NotoSansSymbols2';
+    src: url('/static/fonts/NotoSansSymbols2.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'SegoeUISymbol';
+    src: url('/static/fonts/SegoeUISymbol.woff2') format('woff2');
+}
+
+@font-face {
+    font-family: 'Symbola';
+    src: url('/static/fonts/Symbola.woff2') format('woff2');
 }
 
 @font-face {


### PR DESCRIPTION
Instead we'll load each subsetted font separately. This gets us a nice
monochrome version of ligatures created by zero width joiner like Noto Emoji's
WAVING WHITE FLAG+ZERO WIDTH JOINER+RAINBOW (U+127987 and U+8205 and U+127752)
which is a monochrome pride flag.

Something about the merging was corrupting these or making them inaccessible to
the browser even though they were in the generated font.

<img width="113" alt="image" src="https://github.com/user-attachments/assets/70939eb3-da7f-48cd-81a7-8a8500630409" />

