### PR TITLE
Reject invalid images from /spoiler

### DIFF
--- a/discordbot/commands/spoiler.py
+++ b/discordbot/commands/spoiler.py
@@ -1,3 +1,5 @@
+import logging
+
 from interactions import Client, Extension
 from interactions.models import File, slash_command
 
@@ -5,6 +7,7 @@ from discordbot import emoji
 from discordbot.command import MtgContext, slash_card_option
 from magic import oracle
 from shared import configuration, fetch_tools
+from shared.fetch_tools import FetchException
 
 
 class Spoiler(Extension):
@@ -26,9 +29,17 @@ class Spoiler(Extension):
             c = sfcard['card_faces'][0]
         else:
             c = sfcard
-        fetch_tools.store(c['image_uris']['normal'], imagepath)
+        image_available = True
+        try:
+            fetch_tools.store_image(c['image_uris']['normal'], imagepath)
+        except FetchException as e:
+            logging.warning('Could not download image for %s: %s', sfcard['name'], e)
+            image_available = False
         text = await emoji.replace_emoji('{name} {mana}'.format(name=sfcard['name'], mana=c['mana_cost']), ctx.bot)
-        await ctx.send(file=File(imagepath), content=text)
+        if image_available:
+            await ctx.send(file=File(imagepath), content=text)
+        else:
+            await ctx.send(content=f'{text}\nImage unavailable.')
         await oracle.scryfall_import_async(sfcard['name'])
 
 def setup(bot: Client) -> None:

--- a/discordbot/commands/spoiler_test.py
+++ b/discordbot/commands/spoiler_test.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from discordbot.commands import spoiler
+from shared.fetch_tools import FetchException
+
+
+@pytest.mark.asyncio
+async def test_spoiler_does_not_send_invalid_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = {
+        'object': 'card',
+        'name': 'Unnatural Summons',
+        'set': 'ydsk',
+        'collector_number': '27',
+        'mana_cost': '{1}{G}{U}',
+        'image_uris': {'normal': 'https://example.com/not-an-image.jpg'},
+    }
+    ctx = SimpleNamespace(
+        author=SimpleNamespace(mention='<@123>'),
+        bot=Mock(),
+        send=AsyncMock(),
+    )
+    monkeypatch.setattr(spoiler.fetch_tools, 'fetch_json', Mock(return_value=card))
+    monkeypatch.setattr(spoiler.fetch_tools, 'store_image', Mock(side_effect=FetchException('invalid image')))
+    monkeypatch.setattr(spoiler.configuration, 'get', Mock(return_value='/tmp'))
+    monkeypatch.setattr(spoiler.emoji, 'replace_emoji', AsyncMock(return_value='Unnatural Summons 1GU'))
+    import_card = AsyncMock()
+    monkeypatch.setattr(spoiler.oracle, 'scryfall_import_async', import_card)
+
+    await spoiler.Spoiler.spoiler.callback(SimpleNamespace(), ctx, 'Unnatural Summons')
+
+    ctx.send.assert_awaited_once_with(content='Unnatural Summons 1GU\nImage unavailable.')
+    import_card.assert_awaited_once_with('Unnatural Summons')

--- a/shared/fetch_tools.py
+++ b/shared/fetch_tools.py
@@ -8,6 +8,7 @@ from typing import Any, BinaryIO
 
 import aiohttp
 import requests
+from PIL import Image, UnidentifiedImageError
 
 from shared import perf
 from shared.pd_exception import OperationalException
@@ -135,6 +136,38 @@ def store(url: str, path: str) -> requests.Response:
         raise FetchException(e) from e
     except requests.exceptions.ConnectionError as e:
         raise FetchException(e) from e
