### PR TITLE
Fix initial metagame quality sorting

### DIFF
--- a/shared_web/static/js/datamanager.jsx
+++ b/shared_web/static/js/datamanager.jsx
@@ -19,6 +19,8 @@ export class DataManager extends React.Component {
         super(props);
         this.state = {
             error: "",
+            sortBy: props.initialSortBy,
+            sortOrder: props.initialSortOrder,
             loadedOnce: false,
             message: "",
             objects: [],
@@ -144,6 +146,8 @@ DataManager.propTypes = {
     "hidePerson": PropTypes.string,
     "hideSource": PropTypes.string,
     "hideTop8": PropTypes.string,
+    "initialSortBy": PropTypes.string,
+    "initialSortOrder": PropTypes.oneOf(["ASC", "DESC", "AUTO"]),
     "leagueOnly": PropTypes.string,
     "pageSize": PropTypes.string.isRequired,
     "personId": PropTypes.string,

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -106,6 +106,8 @@ const renderSort = (grid) => (
             <Grid
                 className="metagame-grid"
                 endpoint="/api/archetypes2/"
+                initialSortBy="quality"
+                initialSortOrder="AUTO"
                 renderItem={renderItem}
                 renderSort={renderSort}
                 reloadCards={true}


### PR DESCRIPTION
## Summary

- initialize grid sort state from optional component properties
- initialize the metagame grid to Quality / Auto so the first order change includes the selected field

## Testing

- `npx eslint shared_web/static/js/datamanager.jsx shared_web/static/js/metagamegrid.jsx`
- `npm run build`

Fixes #12942