### PR TITLE
Remove misleading netdecking advice

### DIFF
--- a/discordbot/commands/explain.py
+++ b/discordbot/commands/explain.py
@@ -78,7 +78,7 @@ explanations: dict[str, tuple[str, dict[str, str]]] = {
     'netdecking': (
         """
         Netdecking is both allowed and encouraged. Most deck creators are happy when others play their decks.
-        You can get a glimpse of the meta via the metagame link below. Sort by win percent to find the best-performing decks.
+        You can get a glimpse of the meta via the metagame link below.
         """,
         {
             'Metagame': fetcher.decksite_url('/metagame/'),


### PR DESCRIPTION
## Summary
- remove the suggestion to sort the metagame by win percentage from `/explain netdecking`
- retain the new link to the metagame page from #14836

## Testing
- `uv run --frozen python dev.py test` (643 passed, 2 skipped)