+
+def store_image(url: str, path: str) -> requests.Response:
+    """Download an image without leaving an error response or partial file at ``path``."""
+    logger.info(f'Storing image {url} in {path}')
+    temporary_path = ''
+    try:
+        response = requests.get(url, headers={'User-Agent': USER_AGENT}, stream=True)
+        response.raise_for_status()
+        content_type = response.headers.get('Content-Type', '').split(';', maxsplit=1)[0].strip().lower()
+        if not content_type.startswith('image/'):
+            raise FetchException(f'Expected an image from {url}, got `{content_type or "no content type"}`')
+
+        directory = os.path.dirname(os.path.abspath(path))
+        with tempfile.NamedTemporaryFile(dir=directory, delete=False) as fout:
+            temporary_path = fout.name
+            for chunk in response.iter_content(1024):
+                fout.write(chunk)
+
+        if not acceptable_file(temporary_path):
+            raise FetchException(f'Image from {url} was empty or unexpectedly small')
+        with Image.open(temporary_path) as image:
+            image.verify()
+        os.replace(temporary_path, path)
+        temporary_path = ''
+        return response
+    except FetchException:
+        raise
+    except (OSError, UnidentifiedImageError, requests.exceptions.RequestException) as e:
+        raise FetchException(f'Could not download a valid image from {url}: {e}') from e
+    finally:
+        if temporary_path and os.path.exists(temporary_path):
+            os.remove(temporary_path)
 
 
 async def store_async(url: str, path: str) -> aiohttp.ClientResponse:

--- a/shared/fetch_tools_test.py
+++ b/shared/fetch_tools_test.py
@@ -1,7 +1,12 @@
 import gzip
 import io
 import json
+from pathlib import Path
 from unittest.mock import Mock, patch
+
+import pytest
+import requests
+from PIL import Image
 
 from shared import fetch_tools
 
@@ -19,3 +24,37 @@ def test_load_jsonl_gzip() -> None:
     contents = gzip.compress(b''.join(f'{json.dumps(row)}\n'.encode() for row in rows))
 
     assert fetch_tools.load_jsonl_gzip(io.BytesIO(contents)) == rows
+
+
+def test_store_image_rejects_non_image_response(tmp_path: Path) -> None:
+    response = Mock(status_code=200, headers={'Content-Type': 'text/html'})
+    destination = tmp_path / 'card.jpg'
+
+    with patch.object(fetch_tools.requests, 'get', return_value=response), pytest.raises(fetch_tools.FetchException, match='Expected an image'):
+        fetch_tools.store_image('https://example.com/card.jpg', str(destination))
+
+    assert not destination.exists()
+
+
+def test_store_image_rejects_http_error(tmp_path: Path) -> None:
+    response = Mock(headers={'Content-Type': 'image/jpeg'})
+    response.raise_for_status.side_effect = requests.HTTPError('404 Client Error')
+    destination = tmp_path / 'card.jpg'
+
+    with patch.object(fetch_tools.requests, 'get', return_value=response), pytest.raises(fetch_tools.FetchException, match='Could not download'):
+        fetch_tools.store_image('https://example.com/card.jpg', str(destination))
+
+    assert not destination.exists()
+
+
+def test_store_image_only_publishes_valid_image(tmp_path: Path) -> None:
+    contents = io.BytesIO()
+    Image.new('RGB', (100, 100)).save(contents, format='BMP')
+    response = Mock(headers={'Content-Type': 'image/bmp'})
+    response.iter_content.return_value = [contents.getvalue()]
+    destination = tmp_path / 'card.bmp'
+
+    with patch.object(fetch_tools.requests, 'get', return_value=response):
+        fetch_tools.store_image('https://example.com/card.bmp', str(destination))
+
+    assert destination.read_bytes() == contents.getvalue()


### PR DESCRIPTION
## Summary

- validate spoiler image responses before saving or uploading them
- publish downloads atomically so partial files never reach Discord
- fall back to a text-only response when the image is unavailable while continuing the card import
- add regression coverage for invalid responses and the `/spoiler` fallback

Fixes #13232.

## Validation

- `uv run --frozen pytest -q shared/fetch_tools_test.py discordbot/commands/spoiler_test.py` (6 passed)
- `uv run --frozen ruff check shared/fetch_tools.py shared/fetch_tools_test.py discordbot/commands/spoiler.py discordbot/commands/spoiler_test.py`
- `uv run --frozen mypy shared/fetch_tools.py shared/fetch_tools_test.py discordbot/commands/spoiler.py discordbot/commands/spoiler_test.py`