### PR TITLE
Show active league runs in achievement tables

### DIFF
--- a/decksite/view_test.py
+++ b/decksite/view_test.py
@@ -1,7 +1,29 @@
+from unittest.mock import Mock
+
 from decksite import view
 from decksite.main import APP
+from decksite.views.person_achievements import PersonAchievements
 from magic import seasons
+from shared.container import Container
 from shared_web import template
+
+
+def test_person_achievements_prepare_active_runs() -> None:
+    active_decks = [Mock(), Mock()]
+    for deck in active_decks:
+        deck.is_in_current_run.return_value = True
+    completed_deck = Mock()
+    completed_deck.is_in_current_run.return_value = False
+    detail = Container({'decks': active_decks + [completed_deck]})
+    achievement = Container({'detail': detail, 'legend': 'Achievement earned'})
+    person = Container({'name': 'Achievement Hunter'})
+
+    with APP.test_request_context('/'):
+        achievement_view = PersonAchievements(person, [achievement], [])
+        achievement_view.prepare_decks()
+
+    assert detail.active_runs_text == '2 active league runs'
+    assert detail.decks == [completed_deck]
 
 
 def test_seasonized_url_for_app() -> None:

--- a/decksite/views/person_achievements.py
+++ b/decksite/views/person_achievements.py
@@ -14,5 +14,12 @@ class PersonAchievements(View):
         if len([a for a in achievements if a.legend]) == 0:
             self.no_achievements = True
 
+    def prepare_decks(self) -> None:
+        super().prepare_decks()
+        for achievement in self.achievements:
+            if achievement.detail is not None:
+                achievement.detail.hide_active_runs = self.hide_active_runs
+                self.prepare_active_runs(achievement.detail)
+
     def page_title(self) -> str:
         return f'{self.person.name} Achievements'


### PR DESCRIPTION
## Summary
- prepare nested achievement deck details for active-run visibility
- restore the active league run count in React-backed achievement tables
- preserve admin visibility behavior
- add regression coverage for counting and hiding active decks

## Validation
- `uv run --frozen python dev.py unit` (565 passed, 1 skipped)
- `uv run --frozen python dev.py full-check`

Closes #12791