### PR TITLE
Require authentication for all admin routes

### DIFF
--- a/decksite/auth.py
+++ b/decksite/auth.py
@@ -25,6 +25,7 @@ def demimod_required(f: Callable[..., wrappers.Response]) -> Callable[..., wrapp
         if session.get('admin') is False and session.get('demimod') is False:
             return redirect(url_for('unauthorized'))
         return f(*args, **kwargs)
+    setattr(decorated_function, 'permission_required', 'demimod')
     return decorated_function
 
 def admin_required(f: Callable) -> Callable:
@@ -35,6 +36,7 @@ def admin_required(f: Callable) -> Callable:
         if session.get('admin') is False:
             return redirect(url_for('unauthorized'))
         return f(*args, **kwargs)
+    setattr(decorated_function, 'permission_required', 'admin')
     return decorated_function
 
 def admin_required_no_redirect(f: Callable) -> Callable:
@@ -43,6 +45,7 @@ def admin_required_no_redirect(f: Callable) -> Callable:
         if not session.get('admin'):
             return '', 403
         return f(*args, **kwargs)
+    setattr(decorated_function, 'permission_required', 'admin')
     return decorated_function
 
 

--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -159,12 +159,14 @@ def post_matches() -> wrappers.Response:
     return redirect(url_for('edit_matches'))
 
 @APP.route('/admin/prizes/')
+@auth.admin_required
 def prizes() -> str:
     tournaments_with_prizes = comp.tournaments_with_prizes()
     view = Prizes(tournaments_with_prizes)
     return view.page()
 
 @APP.route('/admin/rotation/')
+@auth.admin_required
 def rotation_checklist() -> str:
     view = RotationChecklist()
     return view.page()

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -20,6 +20,7 @@ def test_all_admin_routes_require_permission() -> None:
 def test_admin_information_pages_require_login(path: str) -> None:
     response = APP.test_client().get(path)
     assert response.status_code == 302
+    assert response.location is not None
     assert response.location.startswith('/authenticate/?target=')
 
 

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -7,6 +7,22 @@ from decksite.main import APP
 from decksite.views import EditRules
 
 
+def test_all_admin_routes_require_permission() -> None:
+    unprotected_routes = sorted({
+        rule.rule
+        for rule in APP.url_map.iter_rules()
+        if rule.rule.startswith('/admin') and getattr(APP.view_functions[rule.endpoint], 'permission_required', None) not in {'admin', 'demimod'}
+    })
+    assert unprotected_routes == []
+
+
+@pytest.mark.parametrize('path', ['/admin/banners/', '/admin/prizes/', '/admin/rotation/'])
+def test_admin_information_pages_require_login(path: str) -> None:
+    response = APP.test_client().get(path)
+    assert response.status_code == 302
+    assert response.location.startswith('/authenticate/?target=')
+
+
 def test_post_rules_requires_archetype(monkeypatch: pytest.MonkeyPatch) -> None:
     def edit_rules(errors: list[str] | None = None) -> str:
         return EditRules(0, 0, [], [], [], [], [], [], errors).render_content()

--- a/decksite/controllers/banners.py
+++ b/decksite/controllers/banners.py
@@ -4,7 +4,7 @@ import os
 
 from flask import Response, make_response, send_file
 
-from decksite import APP, get_season_id
+from decksite import APP, auth, get_season_id
 from decksite.data import playability
 from decksite.views import Banners
 from magic import fetcher, image_fetcher, oracle, seasons
@@ -15,6 +15,7 @@ from shared_web.api import return_json
 
 
 @APP.route('/admin/banners/')
+@auth.admin_required
 def banner_stats() -> str:
     banners = []
     hq_crops = fetcher.hq_artcrops().keys()

--- a/decksite/smoke_test.py
+++ b/decksite/smoke_test.py
@@ -12,5 +12,5 @@ def test() -> None:
 @pytest.mark.functional
 def test_some_pages() -> None:
     for path in ['/', '/people/', '/cards/', '/cards/Unsummon/', '/competitions/', '/competitions/', '/tournaments/',
-                 '/resources/', '/bugs/', '/signup/', '/report/', '/admin/banners/']:
+                 '/resources/', '/bugs/', '/signup/', '/report/']:
         smoke_tester.response_test(path, 200)


### PR DESCRIPTION
## Summary
- require full admin access for banner info, prize summaries, and the rotation checklist
- mark authorization decorators so route protection can be inspected
- add a test that rejects any unprotected `/admin` route
- verify the three formerly public pages redirect logged-out visitors

## Tests
- `uv run pytest decksite/controllers/admin_test.py shared_web/flask_app_test.py -q`
- `uv run ruff check decksite/auth.py decksite/controllers/admin.py decksite/controllers/admin_test.py decksite/controllers/banners.py decksite/smoke_test.py`
- `git diff --check`