### PR TITLE
Report invalid cards in archetype search

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -16,10 +16,11 @@ from decksite.data import rule as rs
 from decksite.league import RetireForm
 from decksite.views import Admin, AdminRetire, Ban, EditAliases, EditArchetypes, EditLeague, EditMatches, EditRules, PlayerNotes, Prizes, RotationChecklist, Sorters, Unlink
 from decksite.views.archetype_search import ArchetypeSearch
+from magic import oracle
 from magic.models import Deck
 from shared import dtutil
 from shared import redis_wrapper as redis
-from shared.pd_exception import InvalidArgumentException
+from shared.pd_exception import InvalidArgumentException, InvalidDataException
 from shared_web.decorators import fill_form
 from shared_web.menu import Menu, MenuItem
 
@@ -58,9 +59,22 @@ def post_aliases(person_id: int | None = None, alias: str | None = None) -> str 
 
 @APP.route('/admin/archetypes/')
 @auth.demimod_required
-def edit_archetypes(q: str = '', notq: str = '') -> wrappers.Response:
-    view = EditArchetypes(archs.load_archetypes(order_by='a.name'), q, notq)
+def edit_archetypes(q: str = '', notq: str = '', query_errors: list[str] | None = None, notquery_errors: list[str] | None = None) -> wrappers.Response:
+    view = EditArchetypes(archs.load_archetypes(order_by='a.name'), q, notq, query_errors, notquery_errors)
     return view.response()
+
+def validate_card_names(raw_names: str) -> tuple[list[str], list[str]]:
+    names = []
+    errors = []
+    for name in raw_names.splitlines():
+        name = name.strip()
+        if not name:
+            continue
+        try:
+            names.append(oracle.valid_name(name))
+        except InvalidDataException:
+            errors.append(f'Card not found: {name}')
+    return names, errors
 
 @APP.route('/admin/archetypes/', methods=['POST'])
 @auth.demimod_required
@@ -77,7 +91,13 @@ def post_archetypes() -> wrappers.Response:
                 archs.assign(int(deck_id), int(archetype_id), auth.person_id())
                 redis.clear(f'decksite:deck:{deck_id}')
     elif request.form.get('q') is not None and request.form.get('notq') is not None:
-        search_results = ds.load_decks_by_cards(cast(str, request.form.get('q')).splitlines(), cast(str, request.form.get('notq')).splitlines())
+        q = cast(str, request.form.get('q'))
+        notq = cast(str, request.form.get('notq'))
+        names, query_errors = validate_card_names(q)
+        not_names, notquery_errors = validate_card_names(notq)
+        if query_errors or notquery_errors:
+            return edit_archetypes(q, notq, query_errors, notquery_errors)
+        search_results = ds.load_decks_by_cards(names, not_names)
     elif request.form.get('find_conflicts') is not None:
         search_results = ds.load_conflicted_decks()
     elif request.form.get('rename_to') is not None:

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -3,8 +3,47 @@ from typing import Any, cast
 import pytest
 
 from decksite.controllers import admin
+from decksite.data import deck
 from decksite.main import APP
