### PR TITLE
Harden Discord bot errors and reboot reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ whoosh_index/
 # Task locking
 /.task.lock
 
+# Local/production Discord bot log
+/discordbot.log
+
 # i18n
 *.mo
 *.po

--- a/discordbot/background.py
+++ b/discordbot/background.py
@@ -2,17 +2,17 @@ import asyncio
 import datetime
 import logging
 import os
-import sys
 import urllib.parse
 
 from interactions import MISSING, Absent, Client, Extension, listen
 from interactions.client.errors import Forbidden
 from interactions.client.utils import timestamp_converter
-from interactions.models.discord import Embed, GuildText, ScheduledEventType
+from interactions.models.discord import Embed, GuildText, MessageableMixin, ScheduledEventType
 from interactions.models.internal.tasks import IntervalTrigger, Task
 
+from discordbot import error_handling, reboot_utils
 from magic import fetcher, image_fetcher, multiverse, rotation, seasons, tournaments
-from shared import configuration, dtutil, fetch_tools, redis_wrapper, repo
+from shared import configuration, dtutil, fetch_tools, redis_wrapper
 
 
 class BackgroundTasks(Extension):
@@ -22,15 +22,24 @@ class BackgroundTasks(Extension):
     async def on_startup(self) -> None:
         self.do_banner.start()
 
-        self.do_reboot_key = 'discordbot:do_reboot'
+        self.do_reboot_key = reboot_utils.REBOOT_KEY
         if redis_wrapper.get_bool(self.do_reboot_key):
             redis_wrapper.clear(self.do_reboot_key)
+        redis_wrapper.clear(reboot_utils.REBOOT_CHANNEL_KEY)
+        await self.announce_reboot_complete()
         self.background_task_reboot.start()
 
         await self.prepare_tournaments()
         await self.prepare_hype()
         await self.prepare_league_end()
         await self.prepare_mos()
+
+    async def announce_reboot_complete(self) -> None:
+        reboot_complete_channel_id = redis_wrapper.get_int(reboot_utils.REBOOT_COMPLETE_CHANNEL_KEY)
+        if reboot_complete_channel_id is not None:
+            redis_wrapper.clear(reboot_utils.REBOOT_COMPLETE_CHANNEL_KEY)
+            loaded_commit = getattr(self.bot, 'commit_id', 'unknown')
+            await self.send_reboot_message(reboot_complete_channel_id, f'Reboot complete. Loaded `{loaded_commit[:8]}`')
 
     @Task.create(IntervalTrigger(hours=12))
     async def do_banner(self) -> None:
@@ -69,16 +78,37 @@ class BackgroundTasks(Extension):
     async def background_task_reboot(self) -> None:
         if redis_wrapper.get_bool(self.do_reboot_key):
             logging.info('Got request to reboot from redis')
+            channel_id = redis_wrapper.get_int(reboot_utils.REBOOT_CHANNEL_KEY)
             try:
-                p = await asyncio.create_subprocess_shell('git pull')
-                await p.wait()
-                p = await asyncio.create_subprocess_shell(f'{sys.executable} -m uv sync')
-                await p.wait()
+                failure = await reboot_utils.update()
+                if failure:
+                    logging.error('Reboot update failed. Error code %s: %s', error_handling.error_code(failure), error_handling.redact(failure.diagnostic))
+                    if channel_id is not None:
+                        await self.send_reboot_message(channel_id, error_handling.public_message(failure))
+                    redis_wrapper.clear(self.do_reboot_key, reboot_utils.REBOOT_CHANNEL_KEY)
+                    return
             except Exception as c:
