### PR TITLE
Support Scryfall JSONL bulk data

### DIFF
--- a/magic/fetcher.py
+++ b/magic/fetcher.py
@@ -37,14 +37,19 @@ async def all_cards_async(force_last_good: bool = False) -> tuple[list[CardDescr
     if force_last_good:
         response = None
     else:
-        response = await fetch_tools.fetch_json_async(download_uri)
+        response = await fetch_bulk_data_async(download_uri)
     if not isinstance(response, list):
         try:
             backup = configuration.last_good_bulk_data.value
-            return await fetch_tools.fetch_json_async(backup), backup
+            return await fetch_bulk_data_async(backup), backup
         except Exception as c:
             raise FetchException(f'Default Cards not in expected format. Got {response}') from c
     return response, download_uri
+
+async def fetch_bulk_data_async(download_uri: str) -> list[CardDescription]:
+    if download_uri.endswith('.jsonl.gz'):
+        return await fetch_tools.fetch_jsonl_gzip_async(download_uri)
+    return await fetch_tools.fetch_json_async(download_uri)
 
 async def all_sets_async() -> list[dict[str, Any]]:
     try:
@@ -62,7 +67,10 @@ async def bulk_data_uri() -> str:
     endpoints = await fetch_tools.fetch_json_async('https://api.scryfall.com/bulk-data')
     for e in endpoints['data']:
         if e['type'] == 'default_cards':
-            return e['download_uri']
+            download_uri = e.get('download_uri') or e.get('jsonl_download_uri')
+            if download_uri:
+                return download_uri
+            raise FetchException('Default Cards has no download URI')
     else:
         raise FetchException('Unable to find Default Cards')
 

--- a/magic/fetcher_test.py
+++ b/magic/fetcher_test.py
@@ -1,0 +1,33 @@
+import pytest
+
+from magic import fetcher
+
+
+@pytest.mark.asyncio
+async def test_bulk_data_uri_uses_jsonl_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fetch_json_async(_url: str) -> dict:
+        return {
+            'data': [{
+                'type': 'default_cards',
+                'jsonl_download_uri': 'https://data.scryfall.io/default-cards.jsonl.gz',
+            }],
+        }
+
+    monkeypatch.setattr(fetcher.fetch_tools, 'fetch_json_async', fetch_json_async)
+
+    assert await fetcher.bulk_data_uri() == 'https://data.scryfall.io/default-cards.jsonl.gz'
+
+
+@pytest.mark.asyncio
+async def test_bulk_data_uri_supports_legacy_json_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fetch_json_async(_url: str) -> dict:
+        return {
+            'data': [{
+                'type': 'default_cards',
+                'download_uri': 'https://data.scryfall.io/default-cards.json',
+            }],
+        }
+
+    monkeypatch.setattr(fetcher.fetch_tools, 'fetch_json_async', fetch_json_async)
+
+    assert await fetcher.bulk_data_uri() == 'https://data.scryfall.io/default-cards.json'

--- a/magic/layout.py
+++ b/magic/layout.py
@@ -41,6 +41,7 @@ LAYOUTS: dict[str, Layout] = {
     'double_faced_token': Layout(playable=False, has_two_names=True, has_single_back=True, uses_canonical_namespace=False),
     'emblem': Layout(playable=False),
     'flip': Layout(has_two_names=True),
+    'front_card': Layout(playable=False, uses_canonical_namespace=False),
     'host': Layout(playable=False),
     'leveler': Layout(),
     'meld': Layout(has_two_names=True, has_meld_back=True),

--- a/magic/layout_test.py
+++ b/magic/layout_test.py
@@ -1,0 +1,6 @@
+from magic import layout
+
+
+def test_front_card_is_not_playable() -> None:
+    assert not layout.is_playable_layout('front_card')
+    assert 'front_card' not in layout.uses_canonical_namespace()

--- a/shared/fetch_tools.py
+++ b/shared/fetch_tools.py
@@ -1,8 +1,10 @@
+import gzip
 import json
 import logging
 import os
+import tempfile
 import urllib.request
-from typing import Any
+from typing import Any, BinaryIO
 
 import aiohttp
 import requests
@@ -79,6 +81,25 @@ async def fetch_json_async(url: str) -> Any:
     except json.decoder.JSONDecodeError:
         logger.error(f'Failed to load JSON:\n{blob}')
         raise
+
+def load_jsonl_gzip(blob: BinaryIO) -> list[Any]:
+    with gzip.open(blob, mode='rt', encoding='utf-8') as lines:
+        return [json.loads(line) for line in lines if line.strip()]
+
+async def fetch_jsonl_gzip_async(url: str) -> list[Any]:
+    logger.info(f'Async fetching {url}')
+    try:
+        async with aiohttp.ClientSession() as aios:
+            aios.headers['User-Agent'] = 'PennyDreadfulMagic'
+            response = await aios.get(url)
+            response.raise_for_status()
+            with tempfile.TemporaryFile() as compressed:
+                async for chunk in response.content.iter_chunked(1024 * 1024):
+                    compressed.write(chunk)
+                compressed.seek(0)
+                return load_jsonl_gzip(compressed)
+    except (aiohttp.ClientError, OSError, json.decoder.JSONDecodeError) as e:
+        raise FetchException(e) from e
 
 async def post_json_async(url: str, data: dict) -> Any:
     try:

--- a/shared/fetch_tools.py
+++ b/shared/fetch_tools.py
@@ -13,10 +13,11 @@ from shared import perf
 from shared.pd_exception import OperationalException
 
 logger = logging.getLogger(__name__)
+USER_AGENT = 'PennyDreadfulMagic'
 
 
 def fetch(url: str, character_encoding: str | None = None, force: bool = False, retry: bool = False, session: requests.Session | None = None) -> str:
-    headers = {}
+    headers = {'User-Agent': USER_AGENT}
     if force:
         headers['Cache-Control'] = 'no-cache'
     logger.info('Fetching {url} ({cache})'.format(url=url, cache='no cache' if force else 'cache ok'))
@@ -46,7 +47,7 @@ async def fetch_async(url: str) -> str:
     logger.info(f'Async fetching {url}')
     try:
         async with aiohttp.ClientSession() as aios:
-            aios.headers['User-Agent'] = 'PennyDreadfulMagic'
+            aios.headers['User-Agent'] = USER_AGENT
             response = await aios.get(url)
             return await response.text()
     except (urllib.error.HTTPError, requests.exceptions.ConnectionError, aiohttp.ClientConnectorError) as e:
@@ -56,7 +57,7 @@ async def post_async_with_json(url: str, data: dict) -> str:
     logger.info(f'Async posting to {url}')
     try:
         async with aiohttp.ClientSession() as aios:
-            aios.headers['User-Agent'] = 'PennyDreadfulMagic'
+            aios.headers['User-Agent'] = USER_AGENT
             response = await aios.post(url, json=data)
             return await response.text()
     except (urllib.error.HTTPError, requests.exceptions.ConnectionError) as e:
@@ -90,7 +91,7 @@ async def fetch_jsonl_gzip_async(url: str) -> list[Any]:
     logger.info(f'Async fetching {url}')
     try:
         async with aiohttp.ClientSession() as aios:
-            aios.headers['User-Agent'] = 'PennyDreadfulMagic'
+            aios.headers['User-Agent'] = USER_AGENT
             response = await aios.get(url)
             response.raise_for_status()
             with tempfile.TemporaryFile() as compressed:

--- a/shared/fetch_tools_test.py
+++ b/shared/fetch_tools_test.py
@@ -1,0 +1,12 @@
+import gzip
+import io
+import json
+
+from shared import fetch_tools
+
+
+def test_load_jsonl_gzip() -> None:
+    rows = [{'name': 'Forest'}, {'name': 'Island'}]
+    contents = gzip.compress(b''.join(f'{json.dumps(row)}\n'.encode() for row in rows))
+
+    assert fetch_tools.load_jsonl_gzip(io.BytesIO(contents)) == rows

--- a/shared/fetch_tools_test.py
+++ b/shared/fetch_tools_test.py
@@ -1,8 +1,17 @@
 import gzip
 import io
 import json
+from unittest.mock import Mock, patch
 
 from shared import fetch_tools
+
+
+def test_fetch_sets_user_agent() -> None:
+    response = Mock(status_code=200, text='ok')
+    with patch.object(fetch_tools.requests, 'get', return_value=response) as get:
+        assert fetch_tools.fetch('https://example.com') == 'ok'
+
+    get.assert_called_once_with('https://example.com', headers={'User-Agent': fetch_tools.USER_AGENT})
 
 
 def test_load_jsonl_gzip() -> None:


### PR DESCRIPTION
## Summary

- support Scryfall’s new `jsonl_download_uri` bulk-data field
- download and parse gzipped JSON Lines without holding the compressed and decompressed payloads in memory simultaneously
- retain compatibility with legacy JSON-array bulk URLs and saved fallback URLs
- recognize Scryfall’s new non-playable `front_card` layout
- identify synchronous HTTP requests so Scryfall accepts search/API queries

## Validation

- `.venv/bin/pytest -q --confcutdir=shared shared/fetch_tools_test.py`
- `.venv/bin/pytest -q --confcutdir=magic magic/fetcher_test.py magic/layout_test.py`
- `.venv/bin/python dev.py lint`
- `.venv/bin/python dev.py mypy`
- live `find/find_test.py::test_shortcuts_and_nicknames` test against Scryfall
- live Scryfall default-cards export parsed successfully (116,700 records)
- full local `init-cards --force` rebuild completed successfully: 34,250 cards, 109,534 printings, and 15,462 current-season legal cards

The complete pytest suite was attempted locally but collection requires permission to create the separate `pdlogs` database. CI provisions its own databases and runs the full suite.