### PR TITLE
[codex] Include sparkles in deployed symbol font

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,4 +17,8 @@ echo "${APP[*]}"
 cd "$(dirname "$0")"
 git pull --ff-only
 uv sync --frozen
+if [[ " ${APP[*]} " == *" decksite "* ]]
+then
+    uv run --frozen python run.py maintenance fonts
+fi
 uv run --frozen run.py "${APP[@]}"

--- a/maintenance/fonts.py
+++ b/maintenance/fonts.py
@@ -201,7 +201,7 @@ def subset_font(font: TTFont, graphemes: set[str]) -> TTFont:
 
 
 def find_base_graphemes() -> set[str]:
-    return set('①②③④⑤⑥⑦⑧⑯Ⓣ⇅⊕⸺▪🐞🚫🏆📰💻▾△🛈✅☐☑⚔🏅☰🏠☼🌙')
+    return set('①②③④⑤⑥⑦⑧⑯Ⓣ⇅⊕⸺▪🐞🚫🏆📰💻▾△🛈✅☐☑⚔🏅☰🏠☼🌙✨')
 
 def encode(font: TTFont) -> str:
     _, tmp_in = tempfile.mkstemp()


### PR DESCRIPTION
## Summary

- include `✨` (U+2728 SPARKLES) in the generated site symbol font
- rebuild the symbol font automatically when deploying the decksite

## Root cause

The admin banners page uses `✨` to mark automatically generated banner backgrounds, but the glyph was absent from the custom font subset. Browsers therefore fell back to a platform emoji font. Because the generated font is gitignored and normal deployment did not rebuild it, changing the base glyph set alone would not reliably update production.

## Impact

Sparkles render consistently from the site font after deployment, and future decksite deployments regenerate the font before startup.

## Validation

- `bash -n bootstrap.sh`
- `shellcheck bootstrap.sh`
- `uv run --frozen ruff check maintenance/fonts.py`
- `uv run --frozen mypy maintenance/fonts.py`
- generated `symbols.woff2` and verified it contains U+2728
- `uv run --frozen pytest` (646 passed, 2 skipped)

Closes #12870
