### PR TITLE
Make db restore during docker dev setup actually work

### DIFF
--- a/docker_dev/mysql/dev-db.sh
+++ b/docker_dev/mysql/dev-db.sh
@@ -1,6 +1,8 @@
 if [ "$PDM_DOWNLOAD_DEVDB" = "true" ]
 then
-    curl https://pennydreadfulmagic.com/static/dev-db.sql.gz | gunzip | mysql -u pennydreadful decksite
+    curl https://pennydreadfulmagic.com/static/dev-db.sql.gz >dev-db.sql.gz
+    gunzip dev-db.sql.gz
+    mysql -u pennydreadful decksite <dev-db.sql
 else
     echo 'PDM_DOWNLOAD_DEVDB!=true.  Not downloading devdb'
 fi


### PR DESCRIPTION
We found that running this as a pipe errors out but not this way

Not sure why but the SQL file is 1.1G these days so just do what it wants.

This is really slow (21m on my machine) but does now at least complete without error.
