### PR TITLE
Keep site heading within narrow viewports

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -666,6 +666,14 @@ header h1 {
     text-transform: lowercase;
 }
 
+/* Let the site title wrap instead of overflowing the header on narrow phones. */
+@media only screen and (max-width: 640px) {
+    header h1 {
+        flex-shrink: 1;
+        margin-right: 0;
+    }
+}
+
 h1, h2 {
     color: inherit;
 }


### PR DESCRIPTION
## Summary

- allow the site heading to shrink and wrap on phone-sized viewports
- remove its desktop-only trailing margin at those widths
- keep the existing markup and localization menu behavior unchanged

Closes #12820

## Validation

- `uv run --frozen python dev.py lint`
- verified the production header markup at 320px in Firefox; header scroll width is 320px instead of 344px