### PR TITLE
Increase deck tooltip width

### DIFF
--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -191,7 +191,7 @@ PD.initTooltips = function() {
         Tipped.delegate("main [title]", {
             "showDelay": 500,
             "size": "large",
-            maxWidth: "200"
+            maxWidth: "250"
         });
         $("body").off();
     });


### PR DESCRIPTION
## Summary

- increase the maximum tooltip width from 200px to 250px
- keep long decklist entries such as Asmoranomardicadaistinaculdacar with their quantity

## Tests

- `npx eslint shared_web/static/js/pd.js`
- `npm run build`

Fixes #13408