### PR TITLE
Revert "To prevent ligatures like the pride flag getting mangled, do not merge fonts"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ decksite/images/*-cmc.png
 shared_web/static/dist/
 
 # Font subsetting output
-shared_web/static/fonts/*.woff2
+shared_web/static/fonts/symbols.woff2
 
 # Dev db output
 shared_web/static/dev-db.sql.gz

--- a/Pipfile
+++ b/Pipfile
@@ -106,7 +106,6 @@ manabase-solver = "*"
 brotli = "*"
 scipy = "*"
 regex = "*"
-grapheme = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4747ece6a841a951c4175142c1f79d77a1b10f6df3a2a1f0feab49dce44de27c"
+            "sha256": "711597f03fce21b0e995ca0d6d54fbc91bfed9e246294ddbd401adaf0b978b22"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1085,13 +1085,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==1.69.2"
-        },
-        "grapheme": {
-            "hashes": [
-                "sha256:44c2b9f21bbe77cfb05835fec230bd435954275267fea1858013b102f8603cca"
-            ],
-            "index": "pypi",
-            "version": "==0.6.0"
         },
         "httplib2": {
             "hashes": [

--- a/decksite/templates/header.mustache
+++ b/decksite/templates/header.mustache
@@ -3,9 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title>{{title}}</title>
-        {{#font_urls}}
-            <link rel="preload" href="{{.}}" as="font" type="font/woff2" crossorigin="anonymous">
-        {{/font_urls}}
+        <link rel="preload" href="{{font_url}}" as="font" type="font/woff2" crossorigin="anonymous">
         <link rel="stylesheet" type="text/css" href="{{css_url}}">
         <link rel="stylesheet" type="text/css" href="/banner/banner.css">
         <link rel="stylesheet" type="text/css" href="//cdn.jsdelivr.net/npm/keyrune@latest/css/keyrune.css">

--- a/shared_web/base_view.py
+++ b/shared_web/base_view.py
@@ -46,17 +46,12 @@ class BaseView:
     def git_branch(self) -> str:
         return current_app.config['branch']
 
-    def font_urls(self) -> list[str]:
-        font_names = ['NotoEmoji', 'NotoSansLiving', 'NotoSansJP', 'NotoSansSC', 'NotoSansHistorical', 'NotoSansSymbols', 'NotoSansSymbols2', 'SegoeUISymbol', 'Symbola']
-        urls = []
-        for name in font_names:
-            try:
-                path = f'shared_web/static/fonts/{name}.woff2'
-                mtime = int(os.path.getmtime(path))
-            except OSError:
-                mtime = 0
-            urls.append(url_for('static', filename=f'fonts/{name}.woff2', v=mtime))
-        return urls
+    def font_url(self) -> str:
+        try:
+            mtime = int(os.path.getmtime('shared_web/static/fonts/symbols.woff2'))
+        except OSError:
+            mtime = 0
+        return url_for('static', filename='fonts/symbols.woff2', v=mtime)
 
     def css_url(self) -> str:
         return current_app.config['css_url'] or url_for('static', filename='css/pd.css', v=self.commit_id('shared_web/static/css/pd.css'))

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -174,54 +174,11 @@ footer a:hover {
 }
 
 /* Fonts */
+
 :root {
-    --heading-font-family: NotoEmoji, NotoSansLiving, NotoSansJP, NotoSansSC, NotoSansHistorical, NotoSansSymbols, NotoSansSymbols2, SegoeUISymbol, Symbola, heading-caps, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-    --main-text-font-family: NotoEmoji, NotoSansLiving, NotoSansJP, NotoSansSC, NotoSansHistorical, NotoSansSymbols, NotoSansSymbols2, SegoeUISymbol, Symbola, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
-}
-
-@font-face {
-    font-family: 'NotoEmoji';
-    src: url('/static/fonts/NotoEmoji.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'NotoSansLiving';
-    src: url('/static/fonts/NotoSansLiving.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'NotoSansJP';
-    src: url('/static/fonts/NotoSansJP.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'NotoSansSC';
-    src: url('/static/fonts/NotoSansSC.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'NotoSansHistorical';
-    src: url('/static/fonts/NotoSansHistorical.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'NotoSansSymbols';
-    src: url('/static/fonts/NotoSansSymbols.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'NotoSansSymbols2';
-    src: url('/static/fonts/NotoSansSymbols2.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'SegoeUISymbol';
-    src: url('/static/fonts/SegoeUISymbol.woff2') format('woff2');
-}
-
-@font-face {
-    font-family: 'Symbola';
-    src: url('/static/fonts/Symbola.woff2') format('woff2');
+    --heading-font-family: symbols, heading-caps, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    /* If you make changes here also change the Chart.js fontFamily in pd.js */
+    --main-text-font-family: symbols, main-text, Lato, "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 @font-face {


### PR DESCRIPTION
This reverts commit 0e6d81d2697fc1a998c1f50a7394fac362365ffb.

I forgot that we only started this font merging because Safari and any browser
on iOS insist on it to work.

Will have to figure out how to get the substitutions (from Noto Emoji at least)
into the combined font.
