### PR TITLE
Recover from expired MySQL connections

### DIFF
--- a/shared/database.py
+++ b/shared/database.py
@@ -60,8 +60,6 @@ class Database:
         except MySQLdb.Error as e:
             if e.args[0] == 1146:
                 raise DatabaseNoSuchTableException(f'Failed to execute `{sql}` with `{args}` because of `{e}`') from e
-            if e.args[0] == 2006:
-                self.connect()
             raise DatabaseException(f'Failed to execute `{sql}` with `{args}` because of `{e}`') from e
 
     def execute_with_reconnect(self, sql: str, args: list[ValidSqlArgumentDescription] | None = None, fetch_rows: bool | None = False) -> tuple[int, list[ValidSqlArgumentDescription]]:
@@ -79,9 +77,14 @@ class Database:
                     result = (n, [])
                 break
             except OperationalError as e:
-                if 'MySQL server has gone away' in str(e):
+                if e.args[0] == 2006 and not self.open_transactions:
                     print('MySQL server has gone away: trying to reconnect')
                     self.connect()
+                elif e.args[0] == 2006:
+                    open_transactions = self.open_transactions.copy()
+                    self.open_transactions = []
+                    self.connect()
+                    raise DatabaseException(f'MySQL server went away during open transactions `{open_transactions}`; they have been rolled back') from e
                 else:
                     # raise any other exception
                     raise

--- a/shared/database_test.py
+++ b/shared/database_test.py
@@ -1,7 +1,36 @@
-import pytest
+from unittest.mock import Mock, patch
 
-from shared.database import sqlescape, sqllikeescape
-from shared.pd_exception import InvalidArgumentException
+import pytest
+from MySQLdb import OperationalError
+
+from shared.database import Database, sqlescape, sqllikeescape
+from shared.pd_exception import DatabaseException, InvalidArgumentException
+
+
+def test_execute_reconnects_and_retries_when_server_has_gone_away() -> None:
+    db = Database.__new__(Database)
+    db.cursor = Mock()
+    db.cursor.execute.side_effect = [OperationalError(2006, 'Server has gone away'), 1]
+    db.open_transactions = []
+
+    with patch.object(db, 'connect') as connect:
+        assert db.execute_with_reconnect('SELECT 1') == (1, [])
+
+    connect.assert_called_once_with()
+    assert db.cursor.execute.call_count == 2
+
+def test_execute_does_not_retry_when_server_goes_away_during_transaction() -> None:
+    db = Database.__new__(Database)
+    db.cursor = Mock()
+    db.cursor.execute.side_effect = OperationalError(2006, 'Server has gone away')
+    db.open_transactions = ['transaction']
+
+    with patch.object(db, 'connect') as connect, pytest.raises(DatabaseException, match='during open transactions'):
+        db.execute_with_reconnect('INSERT INTO example VALUES (1)')
+
+    connect.assert_called_once_with()
+    assert db.cursor.execute.call_count == 1
+    assert db.open_transactions == []
 
 
 def test_sqlescape() -> None:


### PR DESCRIPTION
## Summary

- recognize MySQL error 2006 by numeric code instead of driver-specific message text
- reconnect and retry expired connections when no transaction is active
- reconnect without replaying statements when a connection is lost during a transaction
- add regression coverage for both paths

## Validation

- local integration repro with `SET SESSION wait_timeout = 1` reconnects and completes `BEGIN`
- `uv run --frozen pytest` (617 passed, 2 skipped)
- `uv run --frozen ruff check shared/database.py shared/database_test.py`
- `uv run --frozen mypy shared/database.py shared/database_test.py`