### PR TITLE
Support equivalent card names and canonicalize stored data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ whoosh_index/
 
 # Scryfall
 /scryfall-default-cards.json
+/scryfall-default-cards.jsonl.gz
+/sets.json
 
 # MTGJSON
 AllCards-x.json

--- a/README.md
+++ b/README.md
@@ -146,6 +146,18 @@ There are various levels of granularity but in general use you want:
 
 Check the dev.py source code for the full set of options including `unit`, `types`, `lint` (covered by `test` above) as well as `functional` (integration tests), `perf` (performance tests). `release` will take you all the way from your committed change to a PR via the tests (needs GitHub's commandline `gh` installed).
 
+### Validating card-import changes
+
+Changes to the Scryfall importer should also be checked with two disposable databases made from exactly the same bulk data:
+
+1. Create a worktree at `origin/master` and place the same `scryfall-default-cards.json` and `sets.json` in both worktree roots. The candidate also accepts Scryfall's compressed `scryfall-default-cards.jsonl.gz` format.
+2. Force an import from the master worktree into a database named `pd_alias_shadow_master` and from the candidate into `pd_alias_shadow_candidate`. Shadow database names deliberately use the `pd_alias_shadow_` prefix to keep them separate from development and production data.
+3. From the candidate worktree, run `uv run python dev.py compare-card-databases pd_alias_shadow_master pd_alias_shadow_candidate`.
+
+The comparison fails if canonical card data was removed or changed, if an existing alias or legality was removed, or if aliases became ambiguous. It permits and reports newly recognized aliases and legality rows derived from those aliases.
+
+After importing current cards, run `uv run pytest magic/omenpaths_test.py rotation_script/rotation_script_test.py` for the focused acceptance cases. They cover normal and double-faced alternate names, mixed-name aggregation, the shared four-copy limit across main deck and sideboard, canonical deck and legal-list output, legacy name matching, and search indexing. The full `uv run pytest` suite remains the final regression gate.
+
 ## Working on React components
 
 - Run logsite

--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -74,20 +74,28 @@ def cards(deck_type: str | None = None) -> str:
 @SEASONS.route('/cards/<path:name>/')
 @SEASONS.route('/cards/<path:name>/<any(tournament,league):deck_type>/')
 @cached()
-def card(name: str, deck_type: str | None = None) -> str:
+def card(name: str, deck_type: str | None = None) -> str | wrappers.Response:
     tournament_only = validate_deck_type(deck_type, [DeckType.ALL, DeckType.TOURNAMENT]) == DeckType.TOURNAMENT
     try:
-        c = cs.load_card(parse_card_name(name), tournament_only=tournament_only, season_id=get_season_id())
+        submitted_name = decode_card_name(name)
+        canonical_name = parse_card_name(name)
+        if submitted_name != canonical_name:
+            assert request.endpoint is not None
+            return redirect(url_for(request.endpoint, name=canonical_name, deck_type=deck_type))
+        c = cs.load_card(canonical_name, tournament_only=tournament_only, season_id=get_season_id())
         view = Card(c, tournament_only)
         return view.page()
     except InvalidDataException as e:
         raise DoesNotExistException(e) from e
 
 def parse_card_name(name: str) -> str:
+    return oracle.valid_name(decode_card_name(name))
+
+def decode_card_name(name: str) -> str:
     name = urllib.parse.unquote_plus(name)
     if name.startswith(' '):  # Handle "+2 Mace".
         name = '+' + name.lstrip()
-    return oracle.valid_name(name)
+    return name
 
 @APP.route('/archetypes/')
 @APP.route('/archetypes/<any(tournament,league):deck_type>/')

--- a/decksite/controllers/metagame_test.py
+++ b/decksite/controllers/metagame_test.py
@@ -1,0 +1,66 @@
+from typing import Any, cast
+
+import pytest
+from flask import g
+
+from decksite.controllers import metagame
+from decksite.main import APP
+
+
+@pytest.mark.parametrize(
+    ('path', 'deck_type', 'expected'),
+    [
+        ('/cards/A%20Most%20Helpful%20Weaver/', None, '/cards/Origin%20of%20Spider-Man/'),
+        ('/cards/A%20Most%20Helpful%20Weaver/tournament/', 'tournament', '/cards/Origin%20of%20Spider-Man/tournament/'),
+    ],
+)
+def test_alias_card_pages_redirect_to_the_canonical_url(
+    path: str,
+    deck_type: str | None,
+    expected: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        metagame.oracle,
+        'valid_name',
+        lambda name: 'Origin of Spider-Man' if name == 'A Most Helpful Weaver' else name,
+    )
+    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: pytest.fail('Redirects must not load the card page'))
+
+    with APP.test_request_context(path):
+        response = cast(Any, metagame.card).__wrapped__(name='A Most Helpful Weaver', deck_type=deck_type)
+
+    assert response.status_code == 302
+    assert response.location == expected
+
+
+def test_canonical_card_pages_do_not_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(metagame.oracle, 'valid_name', lambda name: name)
+    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: object())
+
+    class FakeCardView:
+        def __init__(self, _card: object, _tournament_only: bool) -> None:
+            pass
+
+        def page(self) -> str:
+            return 'canonical card page'
+
+    monkeypatch.setattr(metagame, 'Card', FakeCardView)
+    with APP.test_request_context('/cards/Origin%20of%20Spider-Man/'):
+        response = cast(Any, metagame.card).__wrapped__(name='Origin of Spider-Man')
+
+    assert response == 'canonical card page'
+
+
+def test_alias_card_page_redirect_preserves_the_season(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        metagame.oracle,
+        'valid_name',
+        lambda name: 'Origin of Spider-Man' if name == 'A Most Helpful Weaver' else name,
+    )
+    with APP.test_request_context('/seasons/5/cards/A%20Most%20Helpful%20Weaver/tournament/'):
+        g.season_id = 5
+        response = cast(Any, metagame.card).__wrapped__(name='A Most Helpful Weaver', deck_type='tournament')
+
+    assert response.status_code == 302
+    assert response.location == '/seasons/5/cards/Origin%20of%20Spider-Man/tournament/'

--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -5,9 +5,9 @@ from decksite.data.query import person_query
 from decksite.deck_type import DeckType
 from decksite.tournament import CompetitionFlag
 from find import search
-from magic import rotation
+from magic import oracle, rotation
 from shared.database import sqlescape, sqllikeescape
-from shared.pd_exception import InvalidArgumentException
+from shared.pd_exception import InvalidArgumentException, InvalidDataException
 
 # Form SQL WHERE, ORDER BY and LIMIT clauses, sometimes by making db queries.
 
@@ -259,6 +259,10 @@ def archetype_where(archetype_id: int) -> str:
     return f'd.archetype_id IN (SELECT descendant FROM archetype_closure WHERE ancestor = {archetype_id})'
 
 def card_where(name: str) -> str:
+    try:
+        name = oracle.valid_name(name)
+    except InvalidDataException:
+        return 'FALSE'
     return f'd.id IN (SELECT deck_id FROM deck_card WHERE card = {sqlescape(name)})'
 
 # Returns two values, a SQL WHERE clause and a message about that clause (possibly an error message) suitable for display.

--- a/decksite/data/clauses_test.py
+++ b/decksite/data/clauses_test.py
@@ -35,6 +35,17 @@ def test_card_search_where() -> None:
     assert {found.group(1), found.group(2)} == {'Blood Moon', 'Magus of the Moon'}
     assert ('FALSE', "Using 'm' with other colors is not supported, use 'color>b' instead") == clauses.card_search_where('c:bm')
 
+def test_card_where_resolves_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(clauses.oracle, 'valid_name', lambda _name: 'Spider-Man Noir')
+    assert clauses.card_where('Kroble, Envoy of the Bog') == "d.id IN (SELECT deck_id FROM deck_card WHERE card = 'Spider-Man Noir')"
+
+def test_card_where_rejects_unknown_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    def invalid_name(_name: str) -> str:
+        raise clauses.InvalidDataException()
+
+    monkeypatch.setattr(clauses.oracle, 'valid_name', invalid_name)
+    assert clauses.card_where('Definitely Not a Card') == 'FALSE'
+
 def test_limit() -> None:
     args = {'page': '1', 'pageSize': '150'}
     assert clauses.pagination(args) == (1, 150, 'LIMIT 150, 150')

--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -7,7 +7,7 @@ from decksite import deck_name
 from decksite.data import query, season
 from decksite.data.top import Top
 from decksite.database import db
-from magic import legality, mana, oracle, seasons
+from magic import decklist, legality, mana, oracle, seasons
 from magic.colors import find_colors
 from magic.models import CardRef, Deck
 from shared import dtutil, guarantee, logger
@@ -318,7 +318,7 @@ def add_deck(params: RawDeckDescription) -> Deck:
         raise InvalidDataException(f'Did not find a username in {params}')
     person_id = get_or_insert_person_id(params.get('mtgo_username'), params.get('tappedout_username'), params.get('mtggoldfish_username'))
     deck_id = get_deck_id(params['source'], params['identifier'])
-    cards = params['cards']
+    cards = decklist.normalize(params['cards'])
     if deck_id:
         db().begin('replace_deck_cards')
         db().execute('UPDATE deck SET decklist_hash = %s WHERE id = %s', [get_deckhash(cards), deck_id])

--- a/decksite/data/deck_test.py
+++ b/decksite/data/deck_test.py
@@ -1,6 +1,11 @@
 from unittest import mock
 
-from decksite.data import deck
+import pytest
+
+from decksite.data import clauses, deck
+from decksite.database import db
+from decksite.testutil import with_test_db
+from magic import decklist, oracle
 from magic.models import Card, Deck
 from shared.container import Container
 
@@ -59,3 +64,43 @@ def test_set_colors() -> None:
         d = Deck({'maindeck': [Container({'card': c, 'n': 4}) for c in cs], 'sideboard': []})
         deck.set_colors(d)
         assert d.colors == output
+
+def test_equivalent_names_have_the_same_deck_hash(monkeypatch: pytest.MonkeyPatch) -> None:
+    aliases = {
+        'Spider-Man Noir': 'Spider-Man Noir',
+        'Kroble, Envoy of the Bog': 'Spider-Man Noir',
+    }
+    monkeypatch.setattr(oracle, 'valid_name', aliases.__getitem__)
+    spider_man = {'maindeck': {'Spider-Man Noir': 4}, 'sideboard': {}}
+    omenpaths = {'maindeck': {'Kroble, Envoy of the Bog': 4}, 'sideboard': {}}
+    assert deck.get_deckhash(decklist.normalize(spider_man)) == deck.get_deckhash(decklist.normalize(omenpaths))
+
+@with_test_db
+@pytest.mark.functional
+def test_equivalent_names_are_stored_and_found_as_one_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(deck, 'prime_cache', lambda _deck: None)
+    common: deck.RawDeckDescription = {
+        'name': 'Alias integration test',
+        'url': 'https://example.com/deck',
+        'source': 'League',
+        'mtgo_username': 'AliasTester',
+    }
+    omenpaths_params: deck.RawDeckDescription = common | {
+        'identifier': 'omenpaths-name',
+        'cards': {'maindeck': {'Kroble, Envoy of the Bog': 4, 'Swamp': 56}, 'sideboard': {}},
+    }
+    spiderman_params: deck.RawDeckDescription = common | {
+        'identifier': 'spiderman-name',
+        'cards': {'maindeck': {'Spider-Man Noir': 4, 'Swamp': 56}, 'sideboard': {}},
+    }
+    omenpaths = deck.add_deck(omenpaths_params)
+    spiderman = deck.add_deck(spiderman_params)
+
+    assert omenpaths.decklist_hash == spiderman.decklist_hash
+    stored_cards = db().select('SELECT card, n FROM deck_card WHERE deck_id = %s ORDER BY card', [omenpaths.id])
+    assert list(stored_cards) == [
+        {'card': 'Spider-Man Noir', 'n': 4},
+        {'card': 'Swamp', 'n': 56},
+    ]
+    matching_ids = db().values(f'SELECT id FROM deck AS d WHERE {clauses.card_where("Kroble, Envoy of the Bog")}')
+    assert set(matching_ids) == {omenpaths.id, spiderman.id}

