### PR TITLE
Sanitize deck export filenames

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -124,7 +124,7 @@ def normalize(d: Deck) -> str:
 def file_name(d: Deck) -> str:
     safe_name = normalize(d).replace(' ', '-')
     safe_name = re.sub('--+', '-', safe_name, flags=re.IGNORECASE)
-    safe_name = re.sub(':', '', anyascii(safe_name), flags=re.IGNORECASE)
+    safe_name = re.sub('[^0-9a-z-]', '', anyascii(safe_name), flags=re.IGNORECASE)
     return safe_name.strip('-')
 
 def remove_emoji_colors(name: str) -> str:

--- a/decksite/deck_name_test.py
+++ b/decksite/deck_name_test.py
@@ -374,6 +374,13 @@ def test_invalid_color() -> None:
     with pytest.raises(InvalidDataException):
         deck_name.normalize(d)
 
+def test_file_name_removes_punctuation() -> None:
+    d = Container({'original_name': "Thalia Can't Be a Villain, Surely",
+                   'archetype_name': None,
+                   'colors': [],
+                   'season_id': 39})
+    assert deck_name.file_name(d) == 'Thalia-Cant-Be-a-Villain-Surely'
+
 def test_canonicalize_colors() -> None:
     assert deck_name.canonicalize_colors([]) == set()
     assert deck_name.canonicalize_colors(['White', 'Black', 'Orzhov', 'Abzan']) == {'B', 'G', 'W'}


### PR DESCRIPTION
## Summary
- strip punctuation from deck export filenames after ASCII transliteration
- add a regression test for the affected deck name

## Testing
- uv run pytest decksite/deck_name_test.py
- uv run ruff check decksite/deck_name.py decksite/deck_name_test.py
- git diff --check

Fixes #13977