### PR TITLE
Throttle Dependabot CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Run Tests
 on: ['push', 'pull_request']
 
+# Keep automated dependency updates from filling all available runners while
+# allowing human-authored changes to run without a concurrency limit.
+concurrency:
+  group: ${{ github.actor == 'dependabot[bot]' && 'dependabot-ci' || github.run_id }}
+  queue: max
+
 jobs:
   mypy:
     name: mypy

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,12 @@ on:
   schedule:
     - cron: '0 17 * * 2'
 
+# Keep automated dependency updates from filling all available runners while
+# allowing human-authored changes to run without a concurrency limit.
+concurrency:
+  group: ${{ github.actor == 'dependabot[bot]' && 'dependabot-ci' || github.run_id }}
+  queue: max
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,6 +1,12 @@
 name: Labeler
 on: [pull_request]
 
+# Keep automated dependency updates from filling all available runners while
+# allowing human-authored changes to run without a concurrency limit.
+concurrency:
+  group: ${{ github.actor == 'dependabot[bot]' && 'dependabot-ci' || github.run_id }}
+  queue: max
+
 jobs:
   label:
 


### PR DESCRIPTION
## Summary

- serialize Dependabot-triggered test, CodeQL, and labeler workflows in one shared concurrency group
- retain up to 100 waiting Dependabot workflows with `queue: max`
- leave human-authored workflow runs unrestricted by assigning them unique run-based groups

## Testing

- `uvx pre-commit run check-yaml --files .github/workflows/build.yml .github/workflows/codeql-analysis.yml .github/workflows/labeler.yml`
- verify GitHub accepts and starts this human-authored PR's workflow runs

The latest standalone actionlint release predates GitHub's documented `queue` concurrency option and reports that key as unknown; GitHub's current workflow schema is authoritative.