### PR TITLE
Use the underlying original exception not the skinny werkzeug wrapper

### DIFF
--- a/shared/repo.py
+++ b/shared/repo.py
@@ -44,9 +44,6 @@ def create_issue(content: str,
         body += str(exception) + '\n'
         body += '</summary>\n\n'
         pretty = format_exception(exception)
-        if request and request.headers:
-            for _, v in request.headers.items():
-                pretty = pretty.replace(str(v), '...header value redacted...')
         pretty += '\n' + title
         body += 'Stack Trace:\n\n```\n\nPython traceback\n\n' + pretty + '\n\n```\n\n</details>\n\n'
         issue_hash = hashlib.sha1(pretty.encode()).hexdigest()


### PR DESCRIPTION
This will give us real stack traces in our GitHub issues instead of just the
generic InternalServerError message.

We no longer need to redact here because we're just using format_exception
and not format_exception_with_variables. The latter gives more detail but is
so much harder to read that I'm just going with the simple version. When we get
a bug that requires the vars to debug I'll kick myself then :)
