### PR TITLE
Show win rate in archetype history tooltips

### DIFF
--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -113,8 +113,8 @@ def archetype(archetype_id: str, deck_type: str | None = None) -> str:
     all_archetypes = archs.load_archetypes(season_id=season_id, tournament_only=tournament_only)
     archetype_matchups = archs.load_matchups(archetype_id=a.id, season_id=season_id, tournament_only=tournament_only)
     seasons_active = archs.seasons_active(a.id)
-    meta_share = archs.meta_share(a.id, tournament_only=tournament_only)
-    view = Archetype(a, all_archetypes, archetype_matchups, seasons_active, meta_share, tournament_only=tournament_only)
+    season_stats = archs.season_stats(a.id, tournament_only=tournament_only)
+    view = Archetype(a, all_archetypes, archetype_matchups, seasons_active, season_stats, tournament_only=tournament_only)
     return view.page()
 
 

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 import titlecase
 from anytree import NodeMixin
 from anytree.iterators import PreOrderIter
@@ -13,6 +15,11 @@ from shared.pd_exception import DoesNotExistException
 
 class Archetype(Container, NodeMixin):
     pass
+
+
+class SeasonStats(TypedDict):
+    meta_share: float
+    win_rate: float | None
 
 
 BASE_ARCHETYPES: dict[Archetype, Archetype] = {}
@@ -72,7 +79,7 @@ def seasons_active(archetype_id: int) -> list[int]:
     sql = 'SELECT season_id FROM _arch_stats WHERE archetype_id = %s'
     return db().values(sql, [archetype_id])
 
-def meta_share(archetype_id: int, tournament_only: bool = False) -> list[float]:
+def season_stats(archetype_id: int, tournament_only: bool = False) -> list[SeasonStats]:
     where = 'TRUE'
     if tournament_only:
         where = "deck_type = 'tournament'"
@@ -89,7 +96,8 @@ def meta_share(archetype_id: int, tournament_only: bool = False) -> list[float]:
                 season.id
         )
         SELECT
-            CASE WHEN st.num_matches = 0 THEN 0 ELSE SUM(a.wins + a.losses + a.draws) / st.num_matches END AS meta_share
+            CASE WHEN st.num_matches = 0 THEN 0 ELSE SUM(a.wins + a.losses + a.draws) / st.num_matches END AS meta_share,
+            SUM(a.wins) / NULLIF(SUM(a.wins + a.losses), 0) AS win_rate
         FROM
             season_totals AS st
         LEFT JOIN
