### PR TITLE
Restore symbols font cache busting

### DIFF
--- a/decksite/view_test.py
+++ b/decksite/view_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from decksite import view
 from decksite.main import APP
@@ -33,9 +33,9 @@ def test_seasonized_url_for_app() -> None:
         assert view.seasonized_url(seasons.current_season_num()) == '/decks/'
 
 
-def test_font_url_matches_css_url() -> None:
-    with APP.test_request_context('/'):
-        assert BaseView().font_url() == '/static/fonts/symbols.woff2'
+def test_font_url_cache_busts_regenerated_font() -> None:
+    with APP.test_request_context('/'), patch('shared_web.base_view.os.path.getmtime', return_value=123):
+        assert BaseView().font_url() == '/static/fonts/symbols.woff2?v=123'
 
 def test_seasonized_url_for_seasons() -> None:
     with APP.test_request_context('/seasons/2/decks/'):

--- a/shared_web/base_view.py
+++ b/shared_web/base_view.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 from flask import current_app, make_response, url_for, wrappers
@@ -46,9 +47,11 @@ class BaseView:
         return current_app.config['branch']
 
     def font_url(self) -> str:
-        # This must exactly match the @font-face URL in pd.css so the browser can
-        # reuse the preloaded response rather than downloading the font again.
-        return url_for('static', filename='fonts/symbols.woff2')
+        try:
+            mtime = int(os.path.getmtime('shared_web/static/fonts/symbols.woff2'))
+        except OSError:
+            mtime = 0
+        return url_for('static', filename='fonts/symbols.woff2', v=mtime)
 
     def css_url(self) -> str:
         return current_app.config['css_url'] or url_for('static', filename='css/pd.css', v=self.commit_id('shared_web/static/css/pd.css'))


### PR DESCRIPTION
## Summary

- restore the symbols font mtime as a query parameter on its preload URL
- force viewers to fetch a new URL after the dynamically generated font changes
- replace the URL-matching regression test with cache-busting coverage

## Context

#14910 removed the query parameter so the preload URL exactly matched the static `@font-face` URL. That fixed Firefox's unused-preload warning, but it also removed the existing invalidation mechanism for the dynamically regenerated symbols font.

This restores only the previous mtime behavior. The glyph bounding-box fixes from #14910 remain intact. Because the static CSS URL is still unversioned, the Firefox preload warning may return; that tradeoff is intentional for now.

## Validation

- `uv run --frozen pytest` (688 passed, 2 skipped)
- `uv run --frozen ruff check shared_web/base_view.py decksite/view_test.py`
- `uv run --frozen mypy shared_web/base_view.py decksite/view_test.py`

Related to #12870