-from decksite.views import EditRules
+from decksite.views import EditArchetypes, EditRules
+from shared.pd_exception import InvalidDataException
+
+
+def test_post_archetypes_reports_invalid_card_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    def valid_name(name: str) -> str:
+        if name in ['Not a Card', 'Also Not a Card']:
+            raise InvalidDataException()
+        return name
+
+    def load_decks_by_cards(names: list[str], not_names: list[str]) -> None:
+        pytest.fail(f'Should not search for decks with invalid card names: {names}, {not_names}')
+
+    def edit_archetypes(q: str = '', notq: str = '', query_errors: list[str] | None = None, notquery_errors: list[str] | None = None) -> str:
+        return EditArchetypes([], q, notq, query_errors, notquery_errors).render_content()
+
+    monkeypatch.setattr(admin.oracle, 'valid_name', valid_name)
+    monkeypatch.setattr(admin.ds, 'load_decks_by_cards', load_decks_by_cards)
+    monkeypatch.setattr(admin, 'edit_archetypes', edit_archetypes)
+    monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: ([], 0))
+    monkeypatch.setattr(deck, 'load_queue_similarity', lambda decks: None)
+    with APP.test_request_context('/admin/archetypes/', method='POST', data={'q': 'Dark Ritual\nNot a Card', 'notq': 'Also Not a Card'}):
+        response = cast(Any, admin.post_archetypes).__wrapped__()
+    assert 'Card not found: Not a Card' in response
+    assert 'Card not found: Also Not a Card' in response
+    assert '<textarea name="q" id="q" class="error" aria-invalid="true" aria-describedby="q-error">Dark Ritual\nNot a Card</textarea>' in response
+    assert '<textarea name="notq" id="notq" class="error" aria-invalid="true" aria-describedby="notq-error">Also Not a Card</textarea>' in response
+
+
+def test_validate_card_names_canonicalizes_and_ignores_blank_lines(monkeypatch: pytest.MonkeyPatch) -> None:
+    def valid_name(name: str) -> str:
+        if name == 'Not a Card':
+            raise InvalidDataException()
+        return name.title()
+
+    monkeypatch.setattr(admin.oracle, 'valid_name', valid_name)
+    names, errors = admin.validate_card_names(' dark ritual \n\nSWAMP\nNot a Card')
+    assert names == ['Dark Ritual', 'Swamp']
+    assert errors == ['Card not found: Not a Card']
 
 
 def test_post_rules_requires_archetype(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -85,11 +85,21 @@
     <form method="post">
         <div>
             <label for="q">With these cards (separated by newlines)</label>
-            <textarea name="q">{{query}}</textarea>
+            <textarea name="q" id="q"{{#has_query_errors}} class="error" aria-invalid="true" aria-describedby="q-error"{{/has_query_errors}}>{{query}}</textarea>
+            {{#has_query_errors}}
+                <div id="q-error" class="error">
+                    {{#query_errors}}<div>{{.}}</div>{{/query_errors}}
+                </div>
+            {{/has_query_errors}}
         </div>
         <div>
             <label for="notq">Without these cards</label>
-            <textarea name="notq">{{notquery}}</textarea>
+            <textarea name="notq" id="notq"{{#has_notquery_errors}} class="error" aria-invalid="true" aria-describedby="notq-error"{{/has_notquery_errors}}>{{notquery}}</textarea>
+            {{#has_notquery_errors}}
+                <div id="notq-error" class="error">
+                    {{#notquery_errors}}<div>{{.}}</div>{{/notquery_errors}}
+                </div>
+            {{/has_notquery_errors}}
         </div>
         <button type="submit">Search by Card</button>
     </form>

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -7,7 +7,7 @@ from decksite.view import View
 
 
 class EditArchetypes(View):
-    def __init__(self, archetypes: list[Archetype], q: str, notq: str) -> None:
+    def __init__(self, archetypes: list[Archetype], q: str, notq: str, query_errors: list[str] | None = None, notquery_errors: list[str] | None = None) -> None:
         super().__init__()
         self.archetypes = archetypes
         self.archetypes_preordered = archetype.preorder(archetypes)
@@ -32,6 +32,10 @@ class EditArchetypes(View):
         self.edit_rules_url = url_for('edit_rules')
         self.query = q
         self.notquery = notq
+        self.query_errors = query_errors or []
+        self.notquery_errors = notquery_errors or []
+        self.has_query_errors = bool(self.query_errors)
+        self.has_notquery_errors = bool(self.notquery_errors)
 
     def page_title(self) -> str:
         return 'Edit Archetypes'


### PR DESCRIPTION
## Summary

- validate and canonicalize card names before searching admin archetypes
- preserve submitted card lists and show field-specific errors for unknown cards
- skip the deck query when either field contains invalid entries

## Testing

- `uv run --frozen pytest decksite/controllers/admin_test.py -q`
- `uv run --frozen ruff check decksite/controllers/admin.py decksite/controllers/admin_test.py decksite/views/edit_archetypes.py`
- `uv run --frozen mypy decksite/controllers/admin.py decksite/views/edit_archetypes.py`

Closes #12943