### PR TITLE
Prefer standard image for requested sets

### DIFF
--- a/magic/image_fetcher.py
+++ b/magic/image_fetcher.py
@@ -18,7 +18,11 @@ if not os.path.exists(configuration.get_str('image_dir')):
     os.makedirs(configuration.get_str('image_dir'), exist_ok=True)
 
 def basename(cards: list[Card]) -> str:
-    return '_'.join(re.sub('[^a-z-]', '-', card.canonicalize(c.name)) + (c.get('preferred_printing', '') or '') for c in cards)
+    return '_'.join(
+        re.sub('[^a-z-]', '-', card.canonicalize(c.name))
+        + (f'-{preferred_printing}' if (preferred_printing := c.get('preferred_printing')) else '')
+        for c in cards
+    )
 
 def bluebones_image(cards: list[Card]) -> str:
     c = '|'.join(c.name for c in cards)
@@ -33,7 +37,7 @@ def scryfall_image(c: Card, version: str = '', face: str | None = None) -> str:
         name = c.name
     p = oracle.get_printing(c, c.get('preferred_printing'))
     if p is not None:
-        u = f'https://api.scryfall.com/cards/{p.set_code}/{p.number}?format=image'
+        u = f'https://api.scryfall.com/cards/named?exact={escape(name)}&set={escape(p.set_code)}&format=image'
     else:
         u = f'https://api.scryfall.com/cards/named?exact={escape(name)}&format=image'
     if version:

--- a/magic/image_fetcher_test.py
+++ b/magic/image_fetcher_test.py
@@ -1,0 +1,13 @@
+from copy import copy
+
+from magic import image_fetcher, oracle
+
+
+def test_scryfall_image_uses_default_printing_within_preferred_set() -> None:
+    c = copy(oracle.load_card('Sultai Ascendancy'))
+    c['preferred_printing'] = 'ktk'
+
+    assert image_fetcher.basename([c]) == 'sultai-ascendancy-ktk'
+    assert image_fetcher.scryfall_image(c, version='border_crop') == (
+        'https://api.scryfall.com/cards/named?exact=sultai+ascendancy&set=ktk&format=image&version=border_crop'
+    )


### PR DESCRIPTION
## Summary

- let Scryfall choose the default printing when a Discord card query specifies a set
- invalidate existing set-specific image cache entries so corrected images are downloaded
- add regression coverage for `[Sultai Ascendancy | ktk]`

## Testing

- `uv run pytest magic/image_fetcher_test.py discordbot/command_test.py -q`
- `uv run ruff check magic/image_fetcher.py magic/image_fetcher_test.py`
- `uv run mypy magic/image_fetcher.py magic/image_fetcher_test.py`

Fixes #13183