### PR TITLE
Update the Magic Online guide resource

### DIFF
--- a/decksite/resources.json
+++ b/decksite/resources.json
@@ -27,7 +27,7 @@
     "Chat": "https://discord.gg/H6EHdHu",
     "Legal cards list": "http://pdmtgo.com/legal_cards.txt",
     "Cardhoarder free loan program": "https://www.cardhoarder.com/loan-program/apply",
-    "Magic Online guide": "https://docs.google.com/document/d/1GGvhaISyESrrvPAkauP5LWKAixh6rcH1Q2jfbfpUOoA/edit",
+    "Magic Online guide": "https://www.mtgo.com/getting-started/getting-started-home",
     "Official site": "http://pdmtgo.com/",
     "Reddit": "https://reddit.com/r/PennyDreadfulMTG/"
   },

--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -70,6 +70,9 @@ def test_resources_matching_in_url() -> None:
     results = resources.resources_resources('starcitygames')
     assert results['https://old.starcitygames.com/article/33860_Penny-Dreadful.html'] == 'Mrs. Mulligan SCG'
 
+    results = resources.resources_resources('magic online guide')
+    assert results['https://www.mtgo.com/getting-started/getting-started-home'] == 'Magic Online guide'
+
 def test_escape_underscores() -> None:
     r = command.escape_underscores('simple_test')
     assert r == 'simple\\_test'


### PR DESCRIPTION
## Summary

- replace the outdated Google Doc with the maintained official MTGO Getting Started guide
- update both the website and Discord bot through their shared resource catalog
- add a regression assertion for the bot resource lookup

## Testing

- `uv run pytest discordbot/command_test.py -q`
- `uv run ruff check discordbot/command_test.py`
- verified the replacement URL returns HTTP 200

Fixes #12912