### PR TITLE
Populate legal cards during post-rotation

### DIFF
--- a/maintenance/post_rotation.py
+++ b/maintenance/post_rotation.py
@@ -1,6 +1,7 @@
 import asyncio
 
 from decksite import league
+from decksite.data import playability
 from magic import multiverse
 from shared import dtutil
 from shared import redis_wrapper as redis
@@ -21,6 +22,7 @@ def ad_hoc() -> None:
     event_loop.run_until_complete(multiverse.update_pd_legality_async())  # PD previous lists
     insert_seasons.run()  # Make sure Season table is up to date
     multiverse.rebuild_cache()
+    playability.preaggregate_legal_cards()  # Make unplayed cards available on /rotation/changes immediately.
     if redis.REDIS:  # Clear the redis cache
         redis.REDIS.flushdb()
     league_end = league.active_league().end_date

--- a/maintenance/post_rotation_test.py
+++ b/maintenance/post_rotation_test.py
@@ -1,0 +1,38 @@
+import datetime
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+import pytest
+
+from maintenance import post_rotation
+
+
+class EventLoop:
+    def run_until_complete(self, coroutine: Coroutine[Any, Any, None]) -> None:
+        coroutine.close()
+
+
+def test_populates_legal_cards_after_rebuilding_card_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def record(name: str) -> Callable[[], None]:
+        return lambda: calls.append(name)
+
+    async def noop_async() -> None:
+        pass
+
+    monkeypatch.setattr(post_rotation.asyncio, 'get_event_loop', EventLoop)
+    monkeypatch.setattr(post_rotation.league, 'set_status', lambda status: None)
+    monkeypatch.setattr(post_rotation.league, 'active_league', lambda: type('League', (), {'end_date': datetime.datetime.min.replace(tzinfo=datetime.UTC)})())
+    monkeypatch.setattr(post_rotation.multiverse, 'init', lambda: None)
+    monkeypatch.setattr(post_rotation.multiverse, 'set_legal_cards_async', noop_async)
+    monkeypatch.setattr(post_rotation.multiverse, 'update_pd_legality_async', noop_async)
+    monkeypatch.setattr(post_rotation.insert_seasons, 'run', record('insert seasons'))
+    monkeypatch.setattr(post_rotation.multiverse, 'rebuild_cache', record('rebuild card cache'))
+    monkeypatch.setattr(post_rotation.playability, 'preaggregate_legal_cards', record('populate legal cards'))
+    monkeypatch.setattr(post_rotation.dtutil, 'now', lambda: datetime.datetime.now(datetime.UTC))
+    monkeypatch.setattr(post_rotation.redis, 'REDIS', None)
+
+    post_rotation.ad_hoc()
+
+    assert calls == ['insert seasons', 'rebuild card cache', 'populate legal cards']


### PR DESCRIPTION
## Summary

- populate the new season’s legal-card cache during the post-rotation workflow
- make newly legal, unplayed cards appear immediately on `/rotation/changes/` with zero or blank stats
- verify the cache refresh runs after the season is inserted and the card cache is rebuilt

## Testing

- `uv run pytest maintenance/post_rotation_test.py -q`
- `uv run ruff check maintenance/post_rotation.py maintenance/post_rotation_test.py`
- `uv run mypy maintenance/post_rotation.py maintenance/post_rotation_test.py`