### PR TITLE
Differentiate form element backgrounds

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1997,7 +1997,7 @@ button, input, form label, select, textarea {
 }
 
 textarea, input[type=text], select {
-    background-color: inherit;
+    background-color: var(--light-gray);
 }
 
 button {


### PR DESCRIPTION
## Summary

- give text inputs, selects, and textareas a background distinct from the page
- use the existing theme-aware light-gray palette value in light and dark modes
- preserve transparent styling for disabled text inputs and the header search override

Closes #12812

## Testing

- `git diff --check`
- started the Flask development server and loaded `/signup/` successfully