-                repo.create_issue('Bot error while rebooting', 'discord user', 'discordbot', 'PennyDreadfulMTG/perf-reports', exception=c)
-            redis_wrapper.clear(self.do_reboot_key)
-            await self.bot.stop()
-            sys.exit(0)
+                error_handling.log_exception(c, 'Unexpected error while rebooting')
+                if channel_id is not None:
+                    await self.send_reboot_message(channel_id, error_handling.public_message(c))
+                redis_wrapper.clear(self.do_reboot_key, reboot_utils.REBOOT_CHANNEL_KEY)
+                return
+            redis_wrapper.clear(self.do_reboot_key, reboot_utils.REBOOT_CHANNEL_KEY)
+            if channel_id is not None:
+                redis_wrapper.store(reboot_utils.REBOOT_COMPLETE_CHANNEL_KEY, channel_id, ex=3600)
+            try:
+                await asyncio.wait_for(self.bot.stop(), timeout=reboot_utils.SHUTDOWN_TIMEOUT_SECONDS)
+            except TimeoutError:
+                logging.warning('Graceful reboot shutdown timed out; forcing process exit')
+            os._exit(0)
+
+    async def send_reboot_message(self, channel_id: int, message: str) -> None:
+        try:
+            channel = await self.bot.fetch_channel(channel_id)
+            if isinstance(channel, MessageableMixin):
+                await channel.send(message)
+        except Exception as e:
+            error_handling.log_exception(e, f'Could not send reboot status to channel {channel_id}')
 
     async def prepare_tournaments(self) -> None:
         tournament_channel_id = configuration.get_int('tournament_reminders_channel_id')

--- a/discordbot/background_test.py
+++ b/discordbot/background_test.py
@@ -74,7 +74,7 @@ async def test_failed_reboot_sends_short_public_error(monkeypatch: pytest.Monkey
     assert '\n' not in message
     assert len(message) <= error_handling.MAX_PUBLIC_ERROR_LENGTH
     assert 'many' not in message
-    assert 'RebootUpdateError: git pull exited with status 1' in message
+    assert 'RebootUpdateError: git pull exited with status' in message
     bot.stop.assert_not_awaited()
 
 

--- a/discordbot/background_test.py
+++ b/discordbot/background_test.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from discordbot import error_handling, reboot_utils
+from discordbot.background import BackgroundTasks
+
+
+@pytest.mark.asyncio
+async def test_successful_reboot_records_channel_for_next_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace(stop=AsyncMock())
+    background = SimpleNamespace(
+        bot=bot,
+        do_reboot_key=reboot_utils.REBOOT_KEY,
+        send_reboot_message=AsyncMock(),
+    )
+    monkeypatch.setattr(reboot_utils, 'update', AsyncMock(return_value=None))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.get_bool', Mock(return_value=True))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.get_int', Mock(return_value=123))
+    clear = Mock()
+    store = Mock()
+    monkeypatch.setattr('discordbot.background.redis_wrapper.clear', clear)
+    monkeypatch.setattr('discordbot.background.redis_wrapper.store', store)
+    exit_process = Mock()
+    monkeypatch.setattr('discordbot.background.os._exit', exit_process)
+    await BackgroundTasks.background_task_reboot.callback(background)
+
+    store.assert_called_once_with(reboot_utils.REBOOT_COMPLETE_CHANNEL_KEY, 123, ex=3600)
+    bot.stop.assert_awaited_once()
+    exit_process.assert_called_once_with(0)
+    background.send_reboot_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_successful_reboot_forces_exit_after_shutdown_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = SimpleNamespace(stop=AsyncMock(side_effect=TimeoutError))
+    background = SimpleNamespace(
+        bot=bot,
+        do_reboot_key=reboot_utils.REBOOT_KEY,
+        send_reboot_message=AsyncMock(),
+    )
+    monkeypatch.setattr(reboot_utils, 'update', AsyncMock(return_value=None))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.get_bool', Mock(return_value=True))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.get_int', Mock(return_value=123))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.clear', Mock())
+    monkeypatch.setattr('discordbot.background.redis_wrapper.store', Mock())
+    exit_process = Mock()
+    monkeypatch.setattr('discordbot.background.os._exit', exit_process)
+
+    await BackgroundTasks.background_task_reboot.callback(background)
+
+    exit_process.assert_called_once_with(0)
+
+
+@pytest.mark.asyncio
+async def test_failed_reboot_sends_short_public_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    failure = reboot_utils.RebootUpdateError('git pull', 1, 'many\nlines\nof technical output')
+    bot = SimpleNamespace(stop=AsyncMock())
+    background = SimpleNamespace(
+        bot=bot,
+        do_reboot_key=reboot_utils.REBOOT_KEY,
+        send_reboot_message=AsyncMock(),
+    )
+    monkeypatch.setattr(reboot_utils, 'update', AsyncMock(return_value=failure))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.get_bool', Mock(return_value=True))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.get_int', Mock(return_value=123))
+    monkeypatch.setattr('discordbot.background.redis_wrapper.clear', Mock())
+
+    await BackgroundTasks.background_task_reboot.callback(background)
+
+    message = background.send_reboot_message.await_args.args[1]
+    assert '\n' not in message
+    assert len(message) <= error_handling.MAX_PUBLIC_ERROR_LENGTH
+    assert 'many' not in message
+    assert 'RebootUpdateError: git pull exited with status 1' in message
+    bot.stop.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_announces_completed_reboot(monkeypatch: pytest.MonkeyPatch) -> None:
+    send_reboot_message = AsyncMock()
+    background = cast(
+        BackgroundTasks,
+        SimpleNamespace(
+            bot=SimpleNamespace(commit_id='1234567890abcdef'),
+            send_reboot_message=send_reboot_message,
+        ),
+    )
+    monkeypatch.setattr('discordbot.background.redis_wrapper.get_int', Mock(return_value=123))
+    clear = Mock()
+    monkeypatch.setattr('discordbot.background.redis_wrapper.clear', clear)
+
+    await BackgroundTasks.announce_reboot_complete(background)
+
+    clear.assert_called_once_with(reboot_utils.REBOOT_COMPLETE_CHANNEL_KEY)
+    send_reboot_message.assert_awaited_once_with(123, 'Reboot complete. Loaded `12345678`')

