### PR TITLE
Exclude Worldgorger Dragon from the color bar

### DIFF
--- a/magic/colors.py
+++ b/magic/colors.py
@@ -48,7 +48,7 @@ def find_colors(cs: list[Card]) -> tuple[list[str], list[str]]:
         card_colored_symbols = []
         if "you may pay {0} rather than pay this spell's mana cost" in c.oracle_text:
             continue  # Mostly for Ravenous Trap which people sideboard off color to play for the alternative cost.
-        if c.name in ['Damn', 'Dread Return', 'Simian Spirit Guide']:
+        if c.name in ['Damn', 'Dread Return', 'Simian Spirit Guide', 'Worldgorger Dragon']:
             continue  # Cards that you might play without hardcasting/using the front side.
         if 'you may begin the game with it on the battlefield' in c.oracle_text:
             continue  # You can play off-color leylines

--- a/magic/colors_test.py
+++ b/magic/colors_test.py
@@ -20,6 +20,7 @@ def test_find_colors() -> None:
     bedeck_bedazzle = oracle.load_card('Bedeck // Bedazzle')
     leyline_of_lifeforce = oracle.load_card('Leyline of Lifeforce')
     leyline_of_the_guildpact = oracle.load_card('Leyline of the Guildpact')
+    worldgorger_dragon = oracle.load_card('Worldgorger Dragon')
 
     assert (['U'], ['U', 'U', 'U', 'U']) == colors.find_colors([delver_of_secrets, delver_of_secrets, delver_of_secrets, delver_of_secrets])
     assert (['R'], ['R']) == colors.find_colors([dead_gone])
@@ -39,5 +40,6 @@ def test_find_colors() -> None:
     assert ([], []) == colors.find_colors([bedeck_bedazzle])
     assert ([], []) == colors.find_colors([leyline_of_lifeforce])
     assert ([], []) == colors.find_colors([leyline_of_lifeforce, leyline_of_the_guildpact])
+    assert ([], []) == colors.find_colors([worldgorger_dragon])
 
     assert (['W', 'U', 'R'], ['W', 'W', 'U', 'R']) == colors.find_colors([bedeck_bedazzle, bedeck_bedazzle, archangel_avacyn, delver_of_secrets, dead_gone])


### PR DESCRIPTION
## Summary

- exclude Worldgorger Dragon when calculating deck color bars
- add regression coverage for its reanimation use case

Fixes #14014

## Testing

- `uv run pytest magic/colors_test.py -q`
- `uv run ruff check magic/colors.py magic/colors_test.py`