--- a/decksite/data/rotation.py
+++ b/decksite/data/rotation.py
@@ -70,7 +70,7 @@ def update_rotation_runs() -> None:
     for path in rotation.files():
         f = open(path)
         number = rotation.run_number_from_path(path)
-        cs = [(number, line.strip()) for line in f.readlines()]
+        cs = [(number, oracle.canonical_name_or_self(line.strip())) for line in f.readlines()]
         sql = 'INSERT IGNORE INTO rotation_runs (number, name, season_id) VALUES '
         sql += ', '.join(f'({number}, {sqlescape(name)}, {season_id})' for number, name in cs)
         db().execute(sql)

--- a/decksite/data/rotation_test.py
+++ b/decksite/data/rotation_test.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from decksite.data import rotation as rotation_data
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self.sql = ''
+
+    def execute(self, sql: str, _args: list[Any] | None = None) -> int:
+        self.sql = sql
+        return 1
+
+
+def test_update_rotation_runs_stores_canonical_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / 'Run_001.txt'
+    path.write_text('Agent Venom\nRhilex the Accursed\nA Future Card\n', encoding='utf-8')
+    database = FakeDatabase()
+    monkeypatch.setattr(rotation_data, 'db', lambda: database)
+    monkeypatch.setattr(rotation_data.rotation, 'files', lambda: [str(path)])
+    monkeypatch.setattr(rotation_data.seasons, 'next_season_num', lambda: 99)
+    monkeypatch.setattr(rotation_data.oracle, 'canonical_name_or_self', lambda name: 'Agent Venom' if name == 'Rhilex the Accursed' else name)
+
+    rotation_data.update_rotation_runs()
+
+    assert database.sql.count("'Agent Venom'") == 2
+    assert 'Rhilex the Accursed' not in database.sql
+    assert "'A Future Card'" in database.sql

--- a/decksite/form.py
+++ b/decksite/form.py
@@ -4,7 +4,7 @@ from typing import Any
 from werkzeug.datastructures import ImmutableMultiDict
 
 from decksite.data import deck
-from magic import decklist, legality, seasons
+from magic import card, decklist, legality, oracle, seasons
 from magic.decklist import DecklistType
 from shared.container import Container
 from shared.pd_exception import BadRequestException, InvalidDataException
@@ -94,3 +94,35 @@ class DecklistForm(Form):
         if len(playable_bugs) > 0:
             self.warnings['decklist'] = 'Deck contains playable bugs'
             self.card_warnings['Warnings_Bugs'] = playable_bugs
+        self.use_submitted_aliases_in_card_messages()
+
+    def use_submitted_aliases_in_card_messages(self) -> None:
+        aliases = submitted_aliases(self.cards)
+        self.card_errors = card_messages_with_submitted_aliases(self.card_errors, aliases)
+        self.card_warnings = card_messages_with_submitted_aliases(self.card_warnings, aliases)
+
+def submitted_aliases(cards: DecklistType) -> dict[str, set[str]]:
+    aliases: dict[str, set[str]] = {}
+    for section in ['maindeck', 'sideboard']:
+        for submitted_name in cards.get(section, {}):
+            try:
+                canonical_name = oracle.valid_name(submitted_name)
+            except InvalidDataException:
+                continue
+            # A normal double-faced card can be submitted as "Front // Back" even
+            # though Columbus names the identity after its front face. That is not
+            # an alternate name and should not produce a parenthetical explanation.
+            submitted_front = submitted_name.split(' // ')[0]
+            if card.canonicalize(submitted_front) != card.canonicalize(canonical_name):
+                aliases.setdefault(canonical_name, set()).add(submitted_name)
+    return aliases
+
+def card_messages_with_submitted_aliases(messages: dict[str, set[str]], aliases: dict[str, set[str]]) -> dict[str, set[str]]:
+    return {
+        message_type: {
+            f"{canonical_name} (entered as {'; '.join(sorted(aliases[canonical_name]))})"
+            if aliases.get(canonical_name) else canonical_name
+            for canonical_name in names
+        }
+        for message_type, names in messages.items()
+    }

--- a/decksite/form_test.py
+++ b/decksite/form_test.py
@@ -1,0 +1,101 @@
+import pytest
+
+from decksite import form
+from magic.models import Deck
+from shared.pd_exception import InvalidDataException
+
+
+def test_submitted_aliases_records_the_name_the_player_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    names = {
+        'Origin of Spider-Man': 'Origin of Spider-Man',
+        'A Most Helpful Weaver': 'Origin of Spider-Man',
+    }
+    monkeypatch.setattr(form.oracle, 'valid_name', names.__getitem__)
+
+    aliases = form.submitted_aliases({
+        'maindeck': {'Origin of Spider-Man': 3},
+        'sideboard': {'A Most Helpful Weaver': 2},
+    })
+
+    assert aliases == {'Origin of Spider-Man': {'A Most Helpful Weaver'}}
+
+def test_submitted_aliases_does_not_treat_a_normal_double_faced_name_as_an_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(form.oracle, 'valid_name', lambda _name: 'Peter Parker')
+
+    aliases = form.submitted_aliases({
+        'maindeck': {'Peter Parker // Amazing Spider-Man': 4},
+        'sideboard': {},
+    })
+
+    assert aliases == {}
+
+def test_submitted_aliases_ignores_invalid_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    def invalid_name(_name: str) -> str:
+        raise InvalidDataException()
+
+    monkeypatch.setattr(form.oracle, 'valid_name', invalid_name)
+
+    assert form.submitted_aliases({'maindeck': {'Not a Card': 4}, 'sideboard': {}}) == {}
+
+def test_card_messages_show_canonical_and_submitted_names() -> None:
+    messages = {
+        'Legality_Too_Many': {'Origin of Spider-Man', 'Swamp'},
+    }
+    aliases = {
+        'Origin of Spider-Man': {'A Most Helpful Weaver'},
+    }
+
+    assert form.card_messages_with_submitted_aliases(messages, aliases) == {
+        'Legality_Too_Many': {
+            'Origin of Spider-Man (entered as A Most Helpful Weaver)',
+            'Swamp',
+        },
+    }
+
+def test_card_messages_list_multiple_submitted_aliases_deterministically() -> None:
+    messages = {'Legality_Too_Many': {'Peter Parker'}}
+    aliases = {
+        'Peter Parker': {
+            'Surris, Silk-Tech Vanguard',
+            'Surris, Spidersilk Innovator',
+        },
+    }
+
+    assert form.card_messages_with_submitted_aliases(messages, aliases) == {
+        'Legality_Too_Many': {
+            'Peter Parker (entered as Surris, Silk-Tech Vanguard; Surris, Spidersilk Innovator)',
+        },
+    }
+
+def test_legality_validation_uses_the_submitted_alias_in_its_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    decklist_form = form.DecklistForm.__new__(form.DecklistForm)
+    decklist_form.cards = {
+        'maindeck': {'A Most Helpful Weaver': 5, 'Swamp': 55},
+        'sideboard': {},
+    }
+    decklist_form.deck = Deck({'maindeck': [], 'sideboard': []})
+    decklist_form.errors = {}
+    decklist_form.warnings = {}
+    decklist_form.card_errors = {}
+    decklist_form.card_warnings = {}
+
+    monkeypatch.setattr(
+        form.oracle,
+        'valid_name',
+        lambda name: 'Origin of Spider-Man' if name == 'A Most Helpful Weaver' else name,
+    )
+    monkeypatch.setattr(form.seasons, 'current_season_name', lambda: 'Penny Dreadful Test')
+
+    def illegal_deck(_deck: Deck, _formats: set[str] | None, errors: dict[str, dict[str, set[str]]]) -> set[str]:
+        errors['Penny Dreadful Test'] = {'Legality_Too_Many': {'Origin of Spider-Man'}}
+        return set()
+
+    monkeypatch.setattr(form.legality, 'legal_formats', illegal_deck)
+
+    decklist_form.check_deck_legality()
+
+    assert decklist_form.card_errors == {
+        'Legality_Too_Many': {
+            'Origin of Spider-Man (entered as A Most Helpful Weaver)',
+        },
+    }

--- a/dev.py
+++ b/dev.py
@@ -211,6 +211,15 @@ def dev_db() -> None:
             if stmt.strip() != '':
                 decksite.database.db().execute(stmt)
 
+@cli.command()
+@click.argument('baseline')
+@click.argument('candidate')
+def compare_card_databases(baseline: str, candidate: str) -> None:
+    """Compare a master and candidate card import made from identical inputs."""
+    from maintenance import card_database_diff
+    if not card_database_diff.compare(baseline, candidate):
+        sys.exit(1)
+
 def do_push() -> None:
     print('>>>> Pushing')
     branch_name = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip().decode()

--- a/magic/decklist.py
+++ b/magic/decklist.py
@@ -100,21 +100,24 @@ def parse_xml(s: str) -> DecklistType:
     except AttributeError as e:
         raise InvalidDataException(e) from e  # Not valid MTGO .deck format
 
-# Load the cards in the intermediate dict form.
-def vivify(decklist: DecklistType) -> Deck:
+# Resolve all accepted names to the single name used for validation and storage.
+def normalize(decklist: DecklistType) -> DecklistType:
     validated: DecklistType = {'maindeck': {}, 'sideboard': {}}
     invalid_names = set()
     for section in ['maindeck', 'sideboard']:
         for name, n in decklist.get(section, {}).items():
             try:
                 canonical_name = oracle.valid_name(name)
-                if validated[section].get(canonical_name):
-                    raise InvalidDataException(f'More than one entry for {canonical_name} in {section}')
-                validated[section][canonical_name] = n
+                add_card(validated[section], n, canonical_name)
             except InvalidDataException:
                 invalid_names.add(name)
     if invalid_names:
         raise InvalidDataException('Invalid cards: {invalid_names}'.format(invalid_names='; '.join(invalid_names)))
+    return validated
+
+# Load the cards in the intermediate dict form.
+def vivify(decklist: DecklistType) -> Deck:
+    validated = normalize(decklist)
     d = Deck({'maindeck': [], 'sideboard': []})
     for section in ['maindeck', 'sideboard']:
         for name, n in validated.get(section, {}).items():

--- a/magic/decklist_test.py
+++ b/magic/decklist_test.py
@@ -1,6 +1,8 @@
 import textwrap
 
-from magic import decklist
+import pytest
+
+from magic import decklist, oracle
 
 
 def test_parse() -> None:
@@ -838,6 +840,39 @@ def test_spiderman_noir() -> None:
     v = decklist.vivify(d)
     assert v.maindeck[0].name == 'Spider-Man Noir'
     assert v.maindeck[0].n == 4
