### PR TITLE
Fix Season 1 on seasons page

### DIFF
--- a/decksite/views/seasons.py
+++ b/decksite/views/seasons.py
@@ -9,8 +9,8 @@ from shared import dtutil
 class Seasons(View):
     def __init__(self, stats: dict[int, dict[str, int | datetime.datetime]]) -> None:
         super().__init__()
-        seasons = self.all_seasons()
-        seasons.pop()  # Don't show "all time" on this page as it is not fully supported yet.
+        # Don't show "all time" on this page as it is not fully supported yet.
+        seasons = [season for season in self.all_seasons() if season['num'] is not None]
         cards_count: dict[str, int] = {}
         for c in oracle.CARDS_BY_NAME.values():
             for f, is_legal in c.legalities.items():

--- a/decksite/views/seasons_test.py
+++ b/decksite/views/seasons_test.py
@@ -1,0 +1,33 @@
+import datetime
+
+import pytest
+
+from decksite.main import APP
+from decksite.view import View
+from decksite.views.seasons import Seasons
+from magic import oracle
+
+
+def test_includes_season_one_but_not_all_time(monkeypatch: pytest.MonkeyPatch) -> None:
+    all_seasons = [
+        {'name': 'All Time', 'num': None},
+        {'name': 'Season 2', 'num': 2, 'legality_name': 'Penny Dreadful KLD'},
+        {'name': 'Season 1', 'num': 1, 'legality_name': 'Penny Dreadful EMN'},
+    ]
+    stats: dict[int, dict[str, int | datetime.datetime]] = {
+        season_id: {
+            'start_date': datetime.datetime(2016, season_id, 1, tzinfo=datetime.UTC),
+            'end_date': datetime.datetime(2016, season_id + 1, 1, tzinfo=datetime.UTC),
+            'length_in_days': 30,
+            'num_decks': 1,
+            'num_matches': 1,
+        }
+        for season_id in [1, 2]
+    }
+    monkeypatch.setattr(View, 'all_seasons', lambda self: all_seasons)
+    monkeypatch.setattr(oracle, 'CARDS_BY_NAME', {})
+
+    with APP.test_request_context('/seasons/'):
+        view = Seasons(stats)
+
+    assert [season['num'] for season in view.seasons] == ['2', '1']


### PR DESCRIPTION
## Summary
- exclude the unsupported All Time entry by identity instead of removing the last season
- keep Season 1 visible on `/seasons/`
- add regression coverage for the displayed season list

## Tests
- `uv run --frozen pytest -q decksite/views/seasons_test.py decksite/view_test.py`
- `uv run --frozen ruff check decksite/views/seasons.py decksite/views/seasons_test.py`
- `uv run --frozen mypy decksite/views/seasons.py decksite/views/seasons_test.py`

Fixes #12933