### PR TITLE
Share production-safe symbols font rebuild

### DIFF
--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import subprocess
 import time
 from typing import TypedDict
 
@@ -16,6 +15,7 @@ from shared import redis_wrapper as redis
 from shared.container import Container
 from shared.database import sqlescape
 from shared.pd_exception import DatabaseException, InvalidDataException, LockNotAcquiredException
+from shared_web import fonts
 
 
 def latest_decks(season_id: str | int | None = None) -> list[Deck]:
@@ -424,9 +424,7 @@ def maybe_regenerate_symbols_font(name: str) -> None:
         db().get_lock('font_generation', 60 * 15)
     except LockNotAcquiredException:
         return
-    # Fire off a background job to generate the font, it takes too long (10s) to do on user time during deck creation.
-    cmd = ['uv', 'run', '--frozen', 'python', 'run.py', 'maintenance', 'fonts']
-    subprocess.Popen(cmd)
+    fonts.regenerate_symbols_font()
     db().release_lock('font_generation')
 
 def add_cards(deck_id: int, cards: CardsDescription) -> None:

--- a/decksite/data/deck_test.py
+++ b/decksite/data/deck_test.py
@@ -1,6 +1,31 @@
+from unittest import mock
+
 from decksite.data import deck
 from magic.models import Card, Deck
 from shared.container import Container
+
+
+def test_maybe_regenerate_symbols_font_for_unusual_character() -> None:
+    with (
+        mock.patch.object(deck, 'db') as db,
+        mock.patch.object(deck.fonts, 'regenerate_symbols_font') as regenerate_symbols_font,
+    ):
+        deck.maybe_regenerate_symbols_font('Sparkles ✨')
+
+    db.return_value.get_lock.assert_called_once_with('font_generation', 60 * 15)
+    regenerate_symbols_font.assert_called_once_with()
+    db.return_value.release_lock.assert_called_once_with('font_generation')
+
+
+def test_maybe_regenerate_symbols_font_ignores_latin_1() -> None:
+    with (
+        mock.patch.object(deck, 'db') as db,
+        mock.patch.object(deck.fonts, 'regenerate_symbols_font') as regenerate_symbols_font,
+    ):
+        deck.maybe_regenerate_symbols_font('Déjà Vu')
+
+    db.assert_not_called()
+    regenerate_symbols_font.assert_not_called()
 
 
 def test_set_colors() -> None:

--- a/shared_web/api.py
+++ b/shared_web/api.py
@@ -24,7 +24,7 @@ def process_github_webhook() -> Response:
                 except subprocess.CalledProcessError:
                     pass
                 subprocess.Popen(
-                    [sys.executable, 'run.py', 'maintenance', 'fonts'],
+                    ['uv', 'run', '--frozen', 'python', 'run.py', 'maintenance', 'fonts'],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,

--- a/shared_web/api.py
+++ b/shared_web/api.py
@@ -9,6 +9,7 @@ from flask import Response, current_app, request
 from shared import configuration
 from shared.container import Container
 from shared.serialization import extra_serializer
+from shared_web import fonts
 
 
 def process_github_webhook() -> Response:
@@ -23,12 +24,7 @@ def process_github_webhook() -> Response:
                     subprocess.check_output([sys.executable, '-m', 'uv', 'sync', '--frozen'])
                 except subprocess.CalledProcessError:
                     pass
-                subprocess.Popen(
-                    ['uv', 'run', '--frozen', 'python', 'run.py', 'maintenance', 'fonts'],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    start_new_session=True,
-                )
+                fonts.regenerate_symbols_font()
                 try:
                     subprocess.check_output(['npm', 'run-script', 'build'])
                 except subprocess.CalledProcessError:

--- a/shared_web/api_test.py
+++ b/shared_web/api_test.py
@@ -26,7 +26,7 @@ def test_push_deployment_rebuilds_symbols_font() -> None:
         mock.call(['npm', 'run-script', 'build']),
     ]
     popen.assert_called_once_with(
-        [sys.executable, 'run.py', 'maintenance', 'fonts'],
+        ['uv', 'run', '--frozen', 'python', 'run.py', 'maintenance', 'fonts'],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         start_new_session=True,

--- a/shared_web/api_test.py
+++ b/shared_web/api_test.py
@@ -1,4 +1,3 @@
-import subprocess
 import sys
 from unittest import mock
 
@@ -14,7 +13,7 @@ def test_push_deployment_rebuilds_symbols_font() -> None:
     with (
         app.test_request_context('/api/gitpull', method='POST', headers={'X-GitHub-Event': 'push'}, json={'ref': 'refs/heads/master'}),
         mock.patch.object(api.subprocess, 'check_output') as check_output,
-        mock.patch.object(api.subprocess, 'Popen') as popen,
+        mock.patch.object(api.fonts, 'regenerate_symbols_font') as regenerate_symbols_font,
     ):
         response = api.process_github_webhook()
 
@@ -25,9 +24,4 @@ def test_push_deployment_rebuilds_symbols_font() -> None:
         mock.call([sys.executable, '-m', 'uv', 'sync', '--frozen']),
         mock.call(['npm', 'run-script', 'build']),
     ]
-    popen.assert_called_once_with(
-        ['uv', 'run', '--frozen', 'python', 'run.py', 'maintenance', 'fonts'],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        start_new_session=True,
-    )
+    regenerate_symbols_font.assert_called_once_with()

--- a/shared_web/fonts.py
+++ b/shared_web/fonts.py
@@ -1,0 +1,12 @@
+import subprocess
+
+
+def regenerate_symbols_font() -> None:
+    # Font generation takes too long to do while handling a request, so leave it to
+    # a detached process that can outlive the web worker that started it.
+    subprocess.Popen(
+        ['uv', 'run', '--frozen', 'python', 'run.py', 'maintenance', 'fonts'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )

--- a/shared_web/fonts_test.py
+++ b/shared_web/fonts_test.py
@@ -1,0 +1,16 @@
+import subprocess
+from unittest import mock
+
+from shared_web import fonts
+
+
+def test_regenerate_symbols_font() -> None:
+    with mock.patch.object(fonts.subprocess, 'Popen') as popen:
+        fonts.regenerate_symbols_font()
+
+    popen.assert_called_once_with(
+        ['uv', 'run', '--frozen', 'python', 'run.py', 'maintenance', 'fonts'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )


### PR DESCRIPTION
## Summary

- launch symbols-font rebuilds through `uv run --frozen python`
- share one detached launcher between deploys and the existing new-deck-symbol path
- cover the launcher and both callers with regression tests

## Root cause

Follow-up to #14903. The uWSGI production process reports `/usr/sbin/uwsgi` as `sys.executable`, so using `sys.executable` would attempt to run `run.py` through uWSGI and fail silently in the detached process.

The deployment hook now calls the same shared launcher used by `maybe_regenerate_symbols_font`, preventing those commands from drifting apart.

## Rollout

The webhook request that pulls this change will still execute the previously loaded code. Restart or touch the decksite uWSGI vassal after merge, then redeliver that push webhook or allow the next push to `master` to start the corrected rebuild.

## Validation

- `uv run --frozen pytest` (684 passed, 2 skipped)
- focused caller/launcher tests after adding deck-path coverage (5 passed)
- Ruff and mypy on the changed modules

Related to #12870
