### PR TITLE
Prevent external redirects during authentication

### DIFF
--- a/shared_web/flask_app.py
+++ b/shared_web/flask_app.py
@@ -103,11 +103,9 @@ class PDFlask(Flask):
 
     def logout(self) -> wrappers.Response:
         oauth.logout()
-        target = request.args.get('target', 'home')
-        if bool(urllib.parse.urlparse(target).netloc):
-            response = redirect(target)
-        else:
-            response = redirect(url_for(target))
+        target = request.args.get('target')
+        url = self.redirect_target(target) or url_for('home')
+        response = redirect(url)
         # Clean up any session cookie set with no domain created when the site was misconfigured.
         # If we don't then you won't actually log out, we'll keep respecting the no-domain cookie.
         # The cookies we actually want are set with domain=.pennydreadfulmagic.com so they work on subdomains.
@@ -118,8 +116,11 @@ class PDFlask(Flask):
         target = request.args.get('target')
         authorization_url, state = oauth.setup_authentication()
         session['oauth2_state'] = state
-        if target is not None:
-            session['target'] = target
+        safe_target = self.redirect_target(target)
+        if safe_target is not None:
+            session['target'] = safe_target
+        else:
+            session.pop('target', None)
         response = redirect(authorization_url)
         # Google doesn't like the discordapp.com page we redirect to being disallowed in discordapp.com's robots.txt without `X-Robots-Tag: noindex` in our response.
         # See https://support.google.com/webmasters/answer/93710
@@ -130,11 +131,27 @@ class PDFlask(Flask):
         if request.values.get('error'):
             return redirect(url_for('unauthorized', error=request.values['error']))
         oauth.setup_session(request.url)
-        url = session.get('target')
-        if url is None:
-            url = url_for('home')
-        session['target'] = None
+        target = session.pop('target', None)
+        url = self.redirect_target(target) or url_for('home')
         return redirect(url)
+
+    def redirect_target(self, target: str | None) -> str | None:
+        if target is None:
+            return None
+        if target in self.view_functions:
+            return url_for(target)
+        try:
+            parsed_target = urllib.parse.urlsplit(target)
+            parsed_host = urllib.parse.urlsplit(request.host_url)
+        except ValueError:
+            return None
+        decoded_path = urllib.parse.unquote(parsed_target.path)
+        if not decoded_path.startswith('/') or decoded_path.startswith('//') or '\\' in decoded_path:
+            return None
+        if parsed_target.scheme or parsed_target.netloc:
+            if parsed_target.scheme.lower() not in {'http', 'https'} or parsed_target.netloc.lower() != parsed_host.netloc.lower():
+                return None
+        return urllib.parse.urlunsplit(('', '', parsed_target.path, parsed_target.query, parsed_target.fragment))
 
     def robots_txt(self) -> Response:
         """

--- a/shared_web/flask_app_test.py
+++ b/shared_web/flask_app_test.py
@@ -1,0 +1,76 @@
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from shared_web import oauth
+from shared_web.flask_app import PDFlask
+
+
+@pytest.fixture
+def app() -> PDFlask:
+    flask_app = PDFlask(__name__)
+    flask_app.config['SECRET_KEY'] = 'test'
+
+    @flask_app.route('/')
+    def home() -> str:
+        return ''
+
+    @flask_app.route('/destination/')
+    def destination() -> str:
+        return ''
+
+    return flask_app
+
+
+@pytest.mark.parametrize('target', [
+    'https://attacker.example/phishing',
+    '//attacker.example/phishing',
+    r'/\\attacker.example/phishing',
+])
+def test_logout_does_not_redirect_to_an_external_target(app: PDFlask, target: str) -> None:
+    response = app.test_client().get('/logout/', query_string={'target': target})
+
+    assert response.location == '/'
+
+
+@pytest.mark.parametrize('target,expected', [
+    ('destination', '/destination/'),
+    ('/destination/?tab=details', '/destination/?tab=details'),
+    ('https://localhost/destination/?tab=details', '/destination/?tab=details'),
+])
+def test_logout_redirects_to_a_local_target(app: PDFlask, target: str, expected: str) -> None:
+    response = app.test_client().get('/logout/', query_string={'target': target}, base_url='https://localhost')
+
+    assert response.location == expected
+
+
+def test_authentication_does_not_save_an_external_target(app: PDFlask) -> None:
+    client: Any = app.test_client()
+    with mock.patch.object(oauth, 'setup_authentication', return_value=('https://discord.example/auth', 'state')):
+        client.get('/authenticate/', query_string={'target': 'https://attacker.example/phishing'})
+
+    with client.session_transaction() as session:
+        assert 'target' not in session
+
+
+def test_authentication_saves_a_local_target_as_a_path(app: PDFlask) -> None:
+    client: Any = app.test_client()
+    with mock.patch.object(oauth, 'setup_authentication', return_value=('https://discord.example/auth', 'state')):
+        client.get('/authenticate/', query_string={'target': 'https://localhost/destination/?tab=details'}, base_url='https://localhost')
+
+    with client.session_transaction() as session:
+        assert session['target'] == '/destination/?tab=details'
+
+
+def test_authentication_callback_does_not_redirect_to_an_external_target(app: PDFlask) -> None:
+    client: Any = app.test_client()
+    with client.session_transaction() as session:
+        session['target'] = 'https://attacker.example/phishing'
+
+    with mock.patch.object(oauth, 'setup_session'):
+        response = client.get('/authenticate/callback/')
+
+    assert response.location == '/'
+    with client.session_transaction() as session:
+        assert 'target' not in session


### PR DESCRIPTION
## Summary

- restrict logout and authentication targets to local paths or same-origin HTTP(S) URLs
- normalize accepted absolute URLs to local paths and fall back to home for unsafe targets
- revalidate stored targets at the authentication callback
- add regression coverage for external, protocol-relative, and backslash redirect attempts

## Tests

- `uv run pytest -q` (629 passed, 2 skipped)
- `uv run python dev.py mypy`
- `uv run python dev.py lint`

Closes #13310