### PR TITLE
Hide completed rotation confirmation forecast

### DIFF
--- a/magic/rotation.py
+++ b/magic/rotation.py
@@ -176,7 +176,9 @@ async def rotation_hype_message(hype_command: bool) -> str | None:
         newly_eliminated_s = list_of_most_interesting(newly_eliminated)
         s += f'\nEliminated: {newly_eliminated_s}.'
     s += f'\nUndecided: {num_undecided}.'
-    s += f'\nNext new cards confirmed in {soonest_new_card} runs time.\n'
+    if num_undecided > 0:
+        s += f'\nNext new cards confirmed in {soonest_new_card} runs time.'
+    s += '\n'
     if runs_percent >= 50:
         s += f"<{fetcher.decksite_url('/rotation/')}>"
     return s

--- a/magic/rotation_test.py
+++ b/magic/rotation_test.py
@@ -44,6 +44,37 @@ def test_last_run_number() -> None:
     if real_legality_dir:
         configuration.CONFIG['legality_dir'] = real_legality_dir
 
+
+@pytest.mark.asyncio
+async def test_rotation_hype_message_elides_next_confirmation_when_no_cards_are_undecided(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(rotation, 'read_rotation_files', lambda: (rotation.TOTAL_RUNS, 100, []))
+    monkeypatch.setattr(rotation.fetcher, 'decksite_url', lambda path: path)
+
+    message = await rotation.rotation_hype_message(True)
+
+    assert message is not None
+    assert '\nUndecided: 0.\n' in message
+    assert 'Next new cards confirmed' not in message
+
+
+@pytest.mark.asyncio
+async def test_rotation_hype_message_includes_next_confirmation_when_cards_are_undecided(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = Card({
+        'name': 'Still Undecided',
+        'hit_in_last_run': False,
+        'hits': 80,
+        'hits_needed': 4,
+        'status': 'Undecided',
+    }, predetermined_values=True)
+    monkeypatch.setattr(rotation, 'read_rotation_files', lambda: (100, 60, [card]))
+    monkeypatch.setattr(rotation.fetcher, 'decksite_url', lambda path: path)
+
+    message = await rotation.rotation_hype_message(True)
+
+    assert message is not None
+    assert '\nUndecided: 1.\nNext new cards confirmed in 4 runs time.\n' in message
+
+
 @pytest.mark.skip('Because CloudFlare sometimes blocks API access from Github workflow this test is flakey')
 @pytest.mark.functional
 def test_list_of_most_interesting() -> None:


### PR DESCRIPTION
## Summary
- omit the next-card confirmation forecast when no cards remain undecided
- retain the forecast while rotation still has undecided cards
- cover both completed and in-progress rotation messages with regression tests

## Testing
- `uv run pytest -q magic/rotation_test.py`
- `uv run ruff check magic/rotation.py magic/rotation_test.py`
- `uv run mypy magic/rotation.py magic/rotation_test.py`
- `git diff --check`

Fixes #12974