### PR TITLE
Support is:party in card search

### DIFF
--- a/find/find_test.py
+++ b/find/find_test.py
@@ -627,6 +627,10 @@ def test_is_outlaw() -> None:
     do_functional_test('is:outlaw', ['Malcolm, Alluring Scoundrel', 'Shardless Agent', 'Faerie Vandal', 'Murderous Redcap', 'Faerie Dreamthief'], ['Ponder', 'Deep-Cavern Bat', 'Delver of Secrets'])
 
 @pytest.mark.functional
+def test_is_party() -> None:
+    do_functional_test('is:party', ['Mother of Runes', "Thieves' Guild Enforcer", 'Kargan Intimidator', 'Snapcaster Mage', 'Changeling Outcast', 'Stonework Packbeast'], ['Ponder', 'Knowledge Exploitation'])
+
+@pytest.mark.functional
 def test_is_historic() -> None:
     do_functional_test('is:historic', ['Black Lotus', 'Batterskull', 'Karakas', 'Isamaru, Hound of Konda', 'Founding the Third Path'], ['Pacifism', 'Greater Auramancy', 'Figure of Destiny'])
 

--- a/find/search.py
+++ b/find/search.py
@@ -436,6 +436,7 @@ def is_subquery(subquery_name: str) -> str:
         'gainland': 't:land o:"When this land enters, you gain 1 life."',
         'historic': 't:artifact OR t:legendary OR t:saga',
         'outlaw': 't:Assassin OR t:Mercenary OR t:Pirate OR t:Rogue OR t:Warlock',
+        'party': 't:creature (t:Cleric OR t:Rogue OR t:Warrior OR t:Wizard OR o:/^Changeling/ OR o:"is also a Cleric, Rogue, Warrior, and Wizard.")',
         'painland': r't:land o:/Add \{.\} or \{.\}. this land deals 1 damage to you./ -o:"this land enters tapped"',
         'permanent': 't:artifact OR t:creature OR t:enchantment OR t:land OR t:planeswalker',
         'scryland': 't:land "Temple of" o:"When this land enters, scry 1"',


### PR DESCRIPTION
## Summary

- add `is:party` support for Clerics, Rogues, Warriors, Wizards, changelings, and explicit all-party creatures
- exclude noncreature Kindred cards from party results
- add functional regression coverage

## Testing

- `uv run python dev.py test find`
- `uv run ruff check find/search.py find/find_test.py`

Fixes #13193