### PR TITLE
Link netdecking explanation to metagame

### DIFF
--- a/discordbot/commands/explain.py
+++ b/discordbot/commands/explain.py
@@ -78,11 +78,10 @@ explanations: dict[str, tuple[str, dict[str, str]]] = {
     'netdecking': (
         """
         Netdecking is both allowed and encouraged. Most deck creators are happy when others play their decks.
-        You can get a glimpse of the meta via the archetypes link below. Sort by win percent to find the best-performing decks.
+        You can get a glimpse of the meta via the metagame link below. Sort by win percent to find the best-performing decks.
         """,
         {
-            'Archetypes': fetcher.decksite_url('/archetypes/'),
-            'All Decklists': fetcher.decksite_url('/decks/'),
+            'Metagame': fetcher.decksite_url('/metagame/'),
         },
     ),
     'nextround': (


### PR DESCRIPTION
## Summary
- replace the separate archetypes and decklists links in `/explain netdecking` with the metagame page
- update the explanation copy to match the new link

## Testing
- `uv run --frozen python dev.py test` (620 passed, 2 skipped)

Closes #13226