### PR TITLE
Rebuild symbols font outside deploy request

### DIFF
--- a/shared_web/api.py
+++ b/shared_web/api.py
@@ -23,7 +23,12 @@ def process_github_webhook() -> Response:
                     subprocess.check_output([sys.executable, '-m', 'uv', 'sync', '--frozen'])
                 except subprocess.CalledProcessError:
                     pass
-                subprocess.check_output([sys.executable, 'run.py', 'maintenance', 'fonts'])
+                subprocess.Popen(
+                    [sys.executable, 'run.py', 'maintenance', 'fonts'],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
                 try:
                     subprocess.check_output(['npm', 'run-script', 'build'])
                 except subprocess.CalledProcessError:

--- a/shared_web/api_test.py
+++ b/shared_web/api_test.py
@@ -1,3 +1,4 @@
+import subprocess
 import sys
 from unittest import mock
 
@@ -13,6 +14,7 @@ def test_push_deployment_rebuilds_symbols_font() -> None:
     with (
         app.test_request_context('/api/gitpull', method='POST', headers={'X-GitHub-Event': 'push'}, json={'ref': 'refs/heads/master'}),
         mock.patch.object(api.subprocess, 'check_output') as check_output,
+        mock.patch.object(api.subprocess, 'Popen') as popen,
     ):
         response = api.process_github_webhook()
 
@@ -21,6 +23,11 @@ def test_push_deployment_rebuilds_symbols_font() -> None:
         mock.call(['git', 'fetch']),
         mock.call(['git', 'reset', '--hard', 'origin/master']),
         mock.call([sys.executable, '-m', 'uv', 'sync', '--frozen']),
-        mock.call([sys.executable, 'run.py', 'maintenance', 'fonts']),
         mock.call(['npm', 'run-script', 'build']),
     ]
+    popen.assert_called_once_with(
+        [sys.executable, 'run.py', 'maintenance', 'fonts'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )


### PR DESCRIPTION
## Summary

- run production font generation in a detached background process
- prevent the slow font task from blocking and timing out the GitHub deployment webhook
- verify the detached command and synchronous deployment steps independently

## Root cause

Follow-up to #14897. The production webhook delivery after that change returned HTTP 500 after exactly 10 seconds. Font generation itself takes roughly 10 seconds, and it was executed synchronously inside the HTTP request, causing the deployment webhook to time out before the font could be installed.

## Impact

The webhook can return without waiting for font generation. The detached process has no inherited request streams and starts a new session, allowing it to finish even if the web worker reloads after updating the checkout.

## Rollout

The webhook request that pulls this PR will still run the previously loaded synchronous implementation. Once the new code is deployed, redeliver that push webhook or allow the next push to `master` to start the detached rebuild.

## Validation

- `uv run --frozen ruff check shared_web/api.py shared_web/api_test.py`
- `uv run --frozen mypy shared_web/api.py shared_web/api_test.py`
- `uv run --frozen pytest` (679 passed, 2 skipped)

Related to #12870
