### PR TITLE
Fixed kick off achievements ignoring kickoffs which have incosistent naming

### DIFF
--- a/decksite/data/achievements.py
+++ b/decksite/data/achievements.py
@@ -823,8 +823,8 @@ class PD500Top8(CountedAchievement):
     key = 'pd500_top8s'
     title = 'Penny Dreadful 500 Top 8'
     description_safe = 'Top 8 the Penny Dreadful 500.'
-    sql = "COUNT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND c.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
-    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND c.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
+    sql = "COUNT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
+    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
     flags = ['hide_person', 'hide_source']
 
     def leaderboard_heading(self) -> str:
@@ -837,8 +837,8 @@ class PD500Winner(CountedAchievement):
     key = 'pd500_wins'
     title = 'Penny Dreadful 500 Winner'
     description_safe = 'Win the Penny Dreadful 500.'
-    sql = "COUNT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND c.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
-    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND c.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
+    sql = "COUNT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
+    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Penny Dreadful 500%%' THEN d.id ELSE NULL END)"
     flags = ['hide_person', 'hide_source']
 
     def leaderboard_heading(self) -> str:
@@ -851,8 +851,8 @@ class KickoffTop8(CountedAchievement):
     key = 'kickoff_top8s'
     title = 'Season Kick Off Top 8'
     description_safe = 'Top 8 the Season Kick Off.'
-    sql = "COUNT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND c.name LIKE '%%Kick Off%%' THEN d.id ELSE NULL END)"
-    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND c.name LIKE '%%Kick Off%%' THEN d.id ELSE NULL END)"
+    sql = "COUNT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Kick off%%' THEN d.id ELSE NULL END)"
+    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish <= 8 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Kick off%%' THEN d.id ELSE NULL END)"
     flags = ['hide_person', 'hide_source']
 
     def leaderboard_heading(self) -> str:
@@ -865,8 +865,8 @@ class KickoffWinner(CountedAchievement):
     key = 'kickoff_wins'
     title = 'Season Kick Off Winner'
     description_safe = 'Win the Season Kick Off.'
-    sql = "COUNT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND c.name LIKE '%%Kick Off%%' THEN d.id ELSE NULL END)"
-    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND c.name LIKE '%%Kick Off%%' THEN d.id ELSE NULL END)"
+    sql = "COUNT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Kick off%%' THEN d.id ELSE NULL END)"
+    detail_sql = "GROUP_CONCAT(DISTINCT CASE WHEN d.finish = 1 AND ct.name = 'Gatherling' AND cf.name LIKE '%%Kick off%%' THEN d.id ELSE NULL END)"
     flags = ['hide_person', 'hide_source']
 
     def leaderboard_heading(self) -> str:

--- a/decksite/data/query.py
+++ b/decksite/data/query.py
@@ -43,6 +43,8 @@ def competition_join() -> str:
             competition_series AS cs ON cs.id = c.competition_series_id
         LEFT JOIN
             competition_type AS ct ON ct.id = cs.competition_type_id
+        LEFT JOIN
+            competition_flag AS cf ON cf.id = c.competition_flag_id
     """
 
 def season_query(season_id: str | int | None, column_name: str = 'season_id') -> str:


### PR DESCRIPTION
Also made the pd 500 and kickoff achievements check competition flag name instead of the competition name
![obrazek](https://github.com/user-attachments/assets/a62caeb3-0597-4619-9f8d-53ecd70da761)


(I hope adding another left join into competition_join() won't make it much slower, maybe it can be done better?)