### PR TITLE
Restore Discord card disambiguation

### DIFF
--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -28,10 +28,6 @@ if TYPE_CHECKING:
 DEFAULT_CARDS_SHOWN = 4
 MAX_CARDS_SHOWN = 10
 MAX_CARD_INFORMATION_AGE = datetime.timedelta(days=2)
-DISAMBIGUATION_EMOJIS = [':one:', ':two:', ':three:', ':four:', ':five:']
-DISAMBIGUATION_EMOJIS_BY_NUMBER = {1: '1⃣', 2: '2⃣', 3: '3⃣', 4: '4⃣', 5: '5⃣'}
-DISAMBIGUATION_NUMBERS_BY_EMOJI = {'1⃣': 1, '2⃣': 2, '3⃣': 3, '4⃣': 4, '5⃣': 5}
-
 HELP_GROUPS: set[str] = set()
 
 @lazy_property
@@ -113,15 +109,6 @@ def simplify_string(s: str) -> str:
     s = ''.join(s.split())
     return re.sub(r'[\W_]+', '', s).lower()
 
-def disambiguation(cards: list[str]) -> str:
-    if len(cards) > 5:
-        return ','.join(cards)
-    return ' '.join([' '.join(x) for x in zip(DISAMBIGUATION_EMOJIS, cards)])
-
-async def disambiguation_reactions(message: Message, cards: list[str]) -> None:
-    for i in range(1, len(cards) + 1):
-        await message.add_reaction(DISAMBIGUATION_EMOJIS_BY_NUMBER[i])
-
 async def single_card_or_send_error(channel: TYPE_MESSAGEABLE_CHANNEL, args: str, author: Member, command: str) -> Card | None:
     if not args:
         await send(channel, f'{author.mention}: Please specify a card name.')
