### PR TITLE
Fix pipenv env problem

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,11 @@ if [ $# -lt "1" ]
 then
     APP="discordbot"
 fi
+# if pipenv in not in the path, add ~/.local/bin/ to the path
+if ! command -v pipenv &> /dev/null
+then
+    export PATH="$HOME/.local/bin/:$PATH"
+fi
 echo $APP
 cd $(dirname $0)
 git pull


### PR DESCRIPTION
On my raspberry pi where the modobug script is running, pipenv isn't in path for cron jobs.  This is a dirty fix