### PR TITLE
Copy local config into Conductor workspaces

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.env*
+/config.json


### PR DESCRIPTION
## Summary
- add a shared .worktreeinclude rule for the Git-ignored config.json used by local development
- retain Conductor default-style .env file copying after introducing an explicit copy list

## Validation
- confirmed config.json is ignored by Git
- confirmed the committed file contains patterns only and no configuration values or credentials

Conductor Files to copy uses these patterns to copy matching Git-ignored files from the main checkout into each new local workspace.