### PR TITLE
Handle empty card iterables

### DIFF
--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -43,10 +43,10 @@ def load_card(name: str) -> Card:
     return CARDS_BY_NAME.get(name) or load_cards([name])[0]
 
 def load_cards(names: Iterable[str] | None = None, where: str | None = None) -> list[Card]:
-    if names == []:
-        return []
-    if names:
+    if names is not None:
         setnames = set(names)
+        if not setnames:
+            return []
     else:
         setnames = set()
     if setnames:

--- a/magic/oracle_test.py
+++ b/magic/oracle_test.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterable
+
 import pytest
 
 from magic import oracle, seasons
@@ -35,6 +37,10 @@ def test_load_cards() -> None:
     assert len(cards) == 2
     assert 'Think Twice' in [c.name for c in cards]
     assert 'Swamp' in [c.name for c in cards]
+
+@pytest.mark.parametrize('names', [[], (), {}, iter(())])
+def test_load_cards_empty_iterable(names: Iterable[str]) -> None:
+    assert oracle.load_cards(names) == []
 
 def test_deck_sort_x_last() -> None:
     cards = oracle.load_cards(['Ghitu Fire', 'Flash of Insight', 'Frantic Search'])


### PR DESCRIPTION
## Summary
- distinguish an omitted card-name filter from an empty iterable
- return no cards for empty mappings, tuples, and generators as well as empty lists
- prevent Cards Played First from loading every card and crashing when a player has no trailblazer entries

## Validation
- `uv run --frozen pytest magic/oracle_test.py decksite/views/person_test.py`
- `uv run --frozen python dev.py full-check`
- `uv run --frozen python dev.py unit` (603 passed, 1 skipped)
- verified `/people/id/5249/` returns 200 on the local Decksite server