### PR TITLE
Index Universes Beyond flavor names in bot search

### DIFF
--- a/magic/whoosh_search_test.py
+++ b/magic/whoosh_search_test.py
@@ -6,6 +6,7 @@ import whoosh
 from whoosh.index import create_in
 
 from magic import whoosh_write
+from magic.models import Card
 from magic.whoosh_search import WhooshSearcher
 
 
@@ -147,3 +148,21 @@ def test_canonical_name_wins_alias_collision(tmp_path: Path) -> None:
     result = searcher.search('Chittering Host')
     assert result.get_best_match() == 'Midnight Scavengers'
     assert result.get_all_matches() == ['Midnight Scavengers', 'Graf Rats']
+
+def test_flavor_name_is_searchable(tmp_path: Path) -> None:
+    ix = create_in(tmp_path, whoosh_write.WhooshWriter().schema)
+    card = Card({
+        'id': 1,
+        'name': "Greymond, Avacyn's Stalwart",
+        'names': "Greymond, Avacyn's Stalwart",
+        'flavor_names': 'Rick, Steadfast Leader',
+        'layout': 'normal',
+    })
+    whoosh_write.update_index(ix, [card])
+
+    searcher = WhooshSearcher.__new__(WhooshSearcher)
+    searcher.ix = ix
+    searcher.initialize_trie()
+
+    result = searcher.search('Rick, Steadfast Leader')
+    assert result.get_best_match() == "Greymond, Avacyn's Stalwart"

--- a/magic/whoosh_write.py
+++ b/magic/whoosh_write.py
@@ -33,7 +33,9 @@ def update_index(index: FileIndex, cards: list[Card]) -> None:
     # We exclude emblems here to stop them showing up as
     cards = [c for c in cards if layout.is_playable_layout(c.layout)]
     for card in cards:
-        names = card.names
+        names = list(card.names)
+        if card.flavor_names:
+            names.extend(card.flavor_names.split('|'))
         if card.name not in names:
             names.append(card.name)  # Split and aftermath cards
         if card.name.startswith('The '):


### PR DESCRIPTION
## Summary
- index stored flavor and alternate names as aliases in Whoosh
- preserve canonical card names as search results
- add a regression test for Rick, Steadfast Leader

Fixes #12956

## Tests
- `uv run --frozen pytest discordbot/unit_test.py magic/whoosh_search_test.py -q`
- `uv run --frozen ruff check magic/whoosh_write.py magic/whoosh_search_test.py`
- `uv run --frozen mypy magic/whoosh_write.py magic/whoosh_search_test.py`
- rebuilt the real index and verified all 560 stored flavor names resolve uniquely