### PR TITLE
Update the intro Magic Online guide link

### DIFF
--- a/decksite/templates/faqsbody.mustache
+++ b/decksite/templates/faqsbody.mustache
@@ -2,7 +2,7 @@
     <li>
         <p class="question"><a href="#">{{_ How do I get started with Magic Online?}}</a></p>
         <div class="details">
-            <p>{{_ Check out the [guide to Magic Online](https://docs.google.com/document/d/1GGvhaISyESrrvPAkauP5LWKAixh6rcH1Q2jfbfpUOoA/edit).}}</p>
+            <p>{{_ Check out the [guide to Magic Online](https://www.mtgo.com/getting-started/getting-started-home).}}</p>
         </div>
     </li>
     <li>

--- a/decksite/views/faqs_test.py
+++ b/decksite/views/faqs_test.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from magic import fetcher
+
+
+def test_mtgo_guide_matches_resources() -> None:
+    template = Path('decksite/templates/faqsbody.mustache').read_text(encoding='utf-8')
+    guide_url = fetcher.resources()['Essentials']['Magic Online guide']
+
+    assert f'[guide to Magic Online]({guide_url})' in template

--- a/shared_web/translations/messages.pot
+++ b/shared_web/translations/messages.pot
@@ -519,7 +519,7 @@ msgstr ""
 #: decksite/templates/faqsbody.mustache:1
 msgid ""
 "Check out the [guide to Magic "
-"Online](https://docs.google.com/document/d/1GGvhaISyESrrvPAkauP5LWKAixh6rcH1Q2jfbfpUOoA/edit)."
+"Online](https://www.mtgo.com/getting-started/getting-started-home)."
 msgstr ""
 
 #: decksite/templates/faqsbody.mustache:1


### PR DESCRIPTION
## Summary

- replace the second outdated Google Doc link in the homepage intro and FAQ partial
- update the translation source for the changed text
- add a regression test requiring the intro link to match the shared Resources link

## Testing

- `uv run pytest decksite/views/faqs_test.py discordbot/command_test.py maintenance/validate_translations_test.py -q`
- `uv run ruff check decksite/views/faqs_test.py discordbot/command_test.py`

Follow-up to #14852 for #12912.