### PR TITLE
Fix random deck API

### DIFF
--- a/decksite/league.py
+++ b/decksite/league.py
@@ -350,9 +350,9 @@ def retire_deck(d: Deck) -> None:
 def random_legal_deck() -> Deck | None:
     where = f'd.reviewed AND d.created_date > (SELECT start_date FROM season WHERE number = {seasons.current_season_num()})'
     having = f'(d.competition_id NOT IN ({active_competition_id_query()}) OR SUM(cache.wins + cache.draws + cache.losses) >= 5)'
+    ds, _ = deck.load_decks(where=where, having=having, order_by='RAND()', limit='LIMIT 1')
     try:
-        ds, _ = deck.load_decks(where=where, having=having, order_by='RAND()', limit='LIMIT 1')[0]
-        return ds
+        return ds[0]
     except IndexError:
         # For a short while at the start of a season there are no decks that match the WHERE/HAVING clauses.
         return None

--- a/decksite/league_test.py
+++ b/decksite/league_test.py
@@ -4,6 +4,7 @@ import pytest
 from werkzeug.datastructures import ImmutableMultiDict
 
 from decksite import league
+from magic.models import Deck
 from shared import dtutil
 from shared.pd_exception import InvalidArgumentException
 
@@ -74,3 +75,12 @@ def test_determine_league_name() -> None:
     start_date = dtutil.parse('2022-09-16 00:00:00', '%Y-%m-%d %H:%M:%S', dtutil.WOTC_TZ)
     end_date = dtutil.parse('2022-10-31 23:59:59.999', '%Y-%m-%d %H:%M:%S.%f', dtutil.WOTC_TZ)
     assert league.determine_league_name(start_date, end_date) == 'League October 2022'
+
+
+@pytest.mark.parametrize('decks', [[Deck({})], []])
+def test_random_legal_deck(monkeypatch: pytest.MonkeyPatch, decks: list[Deck]) -> None:
+    monkeypatch.setattr(league.seasons, 'current_season_num', lambda: 42)
+    monkeypatch.setattr(league, 'active_competition_id_query', lambda: '1, 2')
+    monkeypatch.setattr(league.deck, 'load_decks', lambda **kwargs: (decks, len(decks)))
+
+    assert league.random_legal_deck() is (decks[0] if decks else None)


### PR DESCRIPTION
## Summary

- fix the random legal deck endpoint after `load_decks()` changed to return decks and a total
- preserve the expected no-eligible-decks response
- add regression tests for populated and empty results

## Testing

- `uv run --frozen python dev.py test` (690 passed, 2 skipped)
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy decksite/league.py decksite/league_test.py`
- verified `/api/randomlegaldeck` returns HTTP 200 from local Decksite