### PR TITLE
Prevent duplicate cards in archetype rules

### DIFF
--- a/decksite/data/rule.py
+++ b/decksite/data/rule.py
@@ -217,6 +217,7 @@ def add_rule(archetype_id: int) -> int:
 def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, str]:
     inc = []
     exc = []
+    cards = set()
     for line in include.strip().splitlines():
         try:
             inc.append(parse_line(line))
@@ -224,6 +225,11 @@ def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, st
             return False, f"Couldn't find a card count and name on line: {line}"
         if not card.card_exists(inc[-1][1]):
             return False, f'Card not found in any deck: {line}'
+        canonical_name = oracle.valid_name(inc[-1][1])
+        if canonical_name in cards:
+            return False, f'Card appears more than once in rule: {canonical_name}'
+        cards.add(canonical_name)
+        inc[-1] = (inc[-1][0], canonical_name)
     for line in exclude.strip().splitlines():
         try:
             exc.append(parse_line(line))
@@ -231,6 +237,11 @@ def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, st
             return False, f"Couldn't find a card count and name on line: {line}"
         if not card.card_exists(exc[-1][1]):
             return False, f'Card not found in any deck {line}'
+        canonical_name = oracle.valid_name(exc[-1][1])
+        if canonical_name in cards:
+            return False, f'Card appears more than once in rule: {canonical_name}'
+        cards.add(canonical_name)
+        exc[-1] = (exc[-1][0], canonical_name)
     update_cards(rule_id, inc, exc)
     return True, ''
 

--- a/decksite/data/rule_test.py
+++ b/decksite/data/rule_test.py
@@ -1,0 +1,37 @@
+import pytest
+
+from decksite.data import rule
+
+
+@pytest.mark.parametrize(
+    ('include', 'exclude'),
+    [
+        ('4 Lightning Bolt\n1 lightning bolt', ''),
+        ('', '4 Lightning Bolt\n1 lightning bolt'),
+        ('4 Lightning Bolt', '1 lightning bolt'),
+    ],
+)
+def test_update_cards_raw_rejects_duplicate_cards(monkeypatch: pytest.MonkeyPatch, include: str, exclude: str) -> None:
+    updates = []
+    monkeypatch.setattr(rule.card, 'card_exists', lambda name: True)
+    monkeypatch.setattr(rule.oracle, 'valid_name', lambda name: name.title())
+    monkeypatch.setattr(rule, 'update_cards', lambda rule_id, inc, exc: updates.append((rule_id, inc, exc)))
+
+    success, message = rule.update_cards_raw(1, include, exclude)
+
+    assert not success
+    assert message == 'Card appears more than once in rule: Lightning Bolt'
+    assert updates == []
+
+
+def test_update_cards_raw_updates_distinct_cards(monkeypatch: pytest.MonkeyPatch) -> None:
+    updates = []
+    monkeypatch.setattr(rule.card, 'card_exists', lambda name: True)
+    monkeypatch.setattr(rule.oracle, 'valid_name', lambda name: name.title())
+    monkeypatch.setattr(rule, 'update_cards', lambda rule_id, inc, exc: updates.append((rule_id, inc, exc)))
+
+    success, message = rule.update_cards_raw(1, '4 lightning bolt', '1 counterspell')
+
+    assert success
+    assert message == ''
+    assert updates == [(1, [(4, 'Lightning Bolt')], [(1, 'Counterspell')])]


### PR DESCRIPTION
Fixes #13055.

## Summary
- canonicalize rule card names before duplicate validation
- reject duplicate inclusions, duplicate exclusions, and cards present in both lists
- add regression coverage for duplicate and valid rule updates

## Testing
- `uv run --frozen pytest decksite/data/rule_test.py`
- `uv run --frozen ruff check decksite/data/rule.py decksite/data/rule_test.py`
- `uv run --frozen mypy decksite/data/rule.py decksite/data/rule_test.py`
- `git diff --check`