### PR TITLE
Show seasons for cards played first

### DIFF
--- a/decksite/controllers/people.py
+++ b/decksite/controllers/people.py
@@ -30,9 +30,8 @@ def person(mtgo_username: str | None = None, person_id: int | None = None) -> st
     all_archetypes = archs.load_archetypes(season_id=get_season_id())
     trailblazer_cards = cs.trailblazer_cards(p.id)
     unique_cards = cs.unique_cards_played(p.id)
-    your_cards = {'unique': unique_cards, 'trailblazer': trailblazer_cards}
     seasons_active = ps.seasons_active(p.id)
-    view = Person(p, person_archetypes, all_archetypes, your_cards, seasons_active, get_season_id())
+    view = Person(p, person_archetypes, all_archetypes, trailblazer_cards, unique_cards, seasons_active, get_season_id())
     return view.page()
 
 @APP.route('/people/<mtgo_username>/achievements/')

--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -345,18 +345,21 @@ def unique_cards_played(person_id: int) -> list[str]:
     return db().values(sql, [person_id])
 
 @retry_after_calling(preaggregate_trailblazer)
-def trailblazer_cards(person_id: int) -> list[str]:
+def trailblazer_cards(person_id: int) -> dict[str, int]:
     sql = """
         SELECT
-            card
+            tc.card,
+            dc.season_id
         FROM
             _trailblazer_cards AS tc
         INNER JOIN
             deck AS d ON tc.deck_id = d.id
+        INNER JOIN
+            deck_cache AS dc ON tc.deck_id = dc.deck_id
         WHERE
             d.person_id = %s
     """
-    return db().values(sql, [person_id])
+    return {r['card']: r['season_id'] for r in db().select(sql, [person_id])}
 
 def card_exists(name: str) -> bool:
     sql = 'SELECT EXISTS(SELECT * FROM deck_card WHERE card = %s LIMIT 1)'

--- a/decksite/data/card_test.py
+++ b/decksite/data/card_test.py
@@ -11,3 +11,20 @@ def test_load_cards_season() -> None:
 @pytest.mark.perf
 def test_load_cards_all() -> None:
     perf.test(card.load_cards, 5)
