### PR TITLE
Validate admin match form

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -13,7 +13,7 @@ from decksite.data import deck as ds
 from decksite.data import match as ms
 from decksite.data import person as ps
 from decksite.data import rule as rs
-from decksite.league import RetireForm
+from decksite.league import EditMatchForm, RetireForm
 from decksite.views import Admin, AdminRetire, Ban, EditAliases, EditArchetypes, EditLeague, EditMatches, EditRules, PlayerNotes, Prizes, RotationChecklist, Sorters, Unlink
 from decksite.views.archetype_search import ArchetypeSearch
 from magic import oracle
@@ -155,9 +155,11 @@ def do_admin_retire_deck() -> wrappers.Response:
 
 @APP.route('/admin/matches/')
 @auth.admin_required
-def edit_matches() -> str:
+def edit_matches(form: EditMatchForm | None = None) -> str:
+    if form is None:
+        form = EditMatchForm(request.form)
     league = lg.active_league(should_load_decks=True)
-    view = EditMatches(league.id, league.decks)
+    view = EditMatches(league.id, league.decks, form)
     return view.page()
 
 @APP.route('/admin/matches/', methods=['POST'])
@@ -168,10 +170,13 @@ def post_matches() -> wrappers.Response:
     if request.form.get('action') == 'delete':
         ms.delete_match(match_id)
         return redirect(url_for('edit_matches'))
-    left_id = cast_int(request.form.get('left_id'))
-    left_games = cast_int(request.form.get('left_games'))
-    right_id = cast_int(request.form.get('right_id'))
-    right_games = cast_int(request.form.get('right_games'))
+    form = EditMatchForm(request.form)
+    if not form.validate():
+        return make_response(edit_matches(form))
+    left_games = cast_int(form.left_games)
+    right_games = cast_int(form.right_games)
+    left_id = cast_int(form.left_id)
+    right_id = cast_int(form.right_id)
     if request.form.get('action') == 'change':
         ms.update_match(match_id, left_id, left_games, right_id, right_games)
     elif request.form.get('action') == 'add':

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -4,8 +4,9 @@ import pytest
 
 from decksite.controllers import admin
 from decksite.data import deck
+from decksite.league import EditMatchForm
 from decksite.main import APP
-from decksite.views import EditArchetypes, EditRules
+from decksite.views import EditArchetypes, EditMatches, EditRules
 from shared.pd_exception import InvalidDataException
 
 
@@ -72,3 +73,44 @@ def test_post_rules_requires_archetype(monkeypatch: pytest.MonkeyPatch) -> None:
         response = cast(Any, admin.post_rules).__wrapped__()
     assert 'Please select an archetype.' in response
     assert '<select name="archetype_id" required class="error" aria-describedby="archetype-error">' in response
+
+
+@pytest.mark.parametrize('action', ['add', 'change'])
+@pytest.mark.parametrize('missing_score', ['left_games', 'right_games'])
+def test_post_matches_requires_both_scores(monkeypatch: pytest.MonkeyPatch, action: str, missing_score: str) -> None:
+    def edit_matches(form: EditMatchForm | None = None) -> str:
+        assert form is not None
+        return EditMatches(0, [], form).render_content()
+
+    monkeypatch.setattr(admin, 'edit_matches', edit_matches)
+    data = {'action': action, 'match_id': '3', 'left_id': '1', 'left_games': '2', 'right_id': '2', 'right_games': '1'}
+    data.pop(missing_score)
+    with APP.test_request_context('/admin/matches/', method='POST', data=data):
+        response = cast(Any, admin.post_matches).__wrapped__()
+    html = response.get_data(as_text=True)
+    missing_side = missing_score.removesuffix('_games').replace('_', '-')
+    present_score = '1' if missing_score == 'left_games' else '2'
+    present_side = 'right' if missing_score == 'left_games' else 'left'
+    assert f'<div id="{missing_side}-games-error" class="error">Please enter a score.</div>' in html
+    assert f'<div id="{present_side}-games-error"' not in html
+    assert f'name="{present_side}_games" value="{present_score}"' in html
+    assert ' required' not in html
+
+
+@pytest.mark.parametrize('action', ['add', 'change'])
+@pytest.mark.parametrize('missing_deck', ['left_id', 'right_id'])
+def test_post_matches_requires_both_decks(monkeypatch: pytest.MonkeyPatch, action: str, missing_deck: str) -> None:
+    def edit_matches(form: EditMatchForm | None = None) -> str:
+        assert form is not None
+        return EditMatches(0, [], form).render_content()
+
+    monkeypatch.setattr(admin, 'edit_matches', edit_matches)
+    data = {'action': action, 'match_id': '3', 'left_id': '1', 'left_games': '2', 'right_id': '2', 'right_games': '1'}
+    data.pop(missing_deck)
+    with APP.test_request_context('/admin/matches/', method='POST', data=data):
+        response = cast(Any, admin.post_matches).__wrapped__()
+    html = response.get_data(as_text=True)
+    missing_side = missing_deck.removesuffix('_id')
+    present_side = 'right' if missing_deck == 'left_id' else 'left'
+    assert f'<div id="{missing_side}-id-error" class="error">Please select a deck.</div>' in html
+    assert f'<div id="{present_side}-id-error"' not in html

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -58,6 +58,31 @@ class DeckCheckForm(DecklistForm):
         if len(self.errors) == 0:
             self.validation_ok_message = 'The deck is legal'
 