--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -1,14 +1,16 @@
 import asyncio
+import datetime
 import logging
 import subprocess
-from typing import Any
+from typing import Any, cast
 
 from interactions import Client, listen
-from interactions.api.events import MemberAdd, MessageCreate, MessageReactionAdd, PresenceUpdate
+from interactions.api.events import CommandError, MemberAdd, MessageCreate, MessageReactionAdd, PresenceUpdate
+from interactions.client.errors import CommandCheckFailure, CommandOnCooldown, MaxConcurrencyReached
 from interactions.models import ActivityType, Guild, GuildText, Intents, Member, Role
 
 import discordbot.commands
-from discordbot import command
+from discordbot import command, error_handling
 from discordbot.shared import guild_id
 from magic import fetcher, multiverse, oracle, whoosh_write
 from shared import configuration, perf, repo
@@ -18,13 +20,17 @@ from shared.settings import with_config_file
 
 class Bot(Client):
     def __init__(self, **kwargs: Any) -> None:
+        error_handling.configure_logging()
         self.launch_time = perf.start()
-        commit_id = subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode()
-        redis.store('discordbot:commit_id', commit_id)
+        self.started_at = datetime.datetime.now(datetime.UTC)
+        self.commit_id = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
+        self._shutdown_lock = asyncio.Lock()
+        self._shutdown_complete = False
+        redis.store('discordbot:commit_id', self.commit_id)
 
         intents = Intents(Intents.DEFAULT | Intents.MESSAGES | Intents.GUILD_PRESENCES | Intents.MESSAGE_CONTENT)
 
-        super().__init__(intents=intents, sync_interactions=True, delete_unused_application_cmds=True, slash_context=command.MtgInteractionContext, **kwargs)
+        super().__init__(intents=intents, sync_interactions=True, delete_unused_application_cmds=True, send_command_tracebacks=False, slash_context=command.MtgInteractionContext, **kwargs)
         self.achievement_cache: dict[str, dict[str, str]] = {}
         discordbot.commands.setup(self)
         if configuration.bot_debug.value:
@@ -38,7 +44,15 @@ class Bot(Client):
         self.add_global_autocomplete(command.autocomplete_card)
 
     async def stop(self) -> None:
-        await super().stop()
+        async with self._shutdown_lock:
+            if self._shutdown_complete:
+                return
+            self._ready.clear()
+            # interactions.py closes HTTP before the gateway, allowing the
+            # heartbeat task to write to an already-closing WebSocket.
+            await self._connection_state.stop()
+            await self.http.close()
+            self._shutdown_complete = True
 
     @listen()
     async def on_ready(self) -> None:
@@ -50,6 +64,21 @@ class Bot(Client):
     @listen()
     async def on_startup(self) -> None:
         perf.check(self.launch_time, 'slow_bot_start', '', 'discordbot')
+
+    @listen(disable_default_listeners=True)
+    async def on_command_error(self, event: CommandError) -> None:
+        ctx = cast(command.MtgInteractionContext, event.ctx)
+        if isinstance(event.error, CommandOnCooldown):
+            await ctx.send(f'This command is on cooldown. Try again in {int(event.error.cooldown.get_cooldown_time())} seconds.')
+            return
+        if isinstance(event.error, MaxConcurrencyReached):
+            await ctx.send('This command is already busy. Please try again shortly.')
+            return
+        if isinstance(event.error, CommandCheckFailure):
+            await ctx.send('You do not have permission to run this command.')
+            return
+        error_handling.log_exception(event.error, f'Unhandled error in /{ctx.invoke_target}')
+        await ctx.send(error_handling.public_message(event.error))
 
     @listen()
     async def on_message_create(self, event: MessageCreate) -> None:

--- a/discordbot/bot_test.py
+++ b/discordbot/bot_test.py
@@ -1,0 +1,30 @@
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, Mock, call
+
+import pytest
+
+from discordbot.bot import Bot
+
+
+@pytest.mark.asyncio
+async def test_stop_closes_gateway_before_http_and_only_once() -> None:
+    calls = Mock()
+    ready = Mock()
+    bot = cast(
+        Bot,
+        SimpleNamespace(
+            _shutdown_lock=asyncio.Lock(),
+            _shutdown_complete=False,
+            _ready=ready,
+            _connection_state=SimpleNamespace(stop=AsyncMock(wraps=calls.gateway_stop)),
+            http=SimpleNamespace(close=AsyncMock(wraps=calls.http_close)),
+        ),
+    )
+
+    await Bot.stop(bot)
+    await Bot.stop(bot)
+
+    assert calls.mock_calls == [call.gateway_stop(), call.http_close()]
+    ready.clear.assert_called_once_with()

--- a/discordbot/commands/configure.py
+++ b/discordbot/commands/configure.py
@@ -1,11 +1,10 @@
-import logging
-import traceback
 from typing import Any
 
 from interactions import Client, Extension, OptionType, check, is_owner, slash_option
 from interactions.client.errors import CommandException
 from interactions.models import slash_command
 
+from discordbot import error_handling
 from discordbot.command import MtgContext
 from shared import settings
 
@@ -53,9 +52,8 @@ class Configure(Extension):
         elif isinstance(error, CommandException):
             await ctx.send(self.help_message(None))
         else:
-            logging.error(error)
-            traceback.print_exception(type(error), error, error.__traceback__)
-            await ctx.send('There was an error processing your command')
+            error_handling.log_exception(error, 'Unhandled error in /configure')
+            await ctx.send(error_handling.public_message(error))
 
     def help_message(self, scope: Any) -> str:
         msg = '/configure {server|channel} {SETTING=VALUE}\n\n'

--- a/discordbot/commands/debug.py
+++ b/discordbot/commands/debug.py
@@ -7,6 +7,7 @@ from interactions.client import Client
 from interactions.client.errors import CommandCheckFailure, ExtensionLoadException
 from interactions.models import check, is_owner
 
+from discordbot import error_handling
 from discordbot.command import MtgContext
 
 
@@ -25,9 +26,11 @@ class PDDebug(Extension):
                     if ctx.message:
                         await ctx.message.add_reaction('▶')
                 except ExtensionLoadException as c:
-                    await ctx.send(str(c))
+                    error_handling.log_exception(c, f'Could not load extension {module}')
+                    await ctx.send(error_handling.public_message(c, f'Could not load {module}'))
             else:
-                await ctx.send(str(e))
+                error_handling.log_exception(e, f'Could not reload extension {module}')
+                await ctx.send(error_handling.public_message(e, f'Could not reload {module}'))
 
     @regrow.error
     async def regrow_error(self, error: Exception, ctx: MtgContext) -> None:

--- a/discordbot/commands/reboot.py
+++ b/discordbot/commands/reboot.py
@@ -1,7 +1,9 @@
 # from interactions.models.checks import is_owner
 from interactions import Client, Extension, check, is_owner, slash_command
 
+from discordbot import reboot_utils
 from discordbot.command import MtgContext
+from discordbot.shared import channel_id
 from shared import redis_wrapper
 
 
@@ -10,13 +12,16 @@ class Reboot(Extension):
     @check(is_owner())
     async def reboot(self, ctx: MtgContext) -> None:
         """Restart the bot."""
-        if redis_wrapper.get_bool('discordbot:do_reboot'):
-            await ctx.send('rebooting!')
-            await ctx.bot.stop()
+        if redis_wrapper.get_bool(reboot_utils.REBOOT_KEY):
+            await ctx.send('A reboot is already scheduled.')
             return
 
         await ctx.send('Scheduling reboot')
-        redis_wrapper.store('discordbot:do_reboot', True)
+        redis_wrapper.clear(reboot_utils.REBOOT_CHANNEL_KEY)
+        requesting_channel_id = channel_id(ctx)
+        if requesting_channel_id is not None:
+            redis_wrapper.store(reboot_utils.REBOOT_CHANNEL_KEY, requesting_channel_id, ex=600)
+        redis_wrapper.store(reboot_utils.REBOOT_KEY, True, ex=600)
 
 def setup(bot: Client) -> None:
     Reboot(bot)

--- a/discordbot/commands/version.py
+++ b/discordbot/commands/version.py
@@ -1,3 +1,6 @@
+import datetime
+import logging
+import os
 import subprocess
 from importlib.metadata import version as _v
 
@@ -6,6 +9,7 @@ from interactions.models import Embed, slash_command
 
 from discordbot.command import MtgContext
 from magic import database
+from shared.pd_exception import DatabaseException
 
 
 class Version(Extension):
@@ -13,12 +17,23 @@ class Version(Extension):
     async def version(self, ctx: MtgContext) -> None:
         """Display the current version numbers"""
         embed = Embed(title='Version')
-        commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip('\n').strip('"')
-        embed.add_field('Commit hash', commit)
-        age = subprocess.check_output(['git', 'show', '-s', '--format=%ct ', 'HEAD'], text=True).strip('\n').strip('"')
-        embed.add_field('Commit age', Timestamp.fromtimestamp(int(age)))
-        scryfall = Timestamp.fromdatetime(database.last_updated())
-        embed.add_field('Scryfall last updated', scryfall)
+        checkout_commit = subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip()
+        loaded_commit = getattr(ctx.bot, 'commit_id', checkout_commit)
+        embed.add_field('Loaded commit', loaded_commit)
+        if checkout_commit != loaded_commit:
+            embed.add_field('Checkout commit', checkout_commit)
+        age = subprocess.check_output(['git', 'show', '-s', '--format=%ct', loaded_commit], text=True).strip()
+        embed.add_field('Loaded commit age', Timestamp.fromtimestamp(int(age)))
+        started_at = getattr(ctx.bot, 'started_at', None)
+        if isinstance(started_at, datetime.datetime):
+            embed.add_field('Process started', Timestamp.fromdatetime(started_at))
+        embed.add_field('Process ID', str(os.getpid()))
+        try:
+            scryfall = Timestamp.fromdatetime(database.last_updated())
+            embed.add_field('Scryfall last updated', scryfall)
+        except DatabaseException as e:
+            logging.warning('Could not get the Scryfall update time for /version: %s', e)
+            embed.add_field('Scryfall last updated', 'Unavailable (database error)')
         snekver = _v('interactions.py')
         embed.add_field('interactions version', snekver)
         await ctx.send(embed=embed)

