### PR TITLE
Rebuild symbols font during production deploy

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,8 +17,4 @@ echo "${APP[*]}"
 cd "$(dirname "$0")"
 git pull --ff-only
 uv sync --frozen
-if [[ " ${APP[*]} " == *" decksite "* ]]
-then
-    uv run --frozen python run.py maintenance fonts
-fi
 uv run --frozen run.py "${APP[@]}"

--- a/shared_web/api.py
+++ b/shared_web/api.py
@@ -23,6 +23,7 @@ def process_github_webhook() -> Response:
                     subprocess.check_output([sys.executable, '-m', 'uv', 'sync', '--frozen'])
                 except subprocess.CalledProcessError:
                     pass
+                subprocess.check_output([sys.executable, 'run.py', 'maintenance', 'fonts'])
                 try:
                     subprocess.check_output(['npm', 'run-script', 'build'])
                 except subprocess.CalledProcessError:

--- a/shared_web/api_test.py
+++ b/shared_web/api_test.py
@@ -1,0 +1,26 @@
+import sys
+from unittest import mock
+
+from flask import Flask
+
+from shared_web import api
+
+
+def test_push_deployment_rebuilds_symbols_font() -> None:
+    app = Flask(__name__)
+    app.config['branch'] = 'master'
+
+    with (
+        app.test_request_context('/api/gitpull', method='POST', headers={'X-GitHub-Event': 'push'}, json={'ref': 'refs/heads/master'}),
+        mock.patch.object(api.subprocess, 'check_output') as check_output,
+    ):
+        response = api.process_github_webhook()
+
+    assert response.status_code == 200
+    assert check_output.call_args_list == [
+        mock.call(['git', 'fetch']),
+        mock.call(['git', 'reset', '--hard', 'origin/master']),
+        mock.call([sys.executable, '-m', 'uv', 'sync', '--frozen']),
+        mock.call([sys.executable, 'run.py', 'maintenance', 'fonts']),
+        mock.call(['npm', 'run-script', 'build']),
+    ]


### PR DESCRIPTION
## Summary

- rebuild the symbols font from the GitHub push webhook that actually deploys production
- remove the ineffective rebuild hook from `bootstrap.sh`
- add a regression test for the complete deployment subprocess sequence

## Root cause

Follow-up to #14872. Production receives updates through `process_github_webhook`, which fetches and resets the checkout directly. It does not invoke `bootstrap.sh`, so the font rebuild added there never ran even though the application code reached production.

## Impact

Every production push now regenerates `symbols.woff2` after syncing Python dependencies. The generator is a required deploy step, so a failure is visible instead of silently leaving a stale font in place.

## Rollout

The webhook request that pulls this PR will still be executing the previously loaded Python code, so it cannot run the new rebuild step itself. After this PR merges, either run `uv run --frozen python run.py maintenance fonts` once on production or allow the next push to `master` to trigger the new step.

## Validation

- `uv run --frozen ruff check shared_web/api.py shared_web/api_test.py`
- `uv run --frozen mypy shared_web/api.py shared_web/api_test.py`
- `bash -n bootstrap.sh`
- `shellcheck bootstrap.sh`
- ran the exact production font-generation command and verified the output contains U+2728 SPARKLES
- `uv run --frozen pytest` (659 passed, 2 skipped)

Related to #12870
