### PR TITLE
[codex] Make season icons dark mode aware

### DIFF
--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -239,6 +239,6 @@ def set_legal_icons(o: Card | Deck) -> None:
         o.legal_icons += season_icon_link(code)
 
 def season_icon_link(code: str) -> str:
-    color = 'rare' if code in seasons.current_season_name() else 'common'
+    current_season_class = ' current-season-icon' if code in seasons.current_season_name() else ''
     n = seasons.SEASONS.index(code.upper()) + 1
-    return f'<a href="/seasons/{n}/"><i class="ss ss-{code.lower()} ss-{color} ss-grad"><span class="ss-num">{n}</span></i></a>'
+    return f'<a href="/seasons/{n}/"><i class="ss ss-{code.lower()} season-icon{current_season_class}"><span class="ss-num">{n}</span></i></a>'

--- a/decksite/prepare_test.py
+++ b/decksite/prepare_test.py
@@ -1,0 +1,17 @@
+import pytest
+
+from decksite import prepare
+from magic import seasons
+
+
+def test_season_icon_link_uses_site_colors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful KLD')
+
+    current = prepare.season_icon_link('KLD')
+    previous = prepare.season_icon_link('EMN')
+
+    assert 'class="ss ss-kld season-icon current-season-icon"' in current
+    assert 'class="ss ss-emn season-icon"' in previous
+    assert 'ss-common' not in previous
+    assert 'ss-rare' not in current
+    assert 'ss-grad' not in current

--- a/decksite/views/person.py
+++ b/decksite/views/person.py
@@ -84,7 +84,7 @@ class Person(View):
                 continue
             active = season_id in seasons_active
             if setcode:
-                class_name = f'ss-{setcode.lower()} ' + ('ss-common' if active else 'inactive')
+                class_name = f'ss-{setcode.lower()} season-icon' + ('' if active else ' inactive')
             else:
                 class_name = ''
             season = {

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2468,6 +2468,19 @@ Season Symbols
     margin-right: 0.317rem;
 }
 
+.season-icon {
+    color: var(--text);
+}
+
+.season-icon.inactive {
+    color: var(--inactive);
+}
+
+.current-season-icon {
+    background-color: var(--highlight);
+    border-radius: var(--text-rounded-corners);
+}
+
 .ss-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);


### PR DESCRIPTION
## Summary

- replace Keyrune's fixed `ss-common`, `ss-rare`, and gradient colors with site-owned season icon classes
- use the existing theme-aware text, inactive, and highlight variables for season markers
- cover current and historical generated season badge classes with a regression test

## Root cause

Season markers relied on fixed colors from the third-party Keyrune stylesheet. The common rarity color is nearly black, so those markers became difficult to see against the site's dark background.

## Impact

Season markers now remain legible in both light and dark mode. Inactive seasons remain muted, while the current season retains a highlighted treatment.

## Validation

- `uv run --frozen pytest decksite/prepare_test.py decksite/view_test.py -q`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- manual dark-mode verification on a local person page

Closes #12819