--- a/discordbot/error_handling.py
+++ b/discordbot/error_handling.py
@@ -1,0 +1,72 @@
+import hashlib
+import logging
+import os
+import re
+import traceback
+from logging.handlers import RotatingFileHandler
+
+from shared import repo
+
+LOG_FILE = os.path.abspath('discordbot.log')
+MAX_PUBLIC_ERROR_LENGTH = 200
+
+
+def configure_logging() -> None:
+    root_logger = logging.getLogger()
+    if any(getattr(handler, '_discordbot_log', False) for handler in root_logger.handlers):
+        return
+    handler = RotatingFileHandler(LOG_FILE, maxBytes=5_000_000, backupCount=3)
+    handler._discordbot_log = True  # type: ignore[attr-defined]
+    handler.setFormatter(logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s'))
+    root_logger.addHandler(handler)
+
+
+def error_code(error: Exception) -> str:
+    frames = traceback.extract_tb(error.__traceback__)
+    locations = '|'.join(f'{frame.filename}:{frame.name}:{frame.lineno}' for frame in frames)
+    diagnostic = getattr(error, 'diagnostic', str(error))
+    fingerprint = f'{type(error).__module__}.{type(error).__qualname__}|{diagnostic}|{locations}'
+    return hashlib.blake2s(fingerprint.encode(), digest_size=4).hexdigest().upper()
+
+
+def public_message(error: Exception, hint: str | None = None) -> str:
+    message = f'Something went wrong. Error code `{error_code(error)}`; ask a mod to look in `{_inline_code(LOG_FILE)}`.'
+    hint = hint if hint is not None else _exception_hint(error)
+    hint = _inline_code(_one_line(redact(hint)))
+    if hint:
+        hint_wrapper = ' Hint: ``.'
+        available = MAX_PUBLIC_ERROR_LENGTH - len(message) - len(hint_wrapper)
+        if available > 0:
+            message += f' Hint: `{hint[:available]}`.'
+    return message
+
+
+def log_exception(error: Exception, context: str) -> None:
+    formatted = redact(''.join(traceback.format_exception(type(error), error, error.__traceback__)))
+    logging.error(
+        '%s. Error code %s\n%s',
+        context,
+        error_code(error),
+        formatted,
+    )
+
+
+def redact(text: str) -> str:
+    for secret in repo.REDACTED_STRINGS:
+        if secret:
+            text = text.replace(secret, 'REDACTED')
+    return re.sub(r'(https?://)[^/\s@]+@', r'\1REDACTED@', text)
+
+
+def _one_line(text: str) -> str:
+    return ' '.join(text.split())
+
+
+def _inline_code(text: str) -> str:
+    return text.replace('`', "'")
+
+
+def _exception_hint(error: Exception) -> str:
+    detail = str(error).splitlines()[0].strip()
+    error_type = type(error).__name__
+    return f'{error_type}: {detail}' if detail else error_type

--- a/discordbot/error_handling.py
+++ b/discordbot/error_handling.py
@@ -37,7 +37,9 @@ def public_message(error: Exception, hint: str | None = None) -> str:
         hint_wrapper = ' Hint: ``.'
         available = MAX_PUBLIC_ERROR_LENGTH - len(message) - len(hint_wrapper)
         if available > 0:
-            message += f' Hint: `{hint[:available]}`.'
+            if len(hint) > available:
+                hint = hint[: max(available - 1, 0)].rstrip() + '…'
+            message += f' Hint: `{hint}`.'
     return message
 
 

--- a/discordbot/error_handling_test.py
+++ b/discordbot/error_handling_test.py
@@ -28,6 +28,7 @@ def test_public_message_is_short_and_one_line() -> None:
     assert 'Error code' in message
     assert error_handling.LOG_FILE in message
     assert f'`{error_handling.LOG_FILE}`' in message
+    assert message.endswith('…`.')
 
 
 def test_public_message_derives_hint_from_exception() -> None:

--- a/discordbot/error_handling_test.py
+++ b/discordbot/error_handling_test.py
@@ -1,0 +1,49 @@
+import logging
+
+import pytest
+
+from discordbot import error_handling
+
+
+def make_error(message: str) -> Exception:
+    try:
+        raise ValueError(message)
+    except ValueError as e:
+        return e
+
+
+def test_same_error_has_same_code() -> None:
+    assert error_handling.error_code(make_error('broken')) == error_handling.error_code(make_error('broken'))
+
+
+def test_different_errors_have_different_codes() -> None:
+    assert error_handling.error_code(make_error('first')) != error_handling.error_code(make_error('second'))
+
+
+def test_public_message_is_short_and_one_line() -> None:
+    message = error_handling.public_message(make_error('broken'), 'first line\n' + ('x' * 300))
+
+    assert '\n' not in message
+    assert len(message) <= error_handling.MAX_PUBLIC_ERROR_LENGTH
+    assert 'Error code' in message
+    assert error_handling.LOG_FILE in message
+    assert f'`{error_handling.LOG_FILE}`' in message
+
+
+def test_public_message_derives_hint_from_exception() -> None:
+    message = error_handling.public_message(make_error('broken\ntechnical detail'))
+
+    assert 'Hint: `ValueError: broken`.' in message
+    assert 'technical detail' not in message
+
+
+def test_log_exception_includes_traceback_but_redacts_secrets(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(error_handling.repo, 'REDACTED_STRINGS', {'secret'})
+    error = make_error('secret')
+
+    with caplog.at_level(logging.ERROR):
+        error_handling.log_exception(error, 'Command failed')
+
+    assert 'Traceback' in caplog.text
+    assert 'secret' not in caplog.text
+    assert 'REDACTED' in caplog.text

--- a/discordbot/reboot_utils.py
+++ b/discordbot/reboot_utils.py
@@ -1,0 +1,44 @@
+import asyncio
+
+REBOOT_KEY = 'discordbot:do_reboot'
+REBOOT_CHANNEL_KEY = 'discordbot:reboot_channel_id'
+REBOOT_COMPLETE_CHANNEL_KEY = 'discordbot:reboot_complete_channel_id'
+SHUTDOWN_TIMEOUT_SECONDS = 10
+
+
+class RebootUpdateError(Exception):
+    def __init__(self, command: str, returncode: int | None, output: str) -> None:
+        self.command = command
+        self.returncode = returncode
+        self.output = output.strip() or '(no output)'
+        status = f'exited with status {returncode}' if returncode is not None else 'could not be started'
+        super().__init__(f'{command} {status}')
+
+    @property
+    def diagnostic(self) -> str:
+        return f'{self}: {self.output}'
+
+
+async def update() -> RebootUpdateError | None:
+    commands = [
+        ('git pull', ('git', 'pull')),
+        ('uv sync', ('uv', 'sync', '--frozen')),
+    ]
+    for display, command in commands:
+        try:
+            returncode, output = await _run_command(*command)
+        except Exception as e:
+            return RebootUpdateError(display, None, str(e))
+        if returncode != 0:
+            return RebootUpdateError(display, returncode, output)
+    return None
+
+
+async def _run_command(*command: str) -> tuple[int, str]:
+    process = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await process.communicate()
+    return process.returncode or 0, stdout.decode(errors='replace')

--- a/discordbot/reboot_utils_test.py
+++ b/discordbot/reboot_utils_test.py
@@ -30,7 +30,7 @@ async def test_update_reports_pull_failure_and_does_not_sync(monkeypatch: pytest
     assert '\n' not in message
     assert len(message) <= 200
     assert 'fatal: pull failed' not in message
-    assert 'RebootUpdateError: git pull exited with status 1' in message
+    assert 'RebootUpdateError: git pull exited with status' in message
     run_command.assert_awaited_once_with('git', 'pull')
 
 

--- a/discordbot/reboot_utils_test.py
+++ b/discordbot/reboot_utils_test.py
@@ -1,0 +1,57 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discordbot import error_handling, reboot_utils
+
+
+@pytest.mark.asyncio
+async def test_update_runs_pull_then_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_command = AsyncMock(side_effect=[(0, 'pulled'), (0, 'synced')])
+    monkeypatch.setattr(reboot_utils, '_run_command', run_command)
+
+    assert await reboot_utils.update() is None
+    assert run_command.await_count == 2
+    assert run_command.await_args_list[0].args == ('git', 'pull')
+    assert run_command.await_args_list[1].args == ('uv', 'sync', '--frozen')
+
+
+@pytest.mark.asyncio
+async def test_update_reports_pull_failure_and_does_not_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_command = AsyncMock(return_value=(1, 'fatal: pull failed'))
+    monkeypatch.setattr(reboot_utils, '_run_command', run_command)
+
+    failure = await reboot_utils.update()
+
+    assert isinstance(failure, reboot_utils.RebootUpdateError)
+    assert str(failure) == 'git pull exited with status 1'
+    assert failure.output == 'fatal: pull failed'
+    message = error_handling.public_message(failure)
+    assert '\n' not in message
+    assert len(message) <= 200
+    assert 'fatal: pull failed' not in message
+    assert 'RebootUpdateError: git pull exited with status 1' in message
+    run_command.assert_awaited_once_with('git', 'pull')
+
+
+@pytest.mark.asyncio
+async def test_update_reports_sync_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_command = AsyncMock(side_effect=[(0, 'pulled'), (2, 'sync failed')])
+    monkeypatch.setattr(reboot_utils, '_run_command', run_command)
+
+    failure = await reboot_utils.update()
+
+    assert isinstance(failure, reboot_utils.RebootUpdateError)
+    assert str(failure) == 'uv sync exited with status 2'
+    assert failure.output == 'sync failed'
+
+
+def test_public_message_redacts_secrets_and_url_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(error_handling.repo, 'REDACTED_STRINGS', {'secret'})
+    failure = reboot_utils.RebootUpdateError('git pull', 1, 'details')
+
+    message = error_handling.public_message(failure, 'secret https://username:password@example.com/repo')
+
+    assert 'secret' not in message
+    assert 'username:password' not in message
+    assert 'REDACTED' in message

--- a/magic/seasons.py
+++ b/magic/seasons.py
@@ -182,7 +182,7 @@ def next_season_num() -> int:
 def season_num(code_to_look_for: str) -> int:
     try:
         return SEASONS.index(code_to_look_for) + 1
-    except KeyError as c:
+    except ValueError as c:
         raise InvalidDataException('I did not find the season code (`{code}`) in the list of seasons ({seasons}) and I am confused.'.format(code=code_to_look_for, seasons=','.join(SEASONS))) from c
 
 def last_rotation() -> datetime.datetime:

--- a/magic/seasons_test.py
+++ b/magic/seasons_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from magic import seasons
-from shared.pd_exception import DoesNotExistException
+from shared.pd_exception import DoesNotExistException, InvalidDataException
 
 
 def test_seasons_enum_uptodate() -> None:
@@ -27,6 +27,10 @@ def test_season_id() -> None:
     assert seasons.season_id('hou') == 5
     assert seasons.season_id('ALL') == 'all'
     assert seasons.season_id('all') == 'all'
+
+def test_season_num_rejects_unknown_code() -> None:
+    with pytest.raises(InvalidDataException, match='not-a-season'):
+        seasons.season_num('not-a-season')
 
 def test_season_code() -> None:
     assert seasons.season_code(1) == 'EMN'


### PR DESCRIPTION
## Summary

- replace user-visible Discord command tracebacks with short, redacted error codes, log paths, and exception-derived hints
- harden reboot updates, report pull/sync failures, announce successful restarts in the requesting channel, and bound shutdown time
- report loaded versus checked-out versions, tolerate version database failures, and fix unknown-season exception handling

## Testing

- manually verified generic `/history` failure reporting, reboot update failure reporting, a complete local reboot loop, restart announcement, `/history`, and `/version`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- `uv run --frozen pytest --confcutdir=. discordbot/background_test.py discordbot/bot_test.py discordbot/error_handling_test.py discordbot/reboot_utils_test.py magic/seasons_test.py -q` (19 passed)
- broad local suite: 598 passed, 2 skipped; 7 database-backed tests could not run because the local MySQL user cannot create `decksite_test`/`pdlogs`
