### PR TITLE
Point intro deck link to metagame

### DIFF
--- a/decksite/templates/faqsbody.mustache
+++ b/decksite/templates/faqsbody.mustache
@@ -18,7 +18,7 @@
         <div class="details">
             <p>{{_ Minimum 60 cards. Any number of basic lands. Max four of any other legal card. Sideboard of up to fifteen cards.}}</p>
             <p>{{_ The best way to build decks is to use a search engine that supports Penny Dreadful legality (f:pd) like [Scryfall](https://scryfall.com/search?q=f%3Apd).}}</p>
-            <p>{{_ Browse [Decklists]({decks_url}) from tournaments, leagues and elsewhere}}</p>
+            <p>{{_ Browse the [Metagame]({metagame_url}) for popular archetypes and successful decklists.}}</p>
             <p>{{_ View the full [legal cards list](http://pdmtgo.com/legal_cards.txt)}}</p>
         </div>
     </li>

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -182,6 +182,9 @@ class View(BaseView):
     def learn_more_url(self) -> str:
         return url_for('about', hide_intro=True)
 
+    def decks_url(self) -> str:
+        return url_for('decks')
+
     def metagame_url(self) -> str:
         return url_for('metagame')
 

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -182,8 +182,8 @@ class View(BaseView):
     def learn_more_url(self) -> str:
         return url_for('about', hide_intro=True)
 
-    def decks_url(self) -> str:
-        return url_for('decks')
+    def metagame_url(self) -> str:
+        return url_for('metagame')
 
     def current_league_url(self) -> str:
         return url_for('current_league')

--- a/decksite/view_test.py
+++ b/decksite/view_test.py
@@ -1,6 +1,7 @@
 from decksite import view
 from decksite.main import APP
 from magic import seasons
+from shared_web import template
 
 
 def test_seasonized_url_for_app() -> None:
@@ -17,3 +18,9 @@ def test_seasonized_url_simple() -> None:
     with APP.test_request_context('/tournaments/'):
         assert view.seasonized_url(1) == '/tournaments/'
         assert view.seasonized_url(seasons.current_season_num()) == '/tournaments/'
+
+def test_intro_deck_links() -> None:
+    with APP.test_request_context('/'):
+        v = view.View()
+        rendered = template.render_name('faqsbody', v)
+        assert 'href="/metagame/"' in rendered

--- a/shared_web/translations/messages.pot
+++ b/shared_web/translations/messages.pot
@@ -562,7 +562,9 @@ msgid ""
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1
-msgid "Browse [Decklists]({decks_url}) from tournaments, leagues and elsewhere"
+msgid ""
+"Browse the [Metagame]({metagame_url}) for popular archetypes and successful "
+"decklists."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1


### PR DESCRIPTION
## Summary
- point the intro FAQ at the metagame instead of the full deck list
- describe the metagame as a source of popular archetypes and successful decklists
- cover the rendered link with a regression test

## Testing
- `uv run pytest decksite/view_test.py -q`
- `uv run ruff check decksite/view.py decksite/view_test.py`
- `git diff --check`

Fixes #12911