@@ -99,7 +107,13 @@ def meta_share(archetype_id: int, tournament_only: bool = False) -> list[float]:
         ORDER BY
             st.season_id;
     """
-    return [float(v) if v else 0.0 for v in db().values(sql, [archetype_id])]
+    return [
+        {
+            'meta_share': float(row['meta_share']) if row['meta_share'] else 0.0,
+            'win_rate': float(row['win_rate']) if row['win_rate'] is not None else None,
+        }
+        for row in db().select(sql, [archetype_id])
+    ]
 
 def add(name: str, parent: int, description: str) -> None:
     archetype_id = db().insert('INSERT INTO archetype (name, description) VALUES (%s, %s)', [name, description])

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -1,0 +1,33 @@
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from decksite.data import archetype
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self.sql = ''
+        self.args: list[Any] = []
+
+    def select(self, sql: str, args: list[Any]) -> list[dict[str, Any]]:
+        self.sql = sql
+        self.args = args
+        return [
+            {'meta_share': Decimal('0.125'), 'win_rate': Decimal('0.6')},
+            {'meta_share': None, 'win_rate': None},
+        ]
+
+
+@pytest.mark.parametrize(('tournament_only', 'where'), [(False, 'TRUE'), (True, "deck_type = 'tournament'")])
+def test_season_stats(monkeypatch: pytest.MonkeyPatch, tournament_only: bool, where: str) -> None:
+    database = FakeDatabase()
+    monkeypatch.setattr(archetype, 'db', lambda: database)
+
+    assert archetype.season_stats(42, tournament_only) == [
+        {'meta_share': 0.125, 'win_rate': 0.6},
+        {'meta_share': 0.0, 'win_rate': None},
+    ]
+    assert database.args == [42]
+    assert f'AND {where}' in database.sql

--- a/decksite/views/archetype.py
+++ b/decksite/views/archetype.py
@@ -17,8 +17,54 @@ class Matchups(TypedDict):
     hide_tournament_results: bool
     archetypes: list[archs.Archetype]
 
+
+def history_chart(season_stats: list[archs.SeasonStats]) -> dict[str, str]:
+    meta_share = [stats['meta_share'] for stats in season_stats]
+    win_rate = [stats['win_rate'] for stats in season_stats]
+    return {
+        'type': 'bar',
+        'labels': json.dumps(list(range(1, len(meta_share) + 1))),
+        'series': json.dumps(meta_share),
+        'options': json.dumps({
+            'pd': {
+                'title': {
+                    'style': 'season',
+                },
+                'tooltip': {
+                    'label': 'Meta Share',
+                    'additional_label': 'Win Rate',
+                    'additional_series': win_rate,
+                },
+            },
+            'indexAxis': 'x',
+            'plugins': {
+                'datalabels': {
+                    'display': False,
+                },
+                'tooltip': {
+                    'enabled': True,
+                },
+            },
+            'scales': {
+                'x': {
+                    'grid': {
+                        'display': False,
+                    },
+                },
+                'y': {
+                    'ticks': {
+                        'format': {
+                            'style': 'percent',
+                        },
+                    },
+                },
+            },
+        }),
+    }
+
+
 class Archetype(View):
-    def __init__(self, archetype: archs.Archetype, archetypes: list[archs.Archetype], matchups: list[Container], seasons_active: list[int], meta_share: list[float], tournament_only: bool = False) -> None:
+    def __init__(self, archetype: archs.Archetype, archetypes: list[archs.Archetype], matchups: list[Container], seasons_active: list[int], season_stats: list[archs.SeasonStats], tournament_only: bool = False) -> None:
         super().__init__()
         if not archetype:
             raise DoesNotExistException('No archetype supplied to view.')
@@ -47,41 +93,7 @@ class Archetype(View):
         self.show_archetype_tree = len(self.archetypes) > 0
         self.has_cards = True
         if self.season_id() == 0:
-            self.history_chart = {
-                'type': 'bar',
-                'labels': json.dumps(list(range(1, len(meta_share) + 1))),
-                'series': json.dumps(meta_share),
-                'options': json.dumps({
-                    'pd': {
-                        'title': {
-                            'style': 'season',
-                        },
-                    },
-                    'indexAxis': 'x',
-                    'plugins': {
-                        'datalabels': {
-                            'display': False,
-                        },
-                        'tooltip': {
-                            'enabled': True,
-                        },
-                    },
-                    'scales': {
-                        'x': {
-                            'grid': {
-                                'display': False,
-                            },
-                        },
-                        'y': {
-                            'ticks': {
-                                'format': {
-                                    'style': 'percent',
-                                },
-                            },
-                        },
-                    },
-                }),
-            }
+            self.history_chart = history_chart(season_stats)
 
     def og_title(self) -> str:
         return self.archetype.name

--- a/decksite/views/archetype_test.py
+++ b/decksite/views/archetype_test.py
@@ -1,0 +1,21 @@
+import json
+
+from decksite.data.archetype import SeasonStats
+from decksite.views.archetype import history_chart
+
+
+def test_history_chart_includes_win_rate_in_tooltip() -> None:
+    season_stats: list[SeasonStats] = [
+        {'meta_share': 0.125, 'win_rate': 0.6},
+        {'meta_share': 0.0, 'win_rate': None},
+    ]
+
+    chart = history_chart(season_stats)
+    options = json.loads(chart['options'])
+
+    assert json.loads(chart['series']) == [0.125, 0.0]
+    assert options['pd']['tooltip'] == {
+        'label': 'Meta Share',
+        'additional_label': 'Win Rate',
+        'additional_series': [0.6, None],
+    }

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -556,6 +556,18 @@ PD.renderCharts = function() {
                 options.plugins.tooltip.callbacks.label = (v) => PD.formatPercentage(v.raw);
             }
         }
+        if (options.pd?.tooltip?.additional_series) {
+            const tooltip = options.pd.tooltip;
+            options.plugins.tooltip.callbacks = options.plugins.tooltip.callbacks || {};
+            options.plugins.tooltip.callbacks.label = (v) => {
+                const additionalValue = tooltip.additional_series[v.dataIndex],
+                    additionalText = additionalValue === null ? "N/A" : PD.formatPercentage(additionalValue);
+                return [
+                    tooltip.label + ": " + PD.formatPercentage(v.raw),
+                    tooltip.additional_label + ": " + additionalText
+                ];
+            };
+        }
 
 
         // eslint-disable-next-line no-new


### PR DESCRIPTION
## Summary
- query season-level win rate alongside meta share
- show both percentages in all-time archetype chart tooltips
- display N/A when a season has no matches
- cover season-stat conversion and chart tooltip configuration

## Testing
- `uv run pytest -q` (652 passed, 2 skipped)
- `uv run python dev.py mypy decksite/data/archetype.py decksite/controllers/metagame.py decksite/views/archetype.py decksite/data/archetype_test.py decksite/views/archetype_test.py`
- `uv run python dev.py jslint`
- `npm run build`

Fixes #13139