+
+def test_trailblazer_cards_include_season(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeDatabase:
+        def select(self, sql: str, args: list[int]) -> list[dict[str, str | int]]:
+            assert 'deck_cache AS dc' in sql
+            assert args == [42]
+            return [
+                {'card': 'Black Lotus', 'season_id': 1},
+                {'card': 'One with Nothing', 'season_id': 2},
+            ]
+
+    monkeypatch.setattr(card, 'db', lambda: FakeDatabase())
+
+    assert card.trailblazer_cards(42) == {
+        'Black Lotus': 1,
+        'One with Nothing': 2,
+    }

--- a/decksite/templates/person.mustache
+++ b/decksite/templates/person.mustache
@@ -62,13 +62,19 @@
     </section>
 {{/has_unique_cards}}
 {{#has_trailblazer_cards}}
-    <section class="card-lists">
-        <h2>Cards Played First</h2>
-        <ul>
+    <section class="card-lists trailblazer-card-lists">
+        <h2>Cards Played First <span class="card-list-count">· {{num_trailblazer_cards}}</span></h2>
+        <ul class="trailblazer-card-list" id="trailblazer-card-list">
             {{#trailblazer_cards}}
-                <li><a class="card" href="{{url}}">{{name}}</a></li>
+                <li{{#additional_trailblazer_card}} class="additional-trailblazer-card"{{/additional_trailblazer_card}}>
+                    <a class="card" href="{{url}}">{{name}}</a>
+                    <span class="trailblazer-season" title="First played in {{first_played_season_name}}">{{{first_played_season_icon}}}</span>
+                </li>
             {{/trailblazer_cards}}
         </ul>
+        {{#has_additional_trailblazer_cards}}
+            <a class="trailblazer-card-list-toggle" href="#trailblazer-card-list" aria-controls="trailblazer-card-list" aria-expanded="false" data-count="{{num_trailblazer_cards}}" hidden>Show all {{num_trailblazer_cards}}…</a>
+        {{/has_additional_trailblazer_cards}}
     </section>
 {{/has_trailblazer_cards}}
 <section class="admin">

--- a/decksite/views/person.py
+++ b/decksite/views/person.py
@@ -6,15 +6,18 @@ from typing import Any
 import titlecase
 from flask import url_for
 
+from decksite import prepare
 from decksite.data import person as ps
 from decksite.data.achievements import Achievement
 from decksite.data.archetype import Archetype
 from decksite.view import View
 from magic import oracle, seasons
 
+TRAILBLAZER_CARD_PREVIEW_SIZE = 12
+
 
 class Person(View):
-    def __init__(self, person: ps.Person, archetypes: list[Archetype], all_archetypes: list[Archetype], your_cards: dict[str, list[str]], seasons_active: Sequence[int], season_id: int | None) -> None:
+    def __init__(self, person: ps.Person, archetypes: list[Archetype], all_archetypes: list[Archetype], trailblazer_card_seasons: dict[str, int], unique_card_names: list[str], seasons_active: Sequence[int], season_id: int | None) -> None:
         super().__init__()
         self.all_archetypes = all_archetypes
         self.person = person
@@ -59,9 +62,19 @@ class Person(View):
         self.add_note_url = url_for('post_player_note')
         self.matches_url = url_for('.person_matches', person_id=person.id, season_id=None if season_id == seasons.current_season_num() else season_id)
         self.is_person_page = True
-        self.trailblazer_cards = oracle.load_cards(your_cards['trailblazer'])
+        self.trailblazer_cards = oracle.load_cards(trailblazer_card_seasons)
+        for card in self.trailblazer_cards:
+            first_played_season_id = trailblazer_card_seasons[card.name]
+            card.first_played_season_id = first_played_season_id
+            card.first_played_season_name = seasons.season_name(first_played_season_id)
+            card.first_played_season_icon = prepare.season_icon_link(seasons.season_code(first_played_season_id))
+        self.trailblazer_cards.sort(key=lambda card: (-card.first_played_season_id, card.name))
+        for i, card in enumerate(self.trailblazer_cards):
+            card.additional_trailblazer_card = i >= TRAILBLAZER_CARD_PREVIEW_SIZE
+        self.num_trailblazer_cards = len(self.trailblazer_cards)
+        self.has_additional_trailblazer_cards = self.num_trailblazer_cards > TRAILBLAZER_CARD_PREVIEW_SIZE
         self.has_trailblazer_cards = len(self.trailblazer_cards) > 0
-        self.unique_cards = oracle.load_cards(your_cards['unique'])
+        self.unique_cards = oracle.load_cards(unique_card_names)
         self.has_unique_cards = len(self.unique_cards) > 0
         self.cards = self.trailblazer_cards + self.unique_cards
         self.seasons_active: list[dict[str, object]] = []

--- a/decksite/views/person_test.py
+++ b/decksite/views/person_test.py
@@ -1,0 +1,32 @@
+from decksite import APP
+from shared_web import template
+
+
+def test_trailblazer_card_displays_first_played_season() -> None:
+    with APP.test_request_context('/'):
+        html = template.render_name('person', {
+            'has_trailblazer_cards': True,
+            'num_trailblazer_cards': 1,
+            'trailblazer_cards': [{
+                'name': 'Black Lotus',
+                'url': '/cards/Black%20Lotus/',
+                'first_played_season_icon': '<a href="/seasons/1/"><i class="ss ss-emn ss-common ss-grad"><span class="ss-num">1</span></i></a>',
+                'first_played_season_name': 'Season 1',
+            }],
+        })
+
+    assert 'Cards Played First <span class="card-list-count">· 1</span>' in html
+    assert '<a class="card" href="/cards/Black%20Lotus/">Black Lotus</a>' in html
+    assert '<span class="trailblazer-season" title="First played in Season 1"><a href="/seasons/1/"><i class="ss ss-emn ss-common ss-grad"><span class="ss-num">1</span></i></a></span>' in html
+
+def test_long_trailblazer_card_list_uses_disclosure_link() -> None:
+    with APP.test_request_context('/'):
+        html = template.render_name('person', {
+            'has_trailblazer_cards': True,
+            'has_additional_trailblazer_cards': True,
+            'num_trailblazer_cards': 134,
+        })
+
+    assert '<a class="trailblazer-card-list-toggle"' in html
+    assert '>Show all 134…</a>' in html
+    assert '<button class="trailblazer-card-list-toggle"' not in html

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2993,6 +2993,45 @@ Used for Unique Cards Played and Cards Played First list on person detail page.
     list-style-type: none;
 }
 
+.card-list-count,
+.trailblazer-season {
+    color: var(--deemphasized-text);
+}
+
+.trailblazer-card-lists {
+    width: min(18rem, 100%);
+}
+
+.trailblazer-card-list {
+    padding-left: 0;
+}
+
+.trailblazer-card-list li {
+    align-items: baseline;
+    column-gap: 0.75em;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+}
+
+.trailblazer-card-list .card {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.trailblazer-season {
+    font-variant-numeric: tabular-nums;
+}
+
+.trailblazer-card-list-toggle {
+    display: inline-block;
+    margin-left: var(--spacing-text);
+}
+
+.trailblazer-card-list.is-collapsed .additional-trailblazer-card {
+    display: none;
+}
+
 /*
 
 Charts

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -7,6 +7,7 @@ PD.init = function() {
     PD.initMenu();
     PD.initDoubleReportCheck();
     PD.initAchievements();
+    PD.initTrailblazerCardLists();
     PD.initTables();
     PD.initDetails();
     PD.initDarkModeToggle();
@@ -86,6 +87,24 @@ PD.initAchievements = function() {
 
 PD.onMoreInfoClick = function() {
     $(this).siblings(".more-info").slideToggle();
+};
+
+PD.initTrailblazerCardLists = function() {
+    document.querySelectorAll(".trailblazer-card-list-toggle").forEach((toggle) => {
+        const list = document.getElementById(toggle.getAttribute("aria-controls"));
+        if (!list) {
+            return;
+        }
+        list.classList.add("is-collapsed");
+        toggle.hidden = false;
+        toggle.onclick = (event) => {
+            event.preventDefault();
+            const expanded = toggle.getAttribute("aria-expanded") === "true";
+            list.classList.toggle("is-collapsed", expanded);
+            toggle.setAttribute("aria-expanded", (!expanded).toString());
+            toggle.textContent = expanded ? `Show all ${toggle.dataset.count}…` : "Show fewer";
+        };
+    });
 };
 
 PD.initTables = function() {


### PR DESCRIPTION
## Summary
- include the first-played season with each trailblazer card on person pages
- use the existing season icon convention in a compact, newest-first list
- collapse unusually long lists behind a lightweight disclosure link
- fetch season data through the indexed `deck_cache.deck_id` lookup without changing global preaggregation

## Testing
- `uv run --frozen python dev.py test` (646 passed, 2 skipped)
- `uv run --frozen python dev.py full-check`

Fixes #12976