### PR TITLE
Make notice banner links obvious

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -148,6 +148,10 @@ blockquote {
     padding: 1em;
 }
 
+.notice a {
+    text-decoration: underline;
+}
+
 main p, footer p {
     /*
         A space equal to 50-100% of the body text size will usually suffice. The larger the point size, the more space you'll need between paragraphs to make a visible difference.


### PR DESCRIPTION
## Summary

- underline links in the site-wide notice banner
- make PD500, Kick Off, and winner links identifiable before hover

## Testing

- `git diff --check`

Closes #12977