### PR TITLE
Improve season icon highlighting

### DIFF
--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -239,6 +239,8 @@ def set_legal_icons(o: Card | Deck) -> None:
         o.legal_icons += season_icon_link(code)
 
 def season_icon_link(code: str) -> str:
-    current_season_class = ' current-season-icon' if code in seasons.current_season_name() else ''
+    is_current_season = code in seasons.current_season_name()
+    current_season_class = ' current-season-icon' if is_current_season else ''
+    current_season_title = ' title="Current season"' if is_current_season else ''
     n = seasons.SEASONS.index(code.upper()) + 1
-    return f'<a href="/seasons/{n}/"><i class="ss ss-{code.lower()} season-icon{current_season_class}"><span class="ss-num">{n}</span></i></a>'
+    return f'<a class="season-icon-link{current_season_class}" href="/seasons/{n}/"{current_season_title}><i class="ss ss-{code.lower()} season-icon"><span class="ss-num">{n}</span></i></a>'

--- a/decksite/prepare_test.py
+++ b/decksite/prepare_test.py
@@ -10,8 +10,13 @@ def test_season_icon_link_uses_site_colors(monkeypatch: pytest.MonkeyPatch) -> N
     current = prepare.season_icon_link('KLD')
     previous = prepare.season_icon_link('EMN')
 
-    assert 'class="ss ss-kld season-icon current-season-icon"' in current
+    assert 'class="season-icon-link current-season-icon"' in current
+    assert 'class="season-icon-link"' in previous
+    assert 'title="Current season"' in current
+    assert 'title="Current season"' not in previous
+    assert 'class="ss ss-kld season-icon"' in current
     assert 'class="ss ss-emn season-icon"' in previous
+    assert 'current-season-icon' not in previous
     assert 'ss-common' not in previous
     assert 'ss-rare' not in current
     assert 'ss-grad' not in current

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -563,6 +563,7 @@ Color attributes are mostly found with their related structural elements in this
     --line: var(--black);
     --highlight: var(--soft-tangerine);
     --highlight-border: var(--soft-tangerine-darker);
+    --current-season-icon: #a58e4a; /* Keyrune rare gold. */
     --selected: var(--light-gray);
     --inactive: var(--dark-gray);
     --disabled: var(--light-gray);
@@ -613,6 +614,7 @@ html.dark-mode {
     --red: oklch(60% 0.137 24); /* Indian Red */
     --soft-tangerine: oklch(55% 0.06 309.48); /* Chinese Violet */
     --soft-tangerine-darker: oklch(65% 0.06 309.48);
+    --current-season-icon: #c4ae69;
     --true-black: #fff; /* White. Only for use at less than 1 opacity, for scrim and similar. */
 
     --w-mana: #fffcdb;
@@ -2484,9 +2486,29 @@ Season Symbols
     color: var(--inactive);
 }
 
-.current-season-icon {
-    background-color: var(--highlight);
+.season-icon-link {
+    white-space: nowrap;
+}
+
+.ss-grid .season-icon-link {
     border-radius: var(--text-rounded-corners);
+    display: inline-block;
+    justify-self: start;
+    line-height: var(--table-line-height);
+    margin-right: 0.317rem;
+    padding: 0.178em 0.317rem;
+}
+
+.ss-grid .season-icon-link .season-icon {
+    margin-right: 0;
+}
+
+main .ss-grid a.season-icon-link:hover {
+    background-color: var(--highlight);
+}
+
+.season-icon-link.current-season-icon .season-icon::before {
+    color: var(--current-season-icon);
 }
 
 .ss-grid {


### PR DESCRIPTION
## Summary
- keep season-icon hover backgrounds compact, evenly padded, and aligned
- distinguish the current season with a theme-aware Keyrune rarity-gold symbol
- add a current-season tooltip and focused rendering coverage

## Validation
- uv run --frozen pytest decksite/prepare_test.py decksite/views/person_test.py -q
- uv run --frozen python dev.py lint
- uv run --frozen python dev.py mypy decksite/prepare.py
- browser verification in light and dark modes