@@ -130,8 +117,7 @@ async def single_card_or_send_error(channel: TYPE_MESSAGEABLE_CHANNEL, args: str
     if result.has_match() and not result.is_ambiguous():
         return cards_from_names_with_mode([result.get_best_match()], mode, preferred_printing)[0]
     if result.is_ambiguous():
-        message = await send(channel, f'{author.mention}: Ambiguous name for {command}. Suggestions: {disambiguation(result.get_ambiguous_matches()[0:5])} (click number below)')
-        await disambiguation_reactions(message, result.get_ambiguous_matches()[0:5])
+        await send(channel, f'{author.mention}: Ambiguous name for {command}. Please use the slash command and choose one of its suggestions.')
     else:
         await send(channel, f'{author.mention}: No matches.')
     return None

--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -1,10 +1,11 @@
 import datetime
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from discordbot import command
-from discordbot.commands import resources
+from discordbot.commands import CardConverter, resources
 
 
 def test_roughly_matches() -> None:
@@ -94,6 +95,56 @@ def test_warning_for_stale_card_information(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(command.database, 'last_updated', lambda: now - datetime.timedelta(days=29))
 
     assert command.stale_card_information_warning() == '\nWARNING: card information is 4 weeks old'
+
+@pytest.mark.asyncio
+async def test_card_converter_uses_buttons_for_ambiguous_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    matches = ['Brainstone', 'Brainstorm', 'Harmonized Trio', 'Brain Freeze', 'Brain Maggot', 'Brain Pry']
+    shown_matches = matches[:5]
+    result = Mock()
+    result.has_match.return_value = True
+    result.is_ambiguous.return_value = True
+    result.get_ambiguous_matches.return_value = matches
+    selected_card = Mock()
+    monkeypatch.setattr(command, 'results_from_queries', lambda _: [(result, '', None)])
+    cards_from_names = Mock(return_value=[selected_card])
+    monkeypatch.setattr(command, 'cards_from_names_with_mode', cards_from_names)
+
+    ctx = Mock()
+    ctx.author.id = 123
+    ctx.author.mention = '<@123>'
+    ctx.invoke_target = 'history'
+    message = Mock()
+    message.edit = AsyncMock()
+    ctx.send = AsyncMock(return_value=message)
+    pressed_ctx = Mock()
+    pressed_ctx.author.id = 123
+    pressed_ctx.edit_origin = AsyncMock()
+
+    async def choose_second(message_arg: object, components: list[Any], check: Any, timeout: int) -> object:
+        assert message_arg == message
+        assert timeout == 60
+        matching_event = Mock()
+        matching_event.ctx = pressed_ctx
+        other_event = Mock()
+        other_event.ctx.author.id = 456
+        assert check(matching_event)
+        assert not check(other_event)
+        pressed_ctx.custom_id = components[1].custom_id
+        return matching_event
+
+    ctx.client.wait_for_component = AsyncMock(side_effect=choose_second)
+
+    converted = await CardConverter.convert(ctx, 'brain')
+
+    assert converted == selected_card
+    sent_components = ctx.send.await_args.kwargs['components']
+    assert len(sent_components) == 1
+    assert [button.label for button in sent_components[0]] == shown_matches
+    assert all(button.emoji is None for button in sent_components[0])
+    cards_from_names.assert_called_once_with(['Brainstorm'], '', None)
+    pressed_ctx.edit_origin.assert_awaited_once_with(content='<@123>: Selected **Brainstorm**.', components=[])
+    event = ctx.client.wait_for_component.await_args
+    assert event.kwargs['components'][1].custom_id is not None
 
 @pytest.mark.asyncio
 async def test_no_matches_includes_card_information_warning(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/discordbot/commands/__init__.py
+++ b/discordbot/commands/__init__.py
@@ -5,7 +5,8 @@ import logging
 from os import path
 
 from interactions import Client, SlashContext
-from interactions.models import InteractionCommand
+from interactions.api.events import Component
+from interactions.models import Button, ButtonStyle, InteractionCommand
 
 from discordbot import command
 from magic.models import Card
@@ -43,8 +44,22 @@ class CardConverter:
             if result.has_match() and not result.is_ambiguous():
                 return command.cards_from_names_with_mode([result.get_best_match()], mode, printing)[0]
             if result.is_ambiguous():
-                message = await ctx.send(f'{ctx.author.mention}: Ambiguous name for {ctx.invoke_target}. Suggestions: {command.disambiguation(result.get_ambiguous_matches()[0:5])}')
-                await command.disambiguation_reactions(message, result.get_ambiguous_matches()[0:5])
+                matches = result.get_ambiguous_matches()[:5]
+                buttons = [Button(style=ButtonStyle.SECONDARY, label=card_name[:80]) for card_name in matches]
+                message = await ctx.send(f'{ctx.author.mention}: Ambiguous name for {ctx.invoke_target}. Choose a card:', components=[buttons])
+
+                def chosen_by_author(event: Component) -> bool:
+                    return event.ctx.author.id == ctx.author.id
+
+                try:
+                    event = await ctx.client.wait_for_component(message, components=buttons, check=chosen_by_author, timeout=60)
+                except TimeoutError:
+                    await message.edit(content=f'{ctx.author.mention}: Card selection expired.', components=[])
+                    return None
+
+                selected = next(i for i, button in enumerate(buttons) if button.custom_id == event.ctx.custom_id)
+                await event.ctx.edit_origin(content=f'{ctx.author.mention}: Selected **{matches[selected]}**.', components=[])
+                return command.cards_from_names_with_mode([matches[selected]], mode, printing)[0]
             else:
                 message = await ctx.send(f'{ctx.author.mention}: No matches.')
                 await message.add_reaction('❎')


### PR DESCRIPTION
## Summary
- replace nonfunctional numbered reactions with clickable card-name buttons
- place up to five suggestions together in one horizontal action row
- continue the original slash command with the invoking user's selection and expire stale controls
- remove the obsolete reaction-based disambiguation helpers

## Testing
- `uv run pytest discordbot -q`
- `uv run ruff check discordbot/command.py discordbot/commands/__init__.py discordbot/command_test.py`
- `uv run mypy discordbot/command.py discordbot/commands/__init__.py discordbot/command_test.py`