### PR TITLE
Move where we declare react version to avoid warning while linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,13 @@ import react from 'eslint-plugin-react';
 
 export default [
     js.configs.recommended,
+    {
+        settings: {
+            react: {
+                version: "detect",
+            },
+        },
+    },
     react.configs.flat.recommended,
     {
 
@@ -12,12 +19,6 @@ export default [
 
         plugins: {
             react,
-        },
-
-        settings: {
-            react: {
-                version: "detect",
-            },
         },
 
         languageOptions: {


### PR DESCRIPTION
Something about including it after the eslint config causes:

Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration

but it's happy like this.