+
+def test_spiderman_and_omenpaths_names_are_combined(monkeypatch: pytest.MonkeyPatch) -> None:
+    aliases = {
+        'Spider-Man Noir': 'Spider-Man Noir',
+        'Kroble, Envoy of the Bog': 'Spider-Man Noir',
+        'Swamp': 'Swamp',
+    }
+    monkeypatch.setattr(oracle, 'valid_name', aliases.__getitem__)
+    s = """
+        2 Spider-Man Noir
+        2 Kroble, Envoy of the Bog
+        56 Swamp
+        """
+    d = decklist.parse(textwrap.dedent(s))
+    v = decklist.vivify(d)
+    spider_man_noir = next(c for c in v.maindeck if c.name == 'Spider-Man Noir')
+    assert spider_man_noir.n == 4
+    assert len(v.maindeck) == 2
+
+def test_normalize_combines_any_names_with_the_same_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    aliases = {
+        'Spider-Man Noir': 'Spider-Man Noir',
+        'Kroble, Envoy of the Bog': 'Spider-Man Noir',
+    }
+    monkeypatch.setattr(oracle, 'valid_name', aliases.__getitem__)
+    raw = {
+        'maindeck': {'Spider-Man Noir': 2, 'Kroble, Envoy of the Bog': 2},
+        'sideboard': {'Kroble, Envoy of the Bog': 1},
+    }
+    assert decklist.normalize(raw) == {
+        'maindeck': {'Spider-Man Noir': 4},
+        'sideboard': {'Spider-Man Noir': 1},
+    }
 
 def test_prepared() -> None:
     s = """

--- a/magic/multiverse.py
+++ b/magic/multiverse.py
@@ -10,7 +10,7 @@ from magic.abc import CardDescription
 from magic.card import TableDescription
 from magic.database import create_table_def, db
 from magic.models import Card
-from shared import configuration, dtutil
+from shared import configuration, dtutil, fetch_tools
 from shared.database import sqlescape
 from shared.pd_exception import InvalidArgumentException, InvalidDataException
 
@@ -139,10 +139,10 @@ def base_query_lite() -> str:
 async def update_database_async(new_date: datetime.datetime) -> bool:
     try:
         sets = await fetcher.all_sets_async()
-        if os.path.exists('scryfall-default-cards.json'):
-            with open('scryfall-default-cards.json', encoding='utf-8') as f:
-                all_cards = json.load(f)
-                download_uri = None
+        local_cards = load_local_cards()
+        if local_cards is not None:
+            all_cards = local_cards
+            download_uri = None
         else:
             all_cards, download_uri = await fetcher.all_cards_async()
     except Exception as e:
@@ -157,6 +157,15 @@ async def update_database_async(new_date: datetime.datetime) -> bool:
         all_cards, download_uri = await fetcher.all_cards_async(force_last_good=True)
         await insert_cards(new_date, sets, all_cards)
     return True
+
+def load_local_cards() -> list[CardDescription] | None:
+    if os.path.exists('scryfall-default-cards.jsonl.gz'):
+        with open('scryfall-default-cards.jsonl.gz', 'rb') as f:
+            return fetch_tools.load_jsonl_gzip(f)
+    if os.path.exists('scryfall-default-cards.json'):
+        with open('scryfall-default-cards.json', encoding='utf-8') as f:
+            return json.load(f)
+    return None
 
 async def insert_cards(new_date: datetime.datetime, sets: list[dict[str, Any]], all_cards: list[CardDescription]) -> None:
     db().begin('update_database')
@@ -203,7 +212,9 @@ async def insert_cards_async(printings: list[CardDescription]) -> list[int]:
 
 async def determine_values_async(printings: list[CardDescription], next_card_id: int) -> dict[str, list[dict[str, Any]]]:
     cards: dict[str, int] = {}
+    canonical_names: dict[str, int] = {}
     flavor_names: dict[str, int] = {}
+    ambiguous_aliases: set[str] = set()
     card_values: list[dict[str, Any]] = []
     face_values: list[dict[str, Any]] = []
     meld_result_printings: list[CardDescription] = []
@@ -263,13 +274,13 @@ async def determine_values_async(printings: list[CardDescription], next_card_id:
             if p['name'] in cards:
                 card_id = cards[p['name']]
                 printing_values.append(printing_value(p, card_id, set_id, rarity_id))
-                if p.get('flavor_name'):
-                    flavor_names[p['flavor_name']] = card_id
+                add_aliases(p, card_id, flavor_names, ambiguous_aliases)
                 continue
 
             card_id = next_card_id
             next_card_id += 1
             cards[p['name']] = card_id
+            canonical_names[canonical_name(p)] = card_id
             card_values.append({'id': card_id, 'oracle_id': p['oracle_id'], 'layout': p['layout']})
 
             if is_meld_result(p):  # We don't make entries for a meld result until we know the card_ids of the front faces.
@@ -300,10 +311,7 @@ async def determine_values_async(printings: list[CardDescription], next_card_id:
 
             cards[p['name']] = card_id
             printing_values.append(printing_value(p, card_id, set_id, rarity_id))
-            if p.get('flavor_name'):
-                flavor_names[p['flavor_name']] = card_id
-            if p.get('printed_name') and p.get('lang') == 'en' and p['printed_name'] != p['name']:
-                flavor_names[p['printed_name']] = card_id
+            add_aliases(p, card_id, flavor_names, ambiguous_aliases)
         except Exception as e:
             print(f'Exception `{e} ({type(e)})` while importing card: {repr(p)}')
             raise InvalidDataException() from e
@@ -311,7 +319,11 @@ async def determine_values_async(printings: list[CardDescription], next_card_id:
     for p in meld_result_printings:
         face_values += meld_face_values(p, cards)
 
-    flavor_name_values = [{'card_id': card_id, 'flavor_name': flavor_name} for flavor_name, card_id in flavor_names.items()]
+    flavor_name_values = [
+        {'card_id': card_id, 'flavor_name': flavor_name}
+        for flavor_name, card_id in flavor_names.items()
+        if canonical_names.get(flavor_name, card_id) == card_id
+    ]
 
     return {
         'card': card_values,
@@ -323,6 +335,46 @@ async def determine_values_async(printings: list[CardDescription], next_card_id:
         'card_legality': card_legality_values,
         'flavor_name': flavor_name_values,
     }
+
+def add_aliases(p: CardDescription, card_id: int, aliases: dict[str, int], ambiguous_aliases: set[str]) -> None:
+    for alias in card_aliases(p):
+        if alias in ambiguous_aliases:
+            continue
+        existing_card_id = aliases.get(alias)
+        if existing_card_id is not None and existing_card_id != card_id:
+            aliases.pop(alias)
+            ambiguous_aliases.add(alias)
+            continue
+        aliases[alias] = card_id
+
+def card_aliases(p: CardDescription) -> set[str]:
+    aliases = set()
+    flavor_name = p.get('flavor_name')
+    if flavor_name and flavor_name != p['name']:
+        aliases.add(flavor_name)
+    printed_name = p.get('printed_name')
+    if p.get('lang') == 'en' and printed_name and printed_name != p['name']:
+        aliases.add(printed_name)
+
+    faces = p.get('card_faces', [])
+    for face in faces:
+        printed_name = face.get('printed_name')
+        if p.get('lang') == 'en' and printed_name and printed_name != face['name']:
+            aliases.add(printed_name)
+
+    if p.get('lang') == 'en':
+        face_aliases = [face.get('printed_name') for face in faces]
+        if face_aliases and all(face_aliases):
+            combined_alias = ' // '.join(face_aliases)
+            if combined_alias != p['name']:
+                aliases.add(combined_alias)
+    return aliases
+
+def canonical_name(p: CardDescription) -> str:
+    faces = p.get('card_faces', [])
+    if faces and p.get('layout') not in layout.uses_two_names():
+        return faces[0]['name']
+    return p['name']
 
 def face_colors(p: CardDescription) -> set[str]:
     colors = set()

--- a/magic/multiverse_test.py
+++ b/magic/multiverse_test.py
@@ -1,6 +1,11 @@
+import gzip
+import json
+from pathlib import Path
+
 import pytest
 
 from magic import multiverse
+from magic.abc import CardDescription
 from magic.database import db
 
 
@@ -27,3 +32,107 @@ def test_subtypes() -> None:
     assert multiverse.subtypes('Basic Snow Land - Island') == ['Island']
     assert multiverse.subtypes('Enchantment') == []
     assert multiverse.subtypes('Creature - Elder Dragon') == ['Elder', 'Dragon']
+
+def test_load_local_cards_supports_compressed_json_lines(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cards: list[CardDescription] = [
+        {'name': 'Spider-Man Noir'},
+        {'name': 'Peter Parker // Amazing Spider-Man'},
+    ]
+    with gzip.open(tmp_path / 'scryfall-default-cards.jsonl.gz', 'wt', encoding='utf-8') as f:
+        for card in cards:
+            f.write(json.dumps(card) + '\n')
+    monkeypatch.chdir(tmp_path)
+    assert multiverse.load_local_cards() == cards
+
+def test_card_aliases_include_english_printed_name() -> None:
+    card: CardDescription = {
+        'name': 'Spider-Man Noir',
+        'printed_name': 'Kroble, Envoy of the Bog',
+        'lang': 'en',
+    }
+    assert multiverse.card_aliases(card) == {'Kroble, Envoy of the Bog'}
+
+def test_card_aliases_include_printed_names_from_faces() -> None:
+    card: CardDescription = {
+        'name': 'Peter Parker // Amazing Spider-Man',
+        'lang': 'en',
+        'card_faces': [
+            {'name': 'Peter Parker', 'printed_name': 'Surris, Spidersilk Innovator'},
+            {'name': 'Amazing Spider-Man', 'printed_name': 'Surris, Silk-Tech Vanguard'},
+        ],
+    }
+    assert multiverse.card_aliases(card) == {
+        'Surris, Spidersilk Innovator',
+        'Surris, Silk-Tech Vanguard',
+        'Surris, Spidersilk Innovator // Surris, Silk-Tech Vanguard',
+    }
+
+def test_card_aliases_exclude_non_english_printed_names() -> None:
+    card: CardDescription = {
+        'name': 'Spider-Man Noir',
+        'printed_name': 'Localized Spider-Man Noir',
+        'lang': 'fr',
+    }
+    assert multiverse.card_aliases(card) == set()
+
+def test_canonical_name_matches_stored_double_faced_card_name() -> None:
+    card: CardDescription = {
+        'name': 'Peter Parker // Amazing Spider-Man',
+        'layout': 'transform',
+        'card_faces': [
+            {'name': 'Peter Parker'},
+            {'name': 'Amazing Spider-Man'},
+        ],
+    }
+    assert multiverse.canonical_name(card) == 'Peter Parker'
+
+def test_add_aliases_ignores_ambiguous_aliases() -> None:
+    aliases = {'Shared Name': 1}
+    ambiguous_aliases: set[str] = set()
+    card: CardDescription = {'name': 'Another Card', 'flavor_name': 'Shared Name'}
+    multiverse.add_aliases(card, 2, aliases, ambiguous_aliases)
+    assert aliases == {}
+    assert ambiguous_aliases == {'Shared Name'}
+
+    multiverse.add_aliases({'name': 'Third Card', 'flavor_name': 'Shared Name'}, 3, aliases, ambiguous_aliases)
+    assert aliases == {}
+
+@pytest.mark.asyncio
+async def test_alias_from_later_printing_is_stored(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeDatabase:
+        def select(self, query: str) -> list[dict[str, object]]:
+            if 'FROM rarity' in query:
+                return [
+                    {'id': 1, 'name': 'Common'},
+                    {'id': 2, 'name': 'Uncommon'},
+                    {'id': 3, 'name': 'Rare'},
+                    {'id': 4, 'name': 'Mythic Rare'},
+                ]
+            return []
+
+    monkeypatch.setattr(multiverse, 'db', FakeDatabase)
+    monkeypatch.setattr(multiverse, 'load_sets', lambda: {'spm': 1, 'om1': 2})
+    printing: CardDescription = {
+        'id': '00000000-0000-0000-0000-000000000001',
+        'name': 'Spider-Man Noir',
+        'oracle_id': '00000000-0000-0000-0000-000000000002',
+        'layout': 'normal',
+        'type_line': 'Legendary Creature — Spider Hero',
+        'rarity': 'rare',
+        'set': 'spm',
+        'mana_cost': '{2}{B}',
+        'cmc': 3,
+        'colors': [],
+        'color_identity': [],
+        'legalities': {},
+    }
+    omenpaths_printing: CardDescription = printing | {
+        'id': '00000000-0000-0000-0000-000000000003',
+        'set': 'om1',
+        'lang': 'en',
+        'printed_name': 'Kroble, Envoy of the Bog',
+    }
+
+    values = await multiverse.determine_values_async([printing, omenpaths_printing], 100)
+
+    assert values['flavor_name'] == [{'card_id': 100, 'flavor_name': 'Kroble, Envoy of the Bog'}]

--- a/magic/omenpaths_test.py
+++ b/magic/omenpaths_test.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+from whoosh.index import create_in
+
+from magic import decklist, legality, oracle, whoosh_write
+
+
+@pytest.mark.functional
+def test_imported_omenpaths_names_resolve_to_spiderman_cards() -> None:
+    expected_names = {
+        'Kroble, Envoy of the Bog': 'Spider-Man Noir',
+        'Surris, Spidersilk Innovator': 'Peter Parker',
+        'Surris, Silk-Tech Vanguard': 'Peter Parker',
+        'Surris, Spidersilk Innovator // Surris, Silk-Tech Vanguard': 'Peter Parker',
+    }
+    for omenpaths_name, spiderman_name in expected_names.items():
+        assert oracle.valid_name(omenpaths_name) == spiderman_name
+        assert oracle.cards_by_name()[omenpaths_name].id == oracle.cards_by_name()[spiderman_name].id
+
+@pytest.mark.functional
+def test_mixed_equivalent_names_are_one_deck_entry() -> None:
+    raw = {
+        'maindeck': {
+            'Spider-Man Noir': 2,
+            'Kroble, Envoy of the Bog': 2,
+            'Swamp': 56,
+        },
+        'sideboard': {},
+    }
+    deck = decklist.vivify(raw)
+    assert [(entry.name, entry.n) for entry in deck.maindeck if entry.name == 'Spider-Man Noir'] == [('Spider-Man Noir', 4)]
+    assert '4 Spider-Man Noir' in str(deck)
+    assert 'Kroble, Envoy of the Bog' not in str(deck)
+
+@pytest.mark.functional
+def test_equivalent_names_share_the_four_copy_limit() -> None:
+    raw = {
+        'maindeck': {
+            'Spider-Man Noir': 3,
+            'Kroble, Envoy of the Bog': 2,
+            'Swamp': 55,
+        },
+        'sideboard': {},
+    }
+    deck = decklist.vivify(raw)
+    errors: dict[str, dict[str, set[str]]] = {}
+    assert legality.legal_formats(deck, {'Legacy'}, errors) == set()
+    assert errors['Legacy']['Legality_Too_Many'] == {'Spider-Man Noir'}
+
+@pytest.mark.functional
+def test_equivalent_names_share_the_four_copy_limit_across_sideboard() -> None:
+    raw = {
+        'maindeck': {
+            'Spider-Man Noir': 3,
+            'Swamp': 57,
+        },
+        'sideboard': {
+            'Kroble, Envoy of the Bog': 2,
+        },
+    }
+    deck = decklist.vivify(raw)
+    errors: dict[str, dict[str, set[str]]] = {}
+    assert legality.legal_formats(deck, {'Legacy'}, errors) == set()
+    assert errors['Legacy']['Legality_Too_Many'] == {'Spider-Man Noir'}
+
+@pytest.mark.functional
+def test_existing_name_matching_behavior_is_unchanged() -> None:
+    assert oracle.valid_name('Godzilla, King of the Monsters') == 'Zilortha, Strength Incarnate'
+    assert oracle.valid_name('Far/Away') == 'Far // Away'
+    assert oracle.valid_name('Torrent Sculptor // Flamethrower Sonata') == 'Torrent Sculptor'
+
+@pytest.mark.functional
+def test_imported_alias_is_written_to_search_index(tmp_path: Path) -> None:
+    card = oracle.cards_by_name()['Spider-Man Noir']
+    index = create_in(tmp_path, whoosh_write.WhooshWriter().schema)
+    whoosh_write.update_index(index, [card])
+    with index.reader() as reader:
+        documents = [fields for _, fields in reader.iter_docs()]
+    assert any(document['name'] == 'Kroble, Envoy of the Bog' and document['canonical_name'] == 'Spider-Man Noir' for document in documents)

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -43,6 +43,12 @@ def valid_name(name: str) -> str:
             return CARDS_BY_NAME[k].name
     raise InvalidDataException(f'Did not find any cards looking for `{name}`')
 
+def canonical_name_or_self(name: str) -> str:
+    try:
+        return valid_name(name)
+    except InvalidDataException:
+        return name
+
 def load_card(name: str) -> Card:
     return CARDS_BY_NAME.get(name) or load_cards([name])[0]
 

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -16,10 +16,14 @@ CARDS_BY_NAME: dict[str, Card] = {}
 
 def init(force: bool = False) -> None:
     if len(CARDS_BY_NAME) == 0 or force:
+        CARDS_BY_NAME.clear()
         for c in load_cards():
             CARDS_BY_NAME[c.name] = c
         for c in load_cards_with_flavor_names():
             for fn in c.flavor_names.split('|'):
+                existing = CARDS_BY_NAME.get(fn)
+                if existing is not None and existing.name != c.name:
+                    continue
                 CARDS_BY_NAME[fn] = c
 
 def valid_name(name: str) -> str:
@@ -30,13 +34,13 @@ def valid_name(name: str) -> str:
     except ValueError:
         front = name
     if front in CARDS_BY_NAME:
-        return front
+        return CARDS_BY_NAME[front].name
     canonicalized_name = card.canonicalize(name)
     canonicalized_front = card.canonicalize(front)
     for k in CARDS_BY_NAME:
         canonicalized = card.canonicalize(k)
         if canonicalized_name == canonicalized or canonicalized_front == canonicalized:
-            return k
+            return CARDS_BY_NAME[k].name
     raise InvalidDataException(f'Did not find any cards looking for `{name}`')
 
 def load_card(name: str) -> Card:

--- a/magic/oracle_test.py
+++ b/magic/oracle_test.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 import pytest
 
 from magic import oracle, seasons
+from magic.models import Card
 from shared.pd_exception import InvalidDataException
 
 
@@ -31,6 +32,24 @@ def test_valid_name() -> None:
     assert oracle.valid_name('Torrent Sculptor/Flamethrower Sonata') == 'Torrent Sculptor'
     with pytest.raises(InvalidDataException):
         oracle.valid_name('Definitely // Not a Card /')
+
+def test_valid_name_returns_canonical_name_for_alias_front(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = Card({'name': 'Peter Parker', 'flavor_names': 'Surris, Spidersilk Innovator'})
+    monkeypatch.setitem(oracle.CARDS_BY_NAME, 'Surris, Spidersilk Innovator', card)
+    assert oracle.valid_name('Surris, Spidersilk Innovator // Surris, Silk-Tech Vanguard') == 'Peter Parker'
+
+def test_init_rebuilds_names_and_ignores_alias_collisions(monkeypatch: pytest.MonkeyPatch) -> None:
+    canonical = Card({'name': 'Shared Name'})
+    aliased = Card({'name': 'Other Card', 'flavor_names': 'Shared Name|Alternate Name'})
+    monkeypatch.setattr(oracle, 'CARDS_BY_NAME', {'Stale Alias': aliased})
+    monkeypatch.setattr(oracle, 'load_cards', lambda: [canonical, aliased])
+    monkeypatch.setattr(oracle, 'load_cards_with_flavor_names', lambda: [aliased])
+
+    oracle.init(force=True)
+
+    assert 'Stale Alias' not in oracle.CARDS_BY_NAME
+    assert oracle.CARDS_BY_NAME['Shared Name'] is canonical
+    assert oracle.CARDS_BY_NAME['Alternate Name'] is aliased
 
 def test_load_cards() -> None:
     cards = oracle.load_cards(['Think Twice', 'Swamp'])

--- a/magic/rotation.py
+++ b/magic/rotation.py
@@ -68,14 +68,13 @@ def rotation_redis_store() -> tuple[int, int, list[Card]]:
             print('WARNING: Could not find legality_dir.')
         return (0, 0, [])
     with open(fs[-1]) as f:
-        latest_list = f.read().splitlines()
+        latest_list = [oracle.canonical_name_or_self(line) for line in f.read().splitlines()]
     cs = oracle.cards_by_name()
     for filename in fs:
         for line in get_file_contents(filename):
             line = text.sanitize(line)
             line = line.strip()
-            if c := cs.get(line):
-                line = c.name
+            line = oracle.canonical_name_or_self(line)
             lines.append(line)
     scores = Counter(lines).most_common()
     runs = scores[0][1]

--- a/magic/rotation_test.py
+++ b/magic/rotation_test.py
@@ -45,6 +45,28 @@ def test_last_run_number() -> None:
         configuration.CONFIG['legality_dir'] = real_legality_dir
 
 
+def test_rotation_summary_combines_aliases_and_marks_latest_hit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first = tmp_path / 'Run_001.txt'
+    second = tmp_path / 'Run_002.txt'
+    first.write_text('Agent Venom\n', encoding='utf-8')
+    second.write_text('Rhilex the Accursed\n', encoding='utf-8')
+    card = Card({'name': 'Agent Venom', 'layout': 'normal'}, predetermined_values=True)
+    monkeypatch.setattr(rotation, 'files', lambda: [str(first), str(second)])
+    monkeypatch.setattr(rotation.oracle, 'canonical_name_or_self', lambda name: 'Agent Venom' if name == 'Rhilex the Accursed' else name)
+    monkeypatch.setattr(rotation.oracle, 'cards_by_name', lambda: {'Agent Venom': card})
+    monkeypatch.setattr(rotation.redis, 'get_list', lambda _key: None)
+    monkeypatch.setattr(rotation.redis, 'store', lambda _key, value, **_kwargs: value)
+    monkeypatch.setattr(rotation.redis, 'sadd', lambda *_args, **_kwargs: None)
+
+    runs, _runs_percent, cards = rotation.rotation_redis_store()
+
+    assert runs == 2
+    assert len(cards) == 1
+    assert cards[0].name == 'Agent Venom'
+    assert cards[0].hits == 2
+    assert cards[0].hit_in_last_run is True
+
+
 @pytest.mark.asyncio
 async def test_rotation_hype_message_elides_next_confirmation_when_no_cards_are_undecided(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(rotation, 'read_rotation_files', lambda: (rotation.TOTAL_RUNS, 100, []))

--- a/magic/whoosh_write.py
+++ b/magic/whoosh_write.py
@@ -43,7 +43,7 @@ def update_index(index: FileIndex, cards: list[Card]) -> None:
         asciiname = anyascii(card.name)
         if asciiname != card.name:
             names.append(asciiname)
-        for name in names:
+        for name in dict.fromkeys(names):
             document = {}
             document['id'] = card.id
             document['name'] = name

--- a/magic/whoosh_write_test.py
+++ b/magic/whoosh_write_test.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from whoosh.index import create_in
+
+from magic import whoosh_write
+from magic.models import Card
+
+
+def test_update_index_includes_card_aliases(tmp_path: Path) -> None:
+    card = Card({
+        'id': 1,
+        'name': 'Spider-Man Noir',
+        'names': 'Spider-Man Noir',
+        'flavor_names': 'Kroble, Envoy of the Bog',
+        'layout': 'normal',
+    })
+    index = create_in(tmp_path, whoosh_write.WhooshWriter().schema)
+    whoosh_write.update_index(index, [card])
+    with index.reader() as reader:
+        documents = [fields for _, fields in reader.iter_docs()]
+    assert {document['name'] for document in documents} == {
+        'Spider-Man Noir',
+        'Kroble, Envoy of the Bog',
+    }
+    assert {document['canonical_name'] for document in documents} == {'Spider-Man Noir'}

--- a/maintenance/canonicalize_card_names.py
+++ b/maintenance/canonicalize_card_names.py
@@ -1,0 +1,276 @@
+from collections import defaultdict
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import Any
+
+from decksite.data import rotation as rotation_data
+from decksite.database import db
+from magic import oracle, rotation
+from maintenance import deck_hash
+from shared import redis_wrapper as redis
+
+LOCK_NAME = 'canonicalize_card_names'
+TRANSACTION_LABEL = 'canonicalize_card_names'
+BACKUP_PREFIX = '_canonicalize_card_names_backup_'
+
+
+@dataclass
+class MigrationPlan:
+    aliases: dict[str, str]
+    deck_groups: dict[tuple[int, int, str], list[dict[str, Any]]]
+    featured_rows: list[dict[str, Any]]
+    rule_groups: dict[tuple[int, int, int, int | None, str], list[dict[str, Any]]]
+    rotation_groups: dict[tuple[int, int, str], list[dict[str, Any]]]
+
+    @property
+    def affected_deck_ids(self) -> set[int]:
+        ids = {key[0] for key in self.deck_groups}
+        ids.update(row['id'] for row in self.featured_rows)
+        return ids
+
+    @property
+    def deck_alias_rows(self) -> int:
+        return sum(name in self.aliases for rows in self.deck_groups.values() for name in [row['card'] for row in rows])
+
+    @property
+    def deck_collisions(self) -> int:
+        return sum(len(rows) - 1 for rows in self.deck_groups.values())
+
+    @property
+    def rule_alias_rows(self) -> int:
+        return sum(name in self.aliases for rows in self.rule_groups.values() for name in [row['card'] for row in rows])
+
+    @property
+    def rule_collisions(self) -> int:
+        return sum(len(rows) - 1 for rows in self.rule_groups.values())
+
+    @property
+    def rotation_alias_rows(self) -> int:
+        return sum(name in self.aliases for rows in self.rotation_groups.values() for name in [row['name'] for row in rows])
+
+    @property
+    def rotation_collisions(self) -> int:
+        return sum(len(rows) - 1 for rows in self.rotation_groups.values())
+
+
+def aliases_from_oracle() -> dict[str, str]:
+    return {
+        name: card.name
+        for name, card in oracle.cards_by_name().items()
+        if name != card.name
+    }
+
+
+def _in_clause(values: Collection[Any]) -> str:
+    return ', '.join(['%s'] * len(values))
+
+
+def _select_alias_rows(table: str, column: str, columns: str, aliases: dict[str, str]) -> list[dict[str, Any]]:
+    if not aliases:
+        return []
+    sql = f'SELECT {columns} FROM {table} WHERE BINARY {column} IN ({_in_clause(aliases)})'
+    return db().select(sql, list(aliases))
+
+
+def _deck_groups(aliases: dict[str, str]) -> dict[tuple[int, int, str], list[dict[str, Any]]]:
+    alias_rows = _select_alias_rows('deck_card', 'card', 'id, deck_id, card, n, sideboard', aliases)
+    affected_keys = {(row['deck_id'], row['sideboard'], aliases[row['card']]) for row in alias_rows}
+    if not affected_keys:
+        return {}
+    deck_ids = {key[0] for key in affected_keys}
+    rows = db().select(
+        f'SELECT id, deck_id, card, n, sideboard FROM deck_card WHERE deck_id IN ({_in_clause(deck_ids)})',
+        list(deck_ids),
+    )
+    groups: dict[tuple[int, int, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        canonical = aliases.get(row['card'], row['card'])
+        key = (row['deck_id'], row['sideboard'], canonical)
+        if key in affected_keys:
+            groups[key].append(row)
+    return dict(groups)
+
+
+def _rule_groups(aliases: dict[str, str]) -> dict[tuple[int, int, int, int | None, str], list[dict[str, Any]]]:
+    alias_rows = _select_alias_rows('rule_card', 'card', 'id, rule_id, card, include, n, sideboard', aliases)
+    affected_keys = {(row['rule_id'], row['include'], row['n'], row['sideboard'], aliases[row['card']]) for row in alias_rows}
+    if not affected_keys:
+        return {}
+    rule_ids = {key[0] for key in affected_keys}
+    rows = db().select(
+        f'SELECT id, rule_id, card, include, n, sideboard FROM rule_card WHERE rule_id IN ({_in_clause(rule_ids)})',
+        list(rule_ids),
+    )
+    groups: dict[tuple[int, int, int, int | None, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        canonical = aliases.get(row['card'], row['card'])
+        key = (row['rule_id'], row['include'], row['n'], row['sideboard'], canonical)
+        if key in affected_keys:
+            groups[key].append(row)
+    return dict(groups)
+
+
+def _rotation_groups(aliases: dict[str, str]) -> dict[tuple[int, int, str], list[dict[str, Any]]]:
+    alias_rows = _select_alias_rows('rotation_runs', 'name', 'number, name, season_id', aliases)
+    affected_keys = {(row['number'], row['season_id'], aliases[row['name']]) for row in alias_rows}
+    if not affected_keys:
+        return {}
+    relevant_names = set(aliases).union(aliases.values())
+    rows = db().select(
+        f'SELECT number, name, season_id FROM rotation_runs WHERE BINARY name IN ({_in_clause(relevant_names)})',
+        list(relevant_names),
+    )
+    groups: dict[tuple[int, int, str], list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        canonical = aliases.get(row['name'], row['name'])
+        key = (row['number'], row['season_id'], canonical)
+        if key in affected_keys:
+            groups[key].append(row)
+    return dict(groups)
+
+
+def plan() -> MigrationPlan:
+    aliases = aliases_from_oracle()
+    return MigrationPlan(
+        aliases=aliases,
+        deck_groups=_deck_groups(aliases),
+        featured_rows=_select_alias_rows('deck', 'featured_card', 'id, featured_card', aliases),
+        rule_groups=_rule_groups(aliases),
+        rotation_groups=_rotation_groups(aliases),
+    )
+
+
+def print_plan(migration: MigrationPlan, heading: str) -> None:
+    print(heading)
+    print(f'  Oracle aliases: {len(migration.aliases)}')
+    print(f'  deck_card: {migration.deck_alias_rows} alias rows in {len(migration.deck_groups)} card slots across {len({key[0] for key in migration.deck_groups})} decks; {migration.deck_collisions} rows will be merged')
+    print(f'  deck.featured_card: {len(migration.featured_rows)} alias rows')
+    print(f'  rule_card: {migration.rule_alias_rows} alias rows; {migration.rule_collisions} rows will be merged')
+    print(f'  rotation_runs: {migration.rotation_alias_rows} alias rows; {migration.rotation_collisions} rows will be merged')
+
+
+def audit() -> MigrationPlan:
+    migration = plan()
+    print_plan(migration, 'Card-name canonicalization dry run (no writes):')
+    return migration
+
+
+def _create_backups(migration: MigrationPlan) -> None:
+    database = db()
+    for table in ['deck', 'deck_card', 'rule_card', 'rotation_runs']:
+        database.execute(f'CREATE TABLE IF NOT EXISTS {BACKUP_PREFIX}{table} LIKE {table}')
+    database.execute(f'''
+        CREATE TABLE IF NOT EXISTS {BACKUP_PREFIX}mapping (
+            alias VARCHAR(190) NOT NULL PRIMARY KEY,
+            canonical VARCHAR(190) NOT NULL
+        ) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin
+    ''')
+    for alias, canonical in migration.aliases.items():
+        database.execute(
+            f'INSERT IGNORE INTO {BACKUP_PREFIX}mapping (alias, canonical) VALUES (%s, %s)',
+            [alias, canonical],
+        )
+
+    deck_ids = migration.affected_deck_ids
+    if deck_ids:
+        placeholders = _in_clause(deck_ids)
+        args = list(deck_ids)
+        database.execute(f'INSERT IGNORE INTO {BACKUP_PREFIX}deck SELECT * FROM deck WHERE id IN ({placeholders})', args)
+        database.execute(f'INSERT IGNORE INTO {BACKUP_PREFIX}deck_card SELECT * FROM deck_card WHERE deck_id IN ({placeholders})', args)
+
+    rule_ids = {key[0] for key in migration.rule_groups}
+    if rule_ids:
+        database.execute(
+            f'INSERT IGNORE INTO {BACKUP_PREFIX}rule_card SELECT * FROM rule_card WHERE rule_id IN ({_in_clause(rule_ids)})',
+            list(rule_ids),
+        )
+
+    if migration.rotation_groups:
+        names = set(migration.aliases).union(migration.aliases.values())
+        database.execute(
+            f'INSERT IGNORE INTO {BACKUP_PREFIX}rotation_runs SELECT * FROM rotation_runs WHERE BINARY name IN ({_in_clause(names)})',
+            list(names),
+        )
+
+
+def _apply_deck_groups(groups: dict[tuple[int, int, str], list[dict[str, Any]]]) -> None:
+    for (_deck_id, _sideboard, canonical), rows in groups.items():
+        rows.sort(key=lambda row: row['id'])
+        keeper, *duplicates = rows
+        for row in duplicates:
+            db().execute('DELETE FROM deck_card WHERE id = %s', [row['id']])
+        db().execute(
+            'UPDATE deck_card SET card = %s, n = %s WHERE id = %s',
+            [canonical, sum(row['n'] for row in rows), keeper['id']],
+        )
+
+
+def _apply_rule_groups(groups: dict[tuple[int, int, int, int | None, str], list[dict[str, Any]]]) -> None:
+    for (_rule_id, _include, _n, _sideboard, canonical), rows in groups.items():
+        rows.sort(key=lambda row: row['id'])
+        keeper, *duplicates = rows
+        for row in duplicates:
+            db().execute('DELETE FROM rule_card WHERE id = %s', [row['id']])
+        db().execute('UPDATE rule_card SET card = %s WHERE id = %s', [canonical, keeper['id']])
+
+
+def _apply_rotation_groups(groups: dict[tuple[int, int, str], list[dict[str, Any]]]) -> None:
+    aliases = {
+        row['name']: canonical
+        for (_number, _season_id, canonical), rows in groups.items()
+        for row in rows
+        if row['name'] != canonical
+    }
+    for alias, canonical in aliases.items():
+        db().execute(
+            '''
+                INSERT IGNORE INTO rotation_runs (number, name, season_id)
+                SELECT number, %s, season_id FROM rotation_runs WHERE BINARY name = BINARY %s
+            ''',
+            [canonical, alias],
+        )
+        db().execute('DELETE FROM rotation_runs WHERE BINARY name = BINARY %s', [alias])
+
+
+def _backup_deck_ids() -> set[int]:
+    return set(db().values(f'SELECT id FROM {BACKUP_PREFIX}deck'))
+
+
+def apply() -> MigrationPlan:
+    database = db()
+    database.get_lock(LOCK_NAME, 60)
+    try:
+        migration = plan()
+        print_plan(migration, 'Card-name canonicalization apply plan:')
+        _create_backups(migration)
+        database.begin(TRANSACTION_LABEL)
+        try:
+            _apply_deck_groups(migration.deck_groups)
+            for row in migration.featured_rows:
+                database.execute(
+                    'UPDATE deck SET featured_card = %s WHERE id = %s',
+                    [migration.aliases[row['featured_card']], row['id']],
+                )
+            _apply_rule_groups(migration.rule_groups)
+            _apply_rotation_groups(migration.rotation_groups)
+            database.commit(TRANSACTION_LABEL)
+        except Exception:
+            database.rollback(TRANSACTION_LABEL)
+            raise
+
+        affected_deck_ids = _backup_deck_ids()
+        if affected_deck_ids:
+            deck_hash.recalculate(affected_deck_ids)
+        if migration.rotation_groups:
+            rotation.clear_redis(clear_files=True)
+            rotation_data.cache_rotation()
+        redis.clear(*redis.keys('decksite:deck:*:similar'))
+        print('Card-name canonicalization complete. Backup tables use prefix '
+              f'{BACKUP_PREFIX}. Run `python run.py maintenance reprime_cache` after deployment.')
+        return migration
+    finally:
+        database.release_lock(LOCK_NAME)
+
+
+def run() -> None:
+    apply()

--- a/maintenance/canonicalize_card_names_audit.py
+++ b/maintenance/canonicalize_card_names_audit.py
@@ -1,0 +1,5 @@
+from maintenance import canonicalize_card_names
+
+
+def run() -> None:
+    canonicalize_card_names.audit()

--- a/maintenance/canonicalize_card_names_test.py
+++ b/maintenance/canonicalize_card_names_test.py
@@ -1,0 +1,93 @@
+import pytest
+
+from decksite.database import db
+from decksite.testutil import with_test_db
+from maintenance import canonicalize_card_names
+
+ALIASES = {
+    'Rhilex the Accursed': 'Agent Venom',
+    'Agent of the Iron Spider': 'Agent Venom',
+}
+
+
+def _insert_deck(identifier: str, featured_card: str | None = None) -> int:
+    person_id = db().insert('INSERT INTO person (name, mtgo_username) VALUES (%s, %s)', [identifier, identifier])
+    source_id = db().value("SELECT id FROM source WHERE name = 'Tapped Out'")
+    return db().insert(
+        '''
+            INSERT INTO deck (person_id, source_id, identifier, name, created_date, updated_date, featured_card)
+            VALUES (%s, %s, %s, %s, 1, 1, %s)
+        ''',
+        [person_id, source_id, identifier, identifier, featured_card],
+    )
+
+
+@with_test_db
+@pytest.mark.functional
+def test_audit_and_apply_are_collision_safe_backed_up_and_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    deck_id = _insert_deck('alias-migration', 'Rhilex the Accursed')
+    cards = [
+        ('Rhilex the Accursed', 2, 0),
+        ('Agent Venom', 1, 0),
+        ('Agent of the Iron Spider', 3, 0),
+        ('Rhilex the Accursed', 1, 1),
+        ('A Future Card', 4, 0),
+    ]
+    for name, n, sideboard in cards:
+        db().execute('INSERT INTO deck_card (deck_id, card, n, sideboard) VALUES (%s, %s, %s, %s)', [deck_id, name, n, sideboard])
+
+    rule_id = db().insert('INSERT INTO rule (archetype_id) VALUES (1)')
+    for name, include in [('Rhilex the Accursed', 1), ('Agent Venom', 1), ('Agent of the Iron Spider', 0)]:
+        db().execute('INSERT INTO rule_card (rule_id, card, include, n) VALUES (%s, %s, %s, 1)', [rule_id, name, include])
+
+    for number, name in [(1, 'Rhilex the Accursed'), (1, 'Agent Venom'), (2, 'Agent of the Iron Spider')]:
+        db().execute('INSERT INTO rotation_runs (number, name, season_id) VALUES (%s, %s, 99)', [number, name])
+
+    monkeypatch.setattr(canonicalize_card_names, 'aliases_from_oracle', lambda: ALIASES)
+    recalculated: list[set[int]] = []
+    monkeypatch.setattr(canonicalize_card_names.deck_hash, 'recalculate', lambda ids: recalculated.append(ids))
+    monkeypatch.setattr(canonicalize_card_names.rotation, 'clear_redis', lambda clear_files=False: None)
+    cache_updates: list[bool] = []
+    monkeypatch.setattr(canonicalize_card_names.rotation_data, 'cache_rotation', lambda: cache_updates.append(True))
+
+    audit = canonicalize_card_names.audit()
+
+    assert audit.deck_alias_rows == 3
+    assert audit.deck_collisions == 2
+    assert audit.rule_alias_rows == 2
+    assert audit.rule_collisions == 1
+    assert audit.rotation_alias_rows == 2
+    assert audit.rotation_collisions == 1
+    assert db().value(
+        'SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name LIKE %s',
+        [canonicalize_card_names.BACKUP_PREFIX + '%'],
+    ) == 0
+
+    canonicalize_card_names.apply()
+
+    assert list(db().select('SELECT card, n, sideboard FROM deck_card WHERE deck_id = %s ORDER BY sideboard, card', [deck_id])) == [
+        {'card': 'A Future Card', 'n': 4, 'sideboard': 0},
+        {'card': 'Agent Venom', 'n': 6, 'sideboard': 0},
+        {'card': 'Agent Venom', 'n': 1, 'sideboard': 1},
+    ]
+    assert db().value('SELECT featured_card FROM deck WHERE id = %s', [deck_id]) == 'Agent Venom'
+    assert list(db().select('SELECT card, include FROM rule_card WHERE rule_id = %s ORDER BY include DESC', [rule_id])) == [
+        {'card': 'Agent Venom', 'include': 1},
+        {'card': 'Agent Venom', 'include': 0},
+    ]
+    assert list(db().select('SELECT number, name, season_id FROM rotation_runs ORDER BY number')) == [
+        {'number': 1, 'name': 'Agent Venom', 'season_id': 99},
+        {'number': 2, 'name': 'Agent Venom', 'season_id': 99},
+    ]
+    assert db().value(f'SELECT COUNT(*) FROM {canonicalize_card_names.BACKUP_PREFIX}deck_card') == 5
+    assert recalculated == [{deck_id}]
+    assert cache_updates == [True]
+
+    second_plan = canonicalize_card_names.apply()
+
+    assert second_plan.deck_alias_rows == 0
+    assert second_plan.rule_alias_rows == 0
+    assert second_plan.rotation_alias_rows == 0
+    assert db().value(f'SELECT COUNT(*) FROM {canonicalize_card_names.BACKUP_PREFIX}deck_card') == 5
+    assert recalculated == [{deck_id}, {deck_id}]
+    assert cache_updates == [True]

--- a/maintenance/card_database_diff.py
+++ b/maintenance/card_database_diff.py
@@ -1,0 +1,198 @@
+import itertools
+import re
+from collections.abc import Iterator
+from typing import Any
+
+import MySQLdb
+from MySQLdb.cursors import SSCursor
+
+from shared import configuration
+from shared.pd_exception import InvalidArgumentException
+
+REQUIRES_APP_CONTEXT = False
+EXPECTED_OMENPATHS_ALIASES = {
+    'Kroble, Envoy of the Bog',
+    'Surris, Spidersilk Innovator',
+    'Surris, Silk-Tech Vanguard',
+}
+SPECIAL_TABLES = {'_cache_card', 'card_flavor_name', 'card_legality', 'scryfall_version'}
+SURROGATE_ID_TABLES = {
+    'card_bug',
+    'card_color',
+    'card_color_identity',
+    'card_produced_mana',
+    'card_subtype',
+    'card_supertype',
+}
+
+
+def compare(baseline: str, candidate: str) -> bool:
+    validate_database_name(baseline)
+    validate_database_name(candidate)
+    baseline_tables = tables(baseline)
+    candidate_tables = tables(candidate)
+    if baseline_tables != candidate_tables:
+        print(f'Table mismatch: baseline-only={baseline_tables - candidate_tables}, candidate-only={candidate_tables - baseline_tables}')
+        return False
+
+    success = True
+    for table in sorted(baseline_tables - SPECIAL_TABLES):
+        excluded_columns = {'id'} if table in SURROGATE_ID_TABLES else set()
+        success = compare_table(baseline, candidate, table, excluded_columns) and success
+    success = compare_table(baseline, candidate, '_cache_card', {'flavor_names', 'legalities', 'pd_legal'}) and success
+    success = compare_aliases(baseline, candidate) and success
+    success = compare_legalities(baseline, candidate) and success
+    return success
+
+def validate_database_name(database: str) -> None:
+    if not re.fullmatch(r'pd_alias_shadow_[a-z0-9_]+', database):
+        raise InvalidArgumentException(f'Shadow database name must start with `pd_alias_shadow_`: {database}')
+    if database not in databases():
+        raise InvalidArgumentException(f'Shadow database does not exist: {database}')
+
+def connection(database: str = 'information_schema', cursorclass: type = SSCursor) -> Any:
+    return MySQLdb.connect(
+        host=configuration.mysql_host.value,
+        port=configuration.mysql_port.value,
+        user=configuration.mysql_user.value,
+        passwd=configuration.mysql_passwd.value,
+        db=database,
+        charset='utf8mb4',
+        use_unicode=True,
+        cursorclass=cursorclass,
+    )
+
+def databases() -> set[str]:
+    with connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT schema_name FROM schemata')
+        return {row[0] for row in cursor}
+
+def tables(database: str) -> set[str]:
+    with connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT table_name FROM tables WHERE table_schema = %s', [database])
+        return {row[0] for row in cursor}
+
+def columns(database: str, table: str) -> list[str]:
+    with connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            'SELECT column_name FROM columns WHERE table_schema = %s AND table_name = %s ORDER BY ordinal_position',
+            [database, table],
+        )
+        return [row[0] for row in cursor]
+
+def primary_key(database: str, table: str) -> list[str]:
+    with connection() as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """SELECT column_name FROM key_column_usage
+               WHERE table_schema = %s AND table_name = %s AND constraint_name = 'PRIMARY'
+               ORDER BY ordinal_position""",
+            [database, table],
+        )
+        return [row[0] for row in cursor]
+
+def rows(database: str, table: str, selected_columns: list[str], order_by: list[str]) -> Iterator[tuple[Any, ...]]:
+    conn = connection(database)
+    cursor = conn.cursor()
+    selected = ', '.join(f'`{column}`' for column in selected_columns)
+    ordering = ', '.join(f'`{column}`' for column in order_by)
+    cursor.execute(f'SELECT {selected} FROM `{table}` ORDER BY {ordering}')
+    try:
+        yield from cursor
+    finally:
+        cursor.close()
+        conn.close()
+
+def compare_table(baseline: str, candidate: str, table: str, excluded_columns: set[str] | None = None) -> bool:
+    excluded_columns = excluded_columns or set()
+    baseline_columns = columns(baseline, table)
+    candidate_columns = columns(candidate, table)
+    if baseline_columns != candidate_columns:
+        print(f'{table}: schema differs')
+        return False
+    selected_columns = [column for column in baseline_columns if column not in excluded_columns]
+    order_by = [column for column in primary_key(baseline, table) if column in selected_columns]
+    if not order_by:
+        order_by = ['card_id'] if 'card_id' in selected_columns else selected_columns
+    baseline_rows = rows(baseline, table, selected_columns, order_by)
+    candidate_rows = rows(candidate, table, selected_columns, order_by)
+    for row_number, (before, after) in enumerate(itertools.zip_longest(baseline_rows, candidate_rows), start=1):
+        if before != after:
+            print(f'{table}: first difference at row {row_number}: {before!r} != {after!r}')
+            return False
+    print(f'{table}: identical')
+    return True
+
+def aliases(database: str) -> set[tuple[int, str]]:
+    with connection(database) as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT card_id, flavor_name FROM card_flavor_name')
+        return {(row[0], row[1]) for row in cursor}
+
+def compare_aliases(baseline: str, candidate: str) -> bool:
+    before = aliases(baseline)
+    after = aliases(candidate)
+    removed = before - after
+    added = after - before
+    if removed:
+        print(f'card_flavor_name: unexpectedly removed {len(removed)} aliases; sample={sorted(removed)[:10]}')
+        return False
+    candidate_names = {name for _, name in after}
+    missing_examples = EXPECTED_OMENPATHS_ALIASES - candidate_names
+    if missing_examples:
+        print(f'card_flavor_name: expected new aliases are missing: {sorted(missing_examples)}')
+        return False
+    if has_ambiguous_aliases(candidate):
+        return False
+    print(f'card_flavor_name: retained {len(before)} aliases and added {len(added)}; sample={sorted(added)[:10]}')
+    return True
+
+def legalities(database: str) -> set[tuple[int, int, str]]:
+    with connection(database) as conn:
+        cursor = conn.cursor()
+        cursor.execute('SELECT card_id, format_id, legality FROM card_legality')
+        return {(row[0], row[1], row[2]) for row in cursor}
+
+def compare_legalities(baseline: str, candidate: str) -> bool:
+    before = legalities(baseline)
+    after = legalities(candidate)
+    removed = before - after
+    added = after - before
+    if removed:
+        print(f'card_legality: unexpectedly removed {len(removed)} entries; sample={sorted(removed)[:10]}')
+        return False
+    added_alias_card_ids = {card_id for card_id, _ in aliases(candidate) - aliases(baseline)}
+    unrelated = {row for row in added if row[0] not in added_alias_card_ids}
+    if unrelated:
+        print(f'card_legality: added {len(unrelated)} entries for cards without new aliases; sample={sorted(unrelated)[:10]}')
+        return False
+    print(
+        f'card_legality: retained {len(before)} entries and added {len(added)} entries '
+        f'for {len({row[0] for row in added})} cards with newly recognized aliases',
+    )
+    return True
+
+def has_ambiguous_aliases(database: str) -> bool:
+    with connection(database) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
+            """SELECT flavor_name, COUNT(DISTINCT card_id)
+               FROM card_flavor_name
+               GROUP BY flavor_name
+               HAVING COUNT(DISTINCT card_id) > 1""",
+        )
+        ambiguous = list(cursor)
+        cursor.execute(
+            """SELECT fn.flavor_name, fn.card_id, c.card_id
+               FROM card_flavor_name AS fn
+               INNER JOIN _cache_card AS c ON c.name = fn.flavor_name AND c.card_id <> fn.card_id""",
+        )
+        canonical_collisions = list(cursor)
+    if ambiguous:
+        print(f'card_flavor_name: ambiguous aliases: {ambiguous[:10]}')
+    if canonical_collisions:
+        print(f'card_flavor_name: canonical-name collisions: {canonical_collisions[:10]}')
+    return bool(ambiguous or canonical_collisions)

--- a/maintenance/deck_hash.py
+++ b/maintenance/deck_hash.py
@@ -7,7 +7,17 @@ from shared import redis_wrapper as redis
 DAILY = True
 
 def run() -> None:
-    all_decks, _ = deck.load_decks()
+    recalculate()
+
+def recalculate(deck_ids: set[int] | None = None) -> None:
+    if deck_ids is not None and not deck_ids:
+        return
+    if deck_ids is None:
+        where = 'TRUE'
+    else:
+        where = 'd.id IN ({})'.format(', '.join(map(str, sorted(deck_ids))))
+        redis.clear(*(f'decksite:deck:{deck_id}' for deck_id in deck_ids))
+    all_decks, _ = deck.load_decks(where=where)
     for d in all_decks:
         # Recalculate all hashes, in case they've changed.  Or we've changed the default sort order.
         cards = {'maindeck': d['maindeck'], 'sideboard': d['sideboard']}

--- a/maintenance/deck_hash_test.py
+++ b/maintenance/deck_hash_test.py
@@ -1,0 +1,20 @@
+import pytest
+
+from maintenance import deck_hash
+
+
+def test_recalculate_selected_decks_uses_an_id_filter(monkeypatch: pytest.MonkeyPatch) -> None:
+    where: list[str] = []
+    cleared: list[str] = []
+
+    def load_decks(**kwargs: str) -> tuple[list[object], int]:
+        where.append(kwargs['where'])
+        return [], 0
+
+    monkeypatch.setattr(deck_hash.deck, 'load_decks', load_decks)
+    monkeypatch.setattr(deck_hash.redis, 'clear', lambda *keys: cleared.extend(keys))
+
+    deck_hash.recalculate({20, 10})
+
+    assert where == ['d.id IN (10, 20)']
+    assert set(cleared) == {'decksite:deck:10', 'decksite:deck:20'}

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -3,6 +3,7 @@ import datetime
 import fileinput
 import functools
 import glob
+import hashlib
 import os
 import pathlib
 import shutil
@@ -15,7 +16,7 @@ import sentry_sdk
 from magic import card_price, fetcher, oracle, rotation, seasons
 from price_grabber.parser import PriceListType, parse_cardhoarder_prices
 from shared import configuration, decorators, dtutil, fetch_tools, redis_wrapper, repo, sentry, text
-from shared.pd_exception import InvalidDataException, NotConfiguredException
+from shared.pd_exception import NotConfiguredException
 
 TIME_UNTIL_FULL_ROTATION = seasons.next_rotation() - dtutil.now()
 TIME_SINCE_FULL_ROTATION = dtutil.now() - seasons.last_rotation()
@@ -47,6 +48,7 @@ def run() -> None:
         print(f'ETA: {dtutil.display_time(int(time_until.total_seconds()))}')
         return
 
+    oracle.init()
     if n == 0:
         rotation.clear_redis(clear_files=True)
         try:
@@ -88,7 +90,7 @@ def process(all_prices: dict[str, PriceListType]) -> int:
             cents = int(float(p) * 100)
             seen_sets.add(mtgo_set)
             if cents <= card_price.MAX_PRICE_CENTS and is_good_set(mtgo_set):
-                hits.add(name)
+                hits.add(oracle.canonical_name_or_self(name))
                 used_sets.add(mtgo_set)
     ignored = seen_sets - used_sets
     return process_sets(seen_sets, used_sets, hits, ignored)
@@ -165,10 +167,7 @@ def make_final_list() -> None:
 
 def canonical_legal_name(name: str, renames: dict[str, str]) -> str:
     name = renames.get(name, name)
-    try:
-        return oracle.valid_name(name)
-    except InvalidDataException:
-        return name
+    return oracle.canonical_name_or_self(name)
 
 def prepare_flavornames() -> dict[str, str]:
     _num, _names, flavored = fetcher.search_scryfall('is:flavor_name', True)
@@ -217,12 +216,14 @@ def do_push() -> None:
         print(c, flush=True)
         sentry_sdk.capture_exception(c)
     print('done!\nGoing through checklist...', flush=True)
+    checksums = {fn: file_sha256(os.path.join(configuration.get_str('legality_dir'), fn)) for fn in files}
     checklist = f"""{setcode} {rottype} checklist
 
 https://pennydreadfulmagic.com/admin/rotation/
 