+
+class EditMatchForm(Form):
+    def do_validation(self) -> None:
+        for field in ['left_id', 'right_id']:
+            deck_id = self.get(field, '')
+            if len(deck_id) == 0:
+                self.errors[field] = 'Please select a deck.'
+                continue
+            try:
+                int(deck_id)
+            except ValueError:
+                self.errors[field] = 'Please select a valid deck.'
+        if not self.errors.get('left_id') and not self.errors.get('right_id') and self.left_id == self.right_id:
+            self.errors['right_id'] = 'Please select two different decks.'
+        for field in ['left_games', 'right_games']:
+            score = self.get(field, '')
+            if len(score) == 0:
+                self.errors[field] = 'Please enter a score.'
+                continue
+            try:
+                int(score)
+            except ValueError:
+                self.errors[field] = 'Score must be a whole number.'
+
+
 class ReportForm(Form):
     def __init__(self, form: ImmutableMultiDict, deck_id: int | None = None, person_id: int | None = None) -> None:
         super().__init__(form)

--- a/decksite/league_test.py
+++ b/decksite/league_test.py
@@ -1,10 +1,30 @@
 from datetime import timedelta
 
 import pytest
+from werkzeug.datastructures import ImmutableMultiDict
 
 from decksite import league
 from shared import dtutil
 from shared.pd_exception import InvalidArgumentException
+
+
+def test_edit_match_form_validates_scores() -> None:
+    form = league.EditMatchForm(ImmutableMultiDict({'left_id': '1', 'right_id': '2', 'left_games': '', 'right_games': 'one'}))
+    assert not form.validate()
+    assert form.errors == {'left_games': 'Please enter a score.', 'right_games': 'Score must be a whole number.'}
+
+    form = league.EditMatchForm(ImmutableMultiDict({'left_id': '1', 'right_id': '2', 'left_games': '0', 'right_games': '2'}))
+    assert form.validate()
+
+
+def test_edit_match_form_requires_two_different_decks() -> None:
+    form = league.EditMatchForm(ImmutableMultiDict({'left_id': '', 'right_id': 'one', 'left_games': '2', 'right_games': '1'}))
+    assert not form.validate()
+    assert form.errors == {'left_id': 'Please select a deck.', 'right_id': 'Please select a valid deck.'}
+
+    form = league.EditMatchForm(ImmutableMultiDict({'left_id': '1', 'right_id': '1', 'left_games': '2', 'right_games': '1'}))
+    assert not form.validate()
+    assert form.errors == {'right_id': 'Please select two different decks.'}
 
 
 def test_determine_end_of_league() -> None:

--- a/decksite/templates/editmatches.mustache
+++ b/decksite/templates/editmatches.mustache
@@ -1,20 +1,32 @@
 <section>
     <h2>Add Match</h2>
     <form method="post">
-        <select name="left_id">
+        <select {{#form.errors.left_id}}class="error" aria-describedby="left-id-error" {{/form.errors.left_id}}name="left_id">
             {{#decks}}
                 <option value="{{id}}" class="person">{{person}} ({{name}}, {{display_date}}, {{id}}{{#retired}}, Retired{{/retired}}, {{wins}}–{{losses}})</option>
             {{/decks}}
         </select>
-        <input type="number" name="left_games">
-        <input type="number" name="right_games">
-        <select name="right_id">
+        <input {{#form.errors.left_games}}class="error" aria-describedby="left-games-error" {{/form.errors.left_games}}type="number" name="left_games" value="{{form.left_games}}">
+        <input {{#form.errors.right_games}}class="error" aria-describedby="right-games-error" {{/form.errors.right_games}}type="number" name="right_games" value="{{form.right_games}}">
+        <select {{#form.errors.right_id}}class="error" aria-describedby="right-id-error" {{/form.errors.right_id}}name="right_id">
             {{#decks}}
                 <option value="{{id}}" class="person">{{person}} ({{name}}, {{display_date}}, {{id}})</option>
             {{/decks}}
         </select>
         <button type="submit" name="action" value="add">Add Match</button>
     </form>
+    {{#form.errors.left_id}}
+        <div id="left-id-error" class="error">{{.}}</div>
+    {{/form.errors.left_id}}
+    {{#form.errors.left_games}}
+        <div id="left-games-error" class="error">{{.}}</div>
+    {{/form.errors.left_games}}
+    {{#form.errors.right_games}}
+        <div id="right-games-error" class="error">{{.}}</div>
+    {{/form.errors.right_games}}
+    {{#form.errors.right_id}}
+        <div id="right-id-error" class="error">{{.}}</div>
+    {{/form.errors.right_id}}
 </section>
 <section>
     <h2>Current League Matches</h2>

--- a/decksite/views/edit_matches.py
+++ b/decksite/views/edit_matches.py
@@ -1,17 +1,19 @@
 from collections.abc import Sequence
 
+from decksite.form import Form
 from decksite.view import View
 from magic.models import Deck
 from shared import dtutil
 
 
 class EditMatches(View):
-    def __init__(self, competition_id: int, decks: Sequence[Deck]) -> None:
+    def __init__(self, competition_id: int, decks: Sequence[Deck], form: Form) -> None:
         super().__init__()
         self.hide_active_runs = False
         self.competition_id = competition_id
         far_future = dtutil.parse('2100-01-01', '%Y-%m-%d', dtutil.UTC_TZ)
         self.decks = sorted(decks, key=lambda d: d.person + str((far_future - d.created_date).total_seconds()))
+        self.form = form
 
     def page_title(self) -> str:
         return 'Edit Matches'


### PR DESCRIPTION
## Summary
- validate both deck selections and match scores before adding or changing admin matches
- show field-level server-side errors without disrupting the inline form layout
- reject missing, invalid, or duplicate deck selections and preserve submitted scores

## Testing
- uv run --frozen pytest --no-cov -q (653 passed, 2 skipped)
- uv run --frozen python dev.py check

Closes #12985