### PR TITLE
Handle missing archetype when creating sorting rules

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -98,11 +98,11 @@ def post_archetypes() -> wrappers.Response:
 
 @APP.route('/admin/rules/')
 @auth.demimod_required
-def edit_rules() -> wrappers.Response:
+def edit_rules(errors: list[str] | None = None) -> wrappers.Response:
     cnum = rs.num_classified_decks()
     tnum = ds.num_decks(rs.classified_decks_query())
     archetypes = archs.load_archetypes(order_by='a.name')
-    view = EditRules(cnum, tnum, rs.doubled_decks(), rs.mistagged_decks(), [], rs.load_all_rules(), archetypes, rs.excluded_archetype_info())
+    view = EditRules(cnum, tnum, rs.doubled_decks(), rs.mistagged_decks(), [], rs.load_all_rules(), archetypes, rs.excluded_archetype_info(), errors)
     return view.response()
 
 @APP.route('/admin/rules/', methods=['POST'])
@@ -112,7 +112,7 @@ def post_rules() -> wrappers.Response:
         rule_id = rs.add_rule(cast_int(request.form.get('archetype_id')))
         rs.update_cards_raw(rule_id, request.form.get('include', ''), request.form.get('exclude', ''))
     else:
-        raise InvalidArgumentException(f'Did not find any of the expected keys in POST to /admin/rules: {request.form}')
+        return edit_rules(['Please select an archetype.'])
     return edit_rules()
 
 @APP.route('/admin/retire/')

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -1,0 +1,18 @@
+from typing import Any, cast
+
+import pytest
+
+from decksite.controllers import admin
+from decksite.main import APP
+from decksite.views import EditRules
+
+
+def test_post_rules_requires_archetype(monkeypatch: pytest.MonkeyPatch) -> None:
+    def edit_rules(errors: list[str] | None = None) -> str:
+        return EditRules(0, 0, [], [], [], [], [], [], errors).render_content()
+
+    monkeypatch.setattr(admin, 'edit_rules', edit_rules)
+    with APP.test_request_context('/admin/rules/', method='POST', data={'archetype_id': '', 'include': '4 Lightning Bolt'}):
+        response = cast(Any, admin.post_rules).__wrapped__()
+    assert 'Please select an archetype.' in response
+    assert '<select name="archetype_id" required class="error" aria-describedby="archetype-error">' in response

--- a/decksite/templates/archetypedropdown.mustache
+++ b/decksite/templates/archetypedropdown.mustache
@@ -1,4 +1,4 @@
-<select name="{{prefix}}archetype_id">
+<select name="{{prefix}}archetype_id" {{#archetype_required}}required{{/archetype_required}} {{#archetype_error}}class="error" aria-describedby="archetype-error"{{/archetype_error}}>
     <option value="">[Select]</option>
     {{#archetypes}}
         <option value="{{id}}" {{#selected}}selected="selected"{{/selected}}>{{name}}</option>

--- a/decksite/templates/editrules.mustache
+++ b/decksite/templates/editrules.mustache
@@ -122,6 +122,9 @@
 </section>
 <section>
     <h2>New Rule</h2>
+    {{#errors}}
+        <p id="archetype-error" class="error">{{.}}</p>
+    {{/errors}}
     <form method="post">
         <div>
             <label>Archetype</label>

--- a/decksite/views/edit_rules.py
+++ b/decksite/views/edit_rules.py
@@ -15,7 +15,8 @@ class EditRules(View):
                  overlooked_decks: list[Deck],
                  rules: list[Container],
                  archetypes: list[Archetype],
-                 excluded_archetype_info: list[Container]) -> None:
+                 excluded_archetype_info: list[Container],
+                 errors: list[str] | None = None) -> None:
         super().__init__()
         self.num_classified = num_classified
         self.num_total = num_total
@@ -44,6 +45,9 @@ class EditRules(View):
             ai.url = url_for('.archetype', archetype_id=ai.id)
         self.excluded_archetypes = excluded_archetype_info
         self.has_excluded_archetypes = len(self.excluded_archetypes) > 0
+        self.errors = errors or []
+        self.archetype_error = len(self.errors) > 0
+        self.archetype_required = True
 
     def page_title(self) -> str:
         return 'Edit Rules'


### PR DESCRIPTION
## Summary
- redisplay the new sorting-rule form with a clear error when no archetype is selected
- require the archetype dropdown in supporting browsers and expose the inline error accessibly
- add a regression test for the missing-archetype submission

## Testing
- `uv run pytest decksite -m "not functional and not gatherling and not external and not perf" -q` (342 passed)
- `uv run pytest decksite/controllers/admin_test.py decksite/view_test.py -q` (4 passed)
- `uv run mypy decksite/controllers/admin.py decksite/controllers/admin_test.py decksite/views/edit_rules.py`
- `uv run ruff check decksite/controllers/admin.py decksite/controllers/admin_test.py decksite/views/edit_rules.py`

Fixes #13739