-- [ ] upload legal_cards.txt to S3 (set Content-Type to 'text/plain; charset=utf-8' in Metadata, System)
-- [ ] upload {setcode}_legal_cards.txt to S3 (set Content-Type to 'text/plain; charset=utf-8' in Metadata, System)
+- [ ] upload the generated legal_cards.txt to S3 (SHA-256 `{checksums['legal_cards.txt']}`; set Content-Type to 'text/plain; charset=utf-8' in Metadata, System)
+- [ ] upload the generated {setcode}_legal_cards.txt to S3 (SHA-256 `{checksums[f'{setcode}_legal_cards.txt']}`; set Content-Type to 'text/plain; charset=utf-8' in Metadata, System)
+- [ ] verify the local, GitHub Pages, and S3 copies have those SHA-256 checksums
 - [ ] ping scryfall
 - [ ] email mtggoldfish
 """
@@ -262,3 +263,10 @@ https://pennydreadfulmagic.com/admin/rotation/
     print('Sending checklist to Github...', flush=True)
     repo.create_issue(checklist, 'rotation script', 'rotation')
     print('Done!', flush=True)
+
+def file_sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, 'rb') as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b''):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/rotation_script/rotation_script.py
+++ b/rotation_script/rotation_script.py
@@ -12,11 +12,10 @@ from collections import Counter
 import ftfy
 import sentry_sdk
 
-from magic import card_price, fetcher, rotation, seasons
+from magic import card_price, fetcher, oracle, rotation, seasons
 from price_grabber.parser import PriceListType, parse_cardhoarder_prices
-from shared import configuration, decorators, dtutil, fetch_tools, repo, sentry, text
-from shared import redis_wrapper as redis
-from shared.pd_exception import NotConfiguredException
+from shared import configuration, decorators, dtutil, fetch_tools, redis_wrapper, repo, sentry, text
+from shared.pd_exception import InvalidDataException, NotConfiguredException
 
 TIME_UNTIL_FULL_ROTATION = seasons.next_rotation() - dtutil.now()
 TIME_SINCE_FULL_ROTATION = dtutil.now() - seasons.last_rotation()
@@ -129,6 +128,7 @@ def make_final_list() -> None:
     bad_names = planes
     bad_names.extend(BANNED_CARDS)
     renames = prepare_flavornames()
+    oracle.init(force=True)
 
     files = rotation.files()
     lines: list[str] = []
@@ -136,9 +136,8 @@ def make_final_list() -> None:
         line = text.sanitize(line)
         if line.strip() in bad_names:
             continue
-        if line.strip() in renames:
-            line = renames[line.strip()] + '\n'
-        lines.append(line)
+        name = canonical_legal_name(line.strip(), renames)
+        lines.append(name + '\n')
     scores = Counter(lines).most_common()
 
     passed: list[str] = []
@@ -149,7 +148,7 @@ def make_final_list() -> None:
     if is_supplemental():
         temp = set(passed)
         legal_cards = asyncio.get_event_loop().run_until_complete(fetcher.legal_cards_async())
-        final = list(temp.union([c + '\n' for c in legal_cards]))
+        final = list(temp.union([canonical_legal_name(c, renames) + '\n' for c in legal_cards]))
 
     final.sort()
     h = open(os.path.join(configuration.get_str('legality_dir'), 'legal_cards.txt'), mode='w', encoding='utf-8')
@@ -163,6 +162,13 @@ def make_final_list() -> None:
     h = open(os.path.join(configuration.get_str('legality_dir'), f'{setcode}_legal_cards.txt'), mode='w', encoding='utf-8')
     h.write(''.join(final))
     h.close()
+
+def canonical_legal_name(name: str, renames: dict[str, str]) -> str:
+    name = renames.get(name, name)
+    try:
+        return oracle.valid_name(name)
+    except InvalidDataException:
+        return name
 
 def prepare_flavornames() -> dict[str, str]:
     _num, _names, flavored = fetcher.search_scryfall('is:flavor_name', True)
@@ -221,8 +227,8 @@ https://pennydreadfulmagic.com/admin/rotation/
 - [ ] email mtggoldfish
 """
     print('Rebooting Discord bot...', flush=True)
