### PR TITLE
Prioritize canonical card names in search

### DIFF
--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -241,13 +241,8 @@ async def autocomplete_card(ctx: AutocompleteContext) -> None:
     if not card:
         await ctx.send(choices=[])
         return
-    choices = []
     results = searcher().search(card)
-    choices.extend(results.exact)
-    choices.extend(results.prefix_whole_word)
-    choices.extend(results.other_prefixed)
-    choices.extend(results.fuzzy)
-    choices = [*set(choices)]
+    choices = list(dict.fromkeys(results.get_all_matches()))
     await ctx.send(choices=list(make_choice(c) for c in choices[:20]))
 
 class MtgMixin:

--- a/magic/whoosh_search.py
+++ b/magic/whoosh_search.py
@@ -12,12 +12,12 @@ from magic.whoosh_constants import WhooshConstants
 class SearchResult:
     def __init__(
             self,
-            exact: str | None,
+            exact: list[str],
             prefix_whole_word: list[str],
             other_prefixed: list[Any],
             fuzzy: list[tuple[str, float]],
     ) -> None:
-        self.exact = [exact] if exact else []
+        self.exact = exact if exact else []
         self.prefix_whole_word = prefix_whole_word if prefix_whole_word else []
         self.other_prefixed = other_prefixed if other_prefixed else []
         self.fuzzy = prune_fuzzy_by_score(fuzzy if fuzzy else [])
@@ -89,9 +89,20 @@ class WhooshSearcher:
 
     def initialize_trie(self) -> None:
         self.trie = pygtrie.CharTrie()
+        canonical_matches: dict[str, list[str]] = {}
+        alias_matches: dict[str, list[str]] = {}
         with self.ix.reader() as reader:
             for doc in reader.iter_docs():
-                self.trie[list(WhooshConstants.normalized_analyzer(doc[1]['name']))[0].text] = doc[1]['canonical_name']
+                name = list(WhooshConstants.normalized_analyzer(doc[1]['name']))[0].text
+                canonical_name = doc[1]['canonical_name']
+                canonical = list(WhooshConstants.normalized_analyzer(canonical_name))[0].text == name
+                matches_by_name = canonical_matches if canonical else alias_matches
+                matches = matches_by_name.setdefault(name, [])
+                if canonical_name not in matches:
+                    # The old one-value trie kept the last indexed match. Retain that ordering within each group while ensuring canonical names precede aliases.
+                    matches.insert(0, canonical_name)
+        for name in canonical_matches.keys() | alias_matches.keys():
+            self.trie[name] = canonical_matches.get(name, []) + alias_matches.get(name, [])
 
     def search(self, w: str) -> SearchResult:
         if not self.ix.up_to_date():
@@ -117,14 +128,14 @@ class WhooshSearcher:
             fuzzy = [(r['canonical_name'], r.score) for r in searcher.search(query, limit=40)]
         return SearchResult(exact, prefix_whole_word, other_prefixed, fuzzy)
 
-    def find_matches_by_prefix(self, query: str) -> tuple[str | None, list[str], list[str]]:
-        exact = None
+    def find_matches_by_prefix(self, query: str) -> tuple[list[str], list[str], list[str]]:
+        exact = []
         prefix_as_whole_word = []
         other_prefixed = []
         if self.trie.has_key(query):
             exact = self.trie.get(query)
         if self.trie.has_subtrie(query):
-            matches = self.trie.values(query)[(1 if exact else 0):]
+            matches = list(itertools.chain.from_iterable(self.trie.values(query)[(1 if exact else 0):]))
             whole_word, subword = classify(matches, query)
             prefix_as_whole_word.extend(whole_word)
             other_prefixed.extend(subword)

--- a/magic/whoosh_search_test.py
+++ b/magic/whoosh_search_test.py
@@ -1,7 +1,9 @@
 import unittest
+from pathlib import Path
 
 import pytest
 import whoosh
+from whoosh.index import create_in
 
 from magic import whoosh_write
 from magic.whoosh_search import WhooshSearcher
@@ -113,3 +115,35 @@ class WhooshSearchTest(unittest.TestCase):
 
 def is_included(name: str, cards: list[str]) -> bool:
     return len([x for x in cards if x == name]) >= 1
+
+def test_canonical_name_wins_alias_collision(tmp_path: Path) -> None:
+    ix = create_in(tmp_path, whoosh_write.WhooshWriter().schema)
+    writer = ix.writer()
+    for card_id, canonical_name, name in [
+        (1, 'Brainstorm', 'Brainstorm'),
+        (2, 'Harmonized Trio', 'Harmonized Trio'),
+        (2, 'Harmonized Trio', 'Brainstorm'),
+        (3, 'Graf Rats', 'Chittering Host'),
+        (4, 'Midnight Scavengers', 'Chittering Host'),
+    ]:
+        writer.update_document(
+            id=card_id,
+            canonical_name=canonical_name,
+            name=name,
+            name_tokenized=name,
+            name_stemmed=name,
+            name_normalized=name,
+        )
+    writer.commit()
+
+    searcher = WhooshSearcher.__new__(WhooshSearcher)
+    searcher.ix = ix
+    searcher.initialize_trie()
+
+    result = searcher.search('Brainstorm')
+    assert result.get_best_match() == 'Brainstorm'
+    assert result.get_all_matches() == ['Brainstorm', 'Harmonized Trio']
+
+    result = searcher.search('Chittering Host')
+    assert result.get_best_match() == 'Midnight Scavengers'
+    assert result.get_all_matches() == ['Midnight Scavengers', 'Graf Rats']


### PR DESCRIPTION
## Summary
- retain every card candidate for a normalized search name
- prioritize canonical names over face-name and other aliases
- preserve historical ordering for alias-only collisions and autocomplete results
- add regression coverage for Brainstorm and meld-name collisions

## Testing
- `uv run pytest magic/whoosh_search_test.py discordbot/command_test.py -q`
- `uv run ruff check magic/whoosh_search.py magic/whoosh_search_test.py discordbot/command.py`
- `uv run mypy magic/whoosh_search.py discordbot/command.py --follow-imports=skip`