-    if redis.get_str('discordbot:commit_id'):
-        redis.store('discordbot:do_reboot', True)
+    if redis_wrapper.get_str('discordbot:commit_id'):
+        redis_wrapper.store('discordbot:do_reboot', True)
         print('Done!', flush=True)
         checklist += '- [x] restart discordbot\n'
     else:

--- a/rotation_script/rotation_script_test.py
+++ b/rotation_script/rotation_script_test.py
@@ -23,6 +23,33 @@ def test_canonical_legal_name_preserves_unknown_names(monkeypatch: pytest.Monkey
     monkeypatch.setattr(rotation_script.oracle, 'valid_name', unknown)
     assert rotation_script.canonical_legal_name('A Future Card', {}) == 'A Future Card'
 
+def test_process_writes_one_canonical_hit_for_equivalent_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_hits: set[str] = set()
+    monkeypatch.setattr(rotation_script.oracle, 'canonical_name_or_self', lambda name: 'Agent Venom' if name == 'Rhilex the Accursed' else name)
+    monkeypatch.setattr(rotation_script, 'is_good_set', lambda _set_code: True)
+
+    def process_sets(_seen: set[str], _used: set[str], hits: set[str], _ignored: set[str]) -> int:
+        captured_hits.update(hits)
+        return 1
+
+    monkeypatch.setattr(rotation_script, 'process_sets', process_sets)
+    prices = {
+        'prices': [
+            ('Agent Venom', '0.01', 'TST'),
+            ('Rhilex the Accursed', '0.01', 'TST'),
+            ('A Future Card', '0.01', 'TST'),
+        ],
+    }
+
+    assert rotation_script.process(prices) == 1
+    assert captured_hits == {'Agent Venom', 'A Future Card'}
+
+def test_file_sha256(tmp_path: Path) -> None:
+    path = tmp_path / 'legal_cards.txt'
+    path.write_text('Agent Venom\n', encoding='utf-8')
+
+    assert rotation_script.file_sha256(str(path)) == 'fb5349f0ac8f2d4ca12c9278ebc1f5aa918b9cafbb2533a5ee3f25212d8c4c81'
+
 def test_make_final_list_combines_equivalent_printing_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     (tmp_path / 'Run_001.txt').write_text('Rhilex the Accursed\n', encoding='utf-8')
     (tmp_path / 'Run_002.txt').write_text('Agent Venom\n', encoding='utf-8')

--- a/rotation_script/rotation_script_test.py
+++ b/rotation_script/rotation_script_test.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rotation_script import rotation_script
+from shared import configuration
+from shared.pd_exception import InvalidDataException
+
+
+def test_canonical_legal_name_uses_imported_aliases(monkeypatch: pytest.MonkeyPatch) -> None:
+    names = {
+        'Agent Venom': 'Agent Venom',
+        'Rhilex the Accursed': 'Agent Venom',
+    }
+    monkeypatch.setattr(rotation_script.oracle, 'valid_name', names.__getitem__)
+    assert rotation_script.canonical_legal_name('Rhilex the Accursed', {}) == 'Agent Venom'
+
+def test_canonical_legal_name_preserves_unknown_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unknown(_name: str) -> str:
+        raise InvalidDataException()
+
+    monkeypatch.setattr(rotation_script.oracle, 'valid_name', unknown)
+    assert rotation_script.canonical_legal_name('A Future Card', {}) == 'A Future Card'
+
+def test_make_final_list_combines_equivalent_printing_names(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / 'Run_001.txt').write_text('Rhilex the Accursed\n', encoding='utf-8')
+    (tmp_path / 'Run_002.txt').write_text('Agent Venom\n', encoding='utf-8')
+    monkeypatch.setitem(configuration.CONFIG, 'legality_dir', str(tmp_path))
+    monkeypatch.setattr(rotation_script.rotation, 'files', lambda: [str(tmp_path / 'Run_001.txt'), str(tmp_path / 'Run_002.txt')])
+    monkeypatch.setattr(rotation_script.rotation, 'TOTAL_RUNS', 4)
+    monkeypatch.setattr(rotation_script.fetcher, 'search_scryfall', lambda _query, _exhaustive: (0, [], []))
+    monkeypatch.setattr(rotation_script, 'prepare_flavornames', lambda: {})
+    monkeypatch.setattr(rotation_script.oracle, 'init', lambda force=False: None)
+    monkeypatch.setattr(
+        rotation_script.oracle,
+        'valid_name',
+        lambda name: 'Agent Venom' if name == 'Rhilex the Accursed' else name,
+    )
+    monkeypatch.setattr(rotation_script, 'is_supplemental', lambda: False)
+    monkeypatch.setattr(rotation_script.seasons, 'next_rotation_ex', lambda: SimpleNamespace(mtgo_code='TST'))
+
+    rotation_script.make_final_list()
+
+    assert (tmp_path / 'legal_cards.txt').read_text(encoding='utf-8') == 'Agent Venom\n'
+    assert (tmp_path / 'TST_legal_cards.txt').read_text(encoding='utf-8') == 'Agent Venom\n'


### PR DESCRIPTION
## Summary

- derive English alternate printed names from Scryfall, including later printings and double-faced cards, while rejecting ambiguous/canonical collisions
- accept either Spider-Man or Omenpaths names for deck entry, league validation, card commands, filters, and search, but store and emit the Scryfall canonical name
- enforce one shared four-copy limit and one deck identity across equivalent names
- redirect alternate-name card-page URLs to the canonical public URL while preserving season and tournament filters
- canonicalize new rotation run files, `rotation_runs`, rotation summaries, and generated `legal_cards.txt` before counting equivalent identities
- provide a Scryfall-derived dry run and collision-safe, idempotent data migration for old `deck_card`, `deck.featured_card`, `rule_card`, and `rotation_runs` values
- create persistent pre-migration backup tables before changing source rows, then refresh affected deck hashes and rotation/cache state
- add SHA-256 values to the rotation publication checklist so GitHub Pages and S3 can be verified as the same generated files
- leave PDBot unchanged

Public decklists remain machine-readable and use canonical Spider-Man names. Validation errors preserve the submitted alias for clarity, for example `Origin of Spider-Man (entered as A Most Helpful Weaver)`.

## Production snapshot rehearsal

Rehearsed against `decksite-2026-08-22.sql.gz` with a card database rebuilt by this branch. The rehearsal used the complete production deck/rule data and every production rotation row belonging to any Scryfall alias identity.

- 680 aliases derived from the rebuilt Oracle data; no hardcoded Omenpaths map
- 2 aliased `deck_card` rows in 2 decks, both `Knife Trick` -> `Pumpkin Bombardment`
- 0 aliased `deck.featured_card` rows
- 0 aliased `rule_card` rows
- 33,927 aliased `rotation_runs` rows: the previously measured 33,117 Omenpaths rows plus 810 older alternate-name rows
- 0 deck, rule, or rotation identity collisions in production
- after apply: zero stored aliases, both deck quantities preserved, both deck hashes matched the normal application calculation, and 460,671 relevant rotation rows plus the complete affected decks were retained in backup tables
- a second audit and apply found zero source changes and completed idempotently

The migration test also covers the harder cases not present in production: alias plus canonical rows, two aliases for one identity, quantity merging, main deck versus sideboard separation, rule semantics, rotation primary-key collisions, dry-run behavior, backups, and reruns.

## Validation

- `uv run pytest -q`: 729 passed, 2 skipped
- `uv run python dev.py lint`
- `uv run mypy .`
- focused migration/rotation suite: 12 passed, 1 pre-existing network test skipped
- pinned Scryfall shadow comparison against `origin/master`: no canonical changes, removals, or ambiguities; 560 aliases retained, 120 added; 910,986 legality rows retained, 80 alias-derived rows added

## Deployment runbook

Take a fresh decksite database snapshot and use a short maintenance window for the migration.

1. Deploy this commit to Columbus consumers of the shared card database. PDBot is not part of this deployment.
2. Rebuild the card database first: `uv run python run.py init-cards --force`.
3. Dry-run the stored-data migration: `uv run python run.py maintenance canonicalize-card-names-audit`. Compare its output with the snapshot counts above and stop if it reports unexpected collisions.
4. Apply it: `uv run python run.py maintenance canonicalize-card-names`. It takes an advisory lock, creates `_canonicalize_card_names_backup_*` tables, and changes the four source locations in one transaction. Hash/cache repair is safe to resume by rerunning the command if a post-commit step is interrupted.
5. Run the audit again and require zero alias rows in every source.
6. Rebuild derived site and search data: `uv run python run.py maintenance reprime-cache` and `uv run python run.py maintenance populate-whoosh-index`.
7. Restart long-lived Decksite and Discord bot processes so their in-memory Oracle maps reload. This does not mean PDBot.
8. Make GitHub Pages and S3 serve the exact same canonical `legal_cards.txt` and current-season legal-list artifact. Verify their SHA-256 hashes match; future rotation issues include the expected hashes automatically.
9. Smoke-test league entry once with each equivalent name, a mixed-name four-copy violation, both card pages/search names, both affected historical decks, and the public legal-card files.

## Rollback

- Any source-write failure rolls back the source transaction automatically.
- The safest rollback after a successful apply is the fresh database snapshot.
- For an immediate targeted rollback during the maintenance window, the `_canonicalize_card_names_backup_deck`, `_deck_card`, `_rule_card`, `_rotation_runs`, and `_mapping` tables contain the complete original affected rows and hashes. Restore those rows, then rerun the cache/search rebuilds and restart processes. Do not use a targeted restore after accepting new deck or rotation writes; use the full snapshot instead.
