### PR TITLE
Show official alternate card names and exact printings

### DIFF
--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -79,11 +79,12 @@ def card(name: str, deck_type: str | None = None) -> str | wrappers.Response:
     try:
         submitted_name = decode_card_name(name)
         canonical_name = parse_card_name(name)
-        if submitted_name != canonical_name:
+        c = cs.load_card(canonical_name, tournament_only=tournament_only, season_id=get_season_id())
+        alternate_name = oracle.matching_official_alternate_name(c, submitted_name)
+        if submitted_name != canonical_name and alternate_name is None:
             assert request.endpoint is not None
             return redirect(url_for(request.endpoint, name=canonical_name, deck_type=deck_type))
-        c = cs.load_card(canonical_name, tournament_only=tournament_only, season_id=get_season_id())
-        view = Card(c, tournament_only)
+        view = Card(c, tournament_only, alternate_name)
         return view.page()
     except InvalidDataException as e:
         raise DoesNotExistException(e) from e

--- a/decksite/controllers/metagame_test.py
+++ b/decksite/controllers/metagame_test.py
@@ -5,13 +5,14 @@ from flask import g
 
 from decksite.controllers import metagame
 from decksite.main import APP
+from magic.models import Card
 
 
 @pytest.mark.parametrize(
     ('path', 'deck_type', 'expected'),
     [
-        ('/cards/A%20Most%20Helpful%20Weaver/', None, '/cards/Origin%20of%20Spider-Man/'),
-        ('/cards/A%20Most%20Helpful%20Weaver/tournament/', 'tournament', '/cards/Origin%20of%20Spider-Man/tournament/'),
+        ('/cards/Origin%20of%20Spiderman/', None, '/cards/Origin%20of%20Spider-Man/'),
+        ('/cards/Origin%20of%20Spiderman/tournament/', 'tournament', '/cards/Origin%20of%20Spider-Man/tournament/'),
     ],
 )
 def test_alias_card_pages_redirect_to_the_canonical_url(
@@ -23,24 +24,48 @@ def test_alias_card_pages_redirect_to_the_canonical_url(
     monkeypatch.setattr(
         metagame.oracle,
         'valid_name',
-        lambda name: 'Origin of Spider-Man' if name == 'A Most Helpful Weaver' else name,
+        lambda name: 'Origin of Spider-Man' if name == 'Origin of Spiderman' else name,
     )
-    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: pytest.fail('Redirects must not load the card page'))
+    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: Card({'name': 'Origin of Spider-Man'}))
 
     with APP.test_request_context(path):
-        response = cast(Any, metagame.card).__wrapped__(name='A Most Helpful Weaver', deck_type=deck_type)
+        response = cast(Any, metagame.card).__wrapped__(name='Origin of Spiderman', deck_type=deck_type)
 
     assert response.status_code == 302
     assert response.location == expected
 
 
-def test_canonical_card_pages_do_not_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(metagame.oracle, 'valid_name', lambda name: name)
-    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: object())
+def test_official_alternate_name_renders_the_card_page_without_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = Card({'name': 'Origin of Spider-Man', 'flavor_names': 'A Most Helpful Weaver'})
+    monkeypatch.setattr(
+        metagame.oracle,
+        'valid_name',
+        lambda name: 'Origin of Spider-Man' if name == 'A Most Helpful Weaver' else name,
+    )
+    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: card)
 
     class FakeCardView:
-        def __init__(self, _card: object, _tournament_only: bool) -> None:
-            pass
+        def __init__(self, loaded_card: Card, _tournament_only: bool, alternate_name: str | None) -> None:
+            assert loaded_card is card
+            assert alternate_name == 'A Most Helpful Weaver'
+
+        def page(self) -> str:
+            return 'alternate card page'
+
+    monkeypatch.setattr(metagame, 'Card', FakeCardView)
+    with APP.test_request_context('/cards/A%20Most%20Helpful%20Weaver/'):
+        response = cast(Any, metagame.card).__wrapped__(name='A Most Helpful Weaver')
+
+    assert response == 'alternate card page'
+
+
+def test_canonical_card_pages_do_not_redirect(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(metagame.oracle, 'valid_name', lambda name: name)
+    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: Card({'name': 'Origin of Spider-Man'}))
+
+    class FakeCardView:
+        def __init__(self, _card: object, _tournament_only: bool, alternate_name: str | None) -> None:
+            assert alternate_name is None
 
         def page(self) -> str:
             return 'canonical card page'
@@ -56,11 +81,12 @@ def test_alias_card_page_redirect_preserves_the_season(monkeypatch: pytest.Monke
     monkeypatch.setattr(
         metagame.oracle,
         'valid_name',
-        lambda name: 'Origin of Spider-Man' if name == 'A Most Helpful Weaver' else name,
+        lambda name: 'Origin of Spider-Man' if name == 'Origin of Spiderman' else name,
     )
-    with APP.test_request_context('/seasons/5/cards/A%20Most%20Helpful%20Weaver/tournament/'):
+    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: Card({'name': 'Origin of Spider-Man'}))
+    with APP.test_request_context('/seasons/5/cards/Origin%20of%20Spiderman/tournament/'):
         g.season_id = 5
-        response = cast(Any, metagame.card).__wrapped__(name='A Most Helpful Weaver', deck_type='tournament')
+        response = cast(Any, metagame.card).__wrapped__(name='Origin of Spiderman', deck_type='tournament')
 
     assert response.status_code == 302
     assert response.location == '/seasons/5/cards/Origin%20of%20Spider-Man/tournament/'

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+from copy import copy
 
 import sentry_sdk
 from flask import Response, abort, g, make_response, redirect, request, send_file, session
@@ -49,6 +50,15 @@ def image(c: str = '') -> wrappers.Response:
     names = c.split('|')
     try:
         requested_cards = oracle.load_cards(names)
+        preferred_printing = request.args.get('printing')
+        preferred_printing_system_id = request.args.get('printing_id')
+        if preferred_printing or preferred_printing_system_id:
+            requested_cards = [copy(card) for card in requested_cards]
+            for card in requested_cards:
+                if preferred_printing:
+                    card['preferred_printing'] = preferred_printing
+                if preferred_printing_system_id:
+                    card['preferred_printing_system_id'] = preferred_printing_system_id
         path = image_fetcher.download_image(requested_cards)
         if path is None:
             raise InternalServerError(f'Failed to get image for {c}')

--- a/decksite/main_test.py
+++ b/decksite/main_test.py
@@ -1,0 +1,26 @@
+import pytest
+
+from decksite import main
+from magic.models import Card
+
+
+def test_image_route_applies_requested_printing_without_mutating_cached_card(monkeypatch: pytest.MonkeyPatch) -> None:
+    cached_card = Card({'name': 'Agent Venom'})
+    captured = []
+    monkeypatch.setattr(main.oracle, 'load_cards', lambda _names: [cached_card])
+
+    def download_image(cards: list[Card]) -> str:
+        captured.extend(cards)
+        return 'LICENSE.md'
+
+    monkeypatch.setattr(main.image_fetcher, 'download_image', download_image)
+
+    with main.APP.test_request_context('/image/Agent%20Venom/?printing=om1&printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760'):
+        response = main.image('Agent Venom')
+
+    assert response.status_code == 200
+    assert captured[0] is not cached_card
+    assert captured[0].preferred_printing == 'om1'
+    assert captured[0].preferred_printing_system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
+    assert cached_card.get('preferred_printing') is None
+    assert cached_card.get('preferred_printing_system_id') is None

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -8,7 +8,7 @@ from decksite.data import archetype
 from decksite.data.archetype import Archetype
 from decksite.data.models.person import Person
 from decksite.deck_type import DeckType
-from magic import fetcher, seasons
+from magic import fetcher, oracle, seasons
 from magic.models import Card, Deck
 from shared import dtutil
 from shared.container import Container
@@ -39,19 +39,35 @@ def prepare_card(c: Card, tournament_only: bool = False, season_id: int | str | 
         c.display_rank = '-'
     else:
         c.display_rank = str(c.rank)
+    c.alternate_printed_names = [
+        {'name': name, 'url': url_for_card_name(name, tournament_only, season_id)}
+        for name in oracle.official_alternate_names(c)
+    ]
+    c.has_alternate_printed_names = bool(c.alternate_printed_names)
 
 def prepare_card_urls(c: Card, tournament_only: bool = False, season_id: int | str | None = None) -> None:
     c.url = url_for_card(c, tournament_only, season_id)
-    c.img_url = url_for_image(c.name)
+    c.img_url = url_for_image(c.name, c.get('preferred_printing'), c.get('preferred_printing_system_id'))
 
-def url_for_image(name: str) -> str:
+def url_for_image(name: str, preferred_printing: str | None = None, preferred_printing_system_id: str | None = None) -> str:
     if g.get('url_cache') is None:
         g.url_cache = {}
     if g.url_cache.get('card_image') is None:
         g.url_cache['card_image'] = url_for('image', c='--cardname--')
-    return g.url_cache['card_image'].replace('--cardname--', name)
+    url = g.url_cache['card_image'].replace('--cardname--', name)
+    query = {}
+    if preferred_printing:
+        query['printing'] = preferred_printing
+    if preferred_printing_system_id:
+        query['printing_id'] = preferred_printing_system_id
+    if query:
+        return f'{url}?{urllib.parse.urlencode(query)}'
+    return url
 
 def url_for_card(c: Card, tournament_only: bool = False, season_id: int | str | None = None) -> str:
+    return url_for_card_name(c.name, tournament_only, season_id)
+
+def url_for_card_name(name: str, tournament_only: bool = False, season_id: int | str | None = None) -> str:
     if g.get('url_cache') is None:
         g.url_cache = {}
     if g.url_cache.get('card_page') is None:
@@ -59,7 +75,7 @@ def url_for_card(c: Card, tournament_only: bool = False, season_id: int | str | 
             g.url_cache['card_page'] = url_for('.card', name='--cardname--', deck_type=DeckType.TOURNAMENT.value if tournament_only else None)
         else:
             g.url_cache['card_page'] = url_for('seasons.card', name='--cardname--', deck_type=DeckType.TOURNAMENT.value if tournament_only else None, season_id=season_id)
-    return g.url_cache['card_page'].replace('--cardname--', urllib.parse.quote(c.name))
+    return g.url_cache['card_page'].replace('--cardname--', urllib.parse.quote(name))
 
 def prepare_decks(ds: list[Deck]) -> None:
     for d in ds:

--- a/decksite/prepare_test.py
+++ b/decksite/prepare_test.py
@@ -1,7 +1,10 @@
 import pytest
 
 from decksite import prepare
+from decksite.main import APP
 from magic import seasons
+from magic.models import Card
+from shared_web import template
 
 
 def test_season_icon_link_uses_site_colors(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -20,3 +23,37 @@ def test_season_icon_link_uses_site_colors(monkeypatch: pytest.MonkeyPatch) -> N
     assert 'ss-common' not in previous
     assert 'ss-rare' not in current
     assert 'ss-grad' not in current
+
+def test_prepare_card_adds_official_alternate_name_links(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    card = Card({
+        'name': 'Agent Venom',
+        'flavor_names': 'Rhilex the Accursed',
+        'layout': 'normal',
+        'legalities': None,
+    })
+
+    with APP.test_request_context('/'):
+        prepare.prepare_card(card)
+        rendered = template.render_name('entry', {'name': card.name, 'n': 4, 'card': card})
+
+    assert card.alternate_printed_names == [
+        {'name': 'Rhilex the Accursed', 'url': '/cards/Rhilex%20the%20Accursed/'},
+    ]
+    assert '4 Agent Venom' in rendered
+    assert 'class="alternate-card-name" title="Alternate printed name">· Rhilex the Accursed</a>' in rendered
+
+def test_prepare_card_uses_preferred_printing_for_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    card = Card({
+        'name': 'Agent Venom',
+        'layout': 'normal',
+        'legalities': None,
+        'preferred_printing': 'om1',
+        'preferred_printing_system_id': 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760',
+    })
+
+    with APP.test_request_context('/'):
+        prepare.prepare_card(card)
+
+    assert card.img_url == '/image/Agent Venom/?printing=om1&printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760'

--- a/decksite/templates/card.mustache
+++ b/decksite/templates/card.mustache
@@ -1,5 +1,19 @@
+{{#alternate_name}}
+    <section>
+        <p><b>{{alternate_name}}</b> is an alternate printing of <a class="card" href="{{canonical_url}}">{{canonical_name}}</a>.</p>
+    </section>
+{{/alternate_name}}
+{{^alternate_name}}
+    {{#card.has_alternate_printed_names}}
+        <section>
+            {{#card.alternate_printed_names}}
+                <p>Also printed as <a class="card" href="{{url}}">{{name}}</a>.</p>
+            {{/card.alternate_printed_names}}
+        </section>
+    {{/card.has_alternate_printed_names}}
+{{/alternate_name}}
 <section>
-    <img src="{{img_url}}" alt="{{name}}" class="card-img {{card_img_class}}">
+    <img src="{{img_url}}" alt="{{display_name}}" class="card-img {{card_img_class}}">
     {{#bugs}}
         <p class="bug-desc {{card_img_class}}"><b>{{classification}} bug</b> {{description}}</p>
     {{/bugs}}

--- a/decksite/templates/entry.mustache
+++ b/decksite/templates/entry.mustache
@@ -1,5 +1,5 @@
 <li class="cardrow" data-cardname="{{name}}">
-    <a href="{{card.url}}" class="card {{#show_interesting}}{{#interestingness}}interesting interestingness-{{interestingness}}{{/interestingness}}{{/show_interesting}}">{{#n}}{{n}} {{/n}}{{name}}</a>{{^card.pd_legal}}<span class="illegal"></span>{{/card.pd_legal}}
+    <a href="{{card.url}}" class="card {{#show_interesting}}{{#interestingness}}interesting interestingness-{{interestingness}}{{/interestingness}}{{/show_interesting}}">{{#n}}{{n}} {{/n}}{{name}}</a>{{^card.pd_legal}}<span class="illegal"></span>{{/card.pd_legal}}{{#card.alternate_printed_names}} <a href="{{url}}" class="alternate-card-name" title="Alternate printed name">· {{name}}</a>{{/card.alternate_printed_names}}
     {{#card.bugs}}
         <a href="{{card.url}}" class="bug" title="{{description}} ({{classification}})">🐞</a>
     {{/card.bugs}}

--- a/decksite/views/card.py
+++ b/decksite/views/card.py
@@ -4,12 +4,12 @@ from flask import url_for
 
 from decksite.deck_type import DeckType
 from decksite.view import View
-from magic import seasons
+from magic import oracle, seasons
 from magic.models import Card as CardContainer
 
 
 class Card(View):
-    def __init__(self, card: CardContainer, tournament_only: bool = False) -> None:
+    def __init__(self, card: CardContainer, tournament_only: bool = False, alternate_name: str | None = None) -> None:
         super().__init__()
         self.legal_formats = ([x for x, y in card.legalities.items() if y == 'Legal'] + [x + ' (restricted)' for x, y in card.legalities.items() if y == 'Restricted'])
         self.legal_seasons = sorted(seasons.SEASONS.index(fmt.replace('Penny Dreadful ', '')) + 1 for fmt, v in card.legalities.items() if 'Penny Dreadful' in fmt and v != 'Banned')
@@ -18,7 +18,16 @@ class Card(View):
         self.show_tournament_toggle = True
         self.tournament_only = self.hide_source = tournament_only
         self.public = True  # Mark this as 'public' so it can share legality section code with deck.
-        self.toggle_results_url = url_for('.card', name=card.name, deck_type=None if tournament_only else DeckType.TOURNAMENT.value)
+        self.alternate_name = alternate_name
+        self.display_name = alternate_name or card.name
+        self.canonical_name = card.name if alternate_name else None
+        self.canonical_url = url_for('.card', name=card.name, deck_type=DeckType.TOURNAMENT.value if tournament_only else None) if alternate_name else None
+        if alternate_name:
+            printing = oracle.preferred_printing_for_alternate_name(card, alternate_name)
+            if printing is not None:
+                card.preferred_printing = str(printing.set_code)
+                card.preferred_printing_system_id = str(printing.system_id)
+        self.toggle_results_url = url_for('.card', name=self.display_name, deck_type=None if tournament_only else DeckType.TOURNAMENT.value)
         self.card = card
         self.cards = [self.card]
 
@@ -26,4 +35,4 @@ class Card(View):
         return getattr(self.card, attr)
 
     def page_title(self) -> str:
-        return self.card.name
+        return str(self.display_name)

--- a/decksite/views/card_test.py
+++ b/decksite/views/card_test.py
@@ -1,0 +1,50 @@
+import pytest
+
+from decksite.main import APP
+from decksite.views.card import Card as CardView
+from magic import oracle, seasons
+from magic.models import Card, Printing
+
+
+def test_alternate_card_page_uses_alternate_name_and_printing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    printing = Printing({'set_code': 'om1', 'system_id': 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'})
+    monkeypatch.setattr(oracle, 'preferred_printing_for_alternate_name', lambda _card, _name: printing)
+    card = Card({
+        'name': 'Agent Venom',
+        'flavor_names': 'Rhilex the Accursed',
+        'layout': 'normal',
+        'legalities': None,
+        'played_competitively': False,
+        'bugs': None,
+    })
+
+    with APP.test_request_context('/cards/Rhilex%20the%20Accursed/'):
+        view = CardView(card, alternate_name='Rhilex the Accursed')
+        content = view.render_content()
+
+    assert view.page_title() == 'Rhilex the Accursed'
+    assert card.preferred_printing == 'om1'
+    assert card.preferred_printing_system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
+    assert '<b>Rhilex the Accursed</b> is an alternate printing of' in content
+    assert 'href="/cards/Agent%20Venom/">Agent Venom</a>' in content
+    assert 'src="/image/Agent Venom/?printing=om1&amp;printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760"' in content
+
+
+def test_canonical_card_page_links_to_alternate_printing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    card = Card({
+        'name': 'Agent Venom',
+        'flavor_names': 'Rhilex the Accursed',
+        'layout': 'normal',
+        'legalities': None,
+        'played_competitively': False,
+        'bugs': None,
+    })
+
+    with APP.test_request_context('/cards/Agent%20Venom/'):
+        view = CardView(card)
+        content = view.render_content()
+
+    assert view.page_title() == 'Agent Venom'
+    assert 'Also printed as <a class="card" href="/cards/Rhilex%20the%20Accursed/">Rhilex the Accursed</a>.' in content

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -51,12 +51,12 @@ async def respond_to_card_names(ctx: 'MtgMessageContext') -> None:
             return
         results = results_from_queries(queries)
         cards = []
-        for i in results:
+        for query, i in zip(queries, results):
             (r, mode, preferred_printing) = i
             if r.has_match() and not r.is_ambiguous():
-                cards.extend(cards_from_names_with_mode([r.get_best_match()], mode, preferred_printing))
+                cards.extend(cards_from_names_with_mode([r.get_best_match()], mode, preferred_printing, query))
             elif r.is_ambiguous():
-                cards.extend(cards_from_names_with_mode(r.get_ambiguous_matches(), mode, preferred_printing))
+                cards.extend(cards_from_names_with_mode(r.get_ambiguous_matches(), mode, preferred_printing, query))
         await ctx.post_cards(cards, ctx.author)
 
 def parse_queries(content: str, scryfall_compatability_mode: bool) -> list[str]:
@@ -67,14 +67,30 @@ def parse_queries(content: str, scryfall_compatability_mode: bool) -> list[str]:
         queries = re.findall(r'\[?\[([^\]]*)\]\]?', to_scan)
     return [card.canonicalize(query) for query in queries if len(query) > 2]
 
-def cards_from_names_with_mode(cards: Sequence[str | None], mode: str, preferred_printing: str | None = None) -> list[Card]:
-    return [copy_with_mode(oracle.load_card(c), mode, preferred_printing) for c in cards if c is not None]
+def cards_from_names_with_mode(cards: Sequence[str | None], mode: str, preferred_printing: str | None = None, requested_name: str | None = None) -> list[Card]:
+    return [copy_with_mode(oracle.load_card(c), mode, preferred_printing, requested_name) for c in cards if c is not None]
 
-def copy_with_mode(oracle_card: Card, mode: str, preferred_printing: str | None = None) -> Card:
+def copy_with_mode(oracle_card: Card, mode: str, preferred_printing: str | None = None, requested_name: str | None = None) -> Card:
     c = copy(oracle_card)
     c['mode'] = mode
+    if requested_name:
+        _requested_mode, name, _requested_printing = parse_mode(requested_name)
+        alternate_name = oracle.matching_official_alternate_name(c, name)
+        if alternate_name:
+            c['display_name'] = alternate_name
+            if preferred_printing is None:
+                printing = oracle.preferred_printing_for_alternate_name(c, alternate_name)
+                if printing is not None:
+                    preferred_printing = str(printing.set_code)
+                    c['preferred_printing_system_id'] = str(printing.system_id)
     c['preferred_printing'] = preferred_printing
     return c
+
+def card_name_for_display(c: Card) -> str:
+    display_name = c.get('display_name')
+    if display_name and display_name != c.name:
+        return f'{display_name} ({c.name})'
+    return str(c.name)
 
 def parse_mode(query: str) -> tuple[str, str, str | None]:
     mode = ''
@@ -115,7 +131,7 @@ async def single_card_or_send_error(channel: TYPE_MESSAGEABLE_CHANNEL, args: str
         return None
     result, mode, preferred_printing = results_from_queries([args])[0]
     if result.has_match() and not result.is_ambiguous():
-        return cards_from_names_with_mode([result.get_best_match()], mode, preferred_printing)[0]
+        return cards_from_names_with_mode([result.get_best_match()], mode, preferred_printing, args)[0]
     if result.is_ambiguous():
         await send(channel, f'{author.mention}: Ambiguous name for {command}. Please use the slash command and choose one of its suggestions.')
     else:
@@ -125,7 +141,7 @@ async def single_card_or_send_error(channel: TYPE_MESSAGEABLE_CHANNEL, args: str
 async def single_card_text(client: Client, channel: TYPE_MESSAGEABLE_CHANNEL, args: str, author: Member, f: Callable[[Card], str], command: str, show_legality: bool = True) -> None:
     c = await single_card_or_send_error(channel, args, author, command)
     if c is not None:
-        name = c.name
+        name = card_name_for_display(c)
         info_emoji = emoji.info_emoji(c, show_legality=show_legality)
         text = await emoji.replace_emoji(f(c), client)
         message = f'**{name}** {info_emoji} {text}'
@@ -163,9 +179,9 @@ async def single_card_text_internal(client: Client, requested_card: Card, legali
     mana = mana.replace('|', ' // ').removeprefix(' // ').removesuffix(' // ')  # Strip leading/trailing // for lands (See #9147)
     legal = ' — ' + emoji.info_emoji(requested_card, verbose=True, legality_format=legality_format)
     if requested_card.get('mode', None) == '$':
-        text = f'{requested_card.name} {legal} — {card_price.card_price_string(requested_card)}'
+        text = f'{card_name_for_display(requested_card)} {legal} — {card_price.card_price_string(requested_card)}'
     else:
-        text = f'{requested_card.name} {mana} — {requested_card.type_line}{legal}'
+        text = f'{card_name_for_display(requested_card)} {mana} — {requested_card.type_line}{legal}'
     if requested_card.bugs:
         for bug in requested_card.bugs:
             text += '\n:lady_beetle:{rank} bug: {bug}'.format(bug=bug['description'], rank=bug['classification'])
@@ -223,13 +239,21 @@ def make_choice(value: str, name: str | None = None) -> dict[str, int | float | 
 
 @global_autocomplete('card')
 async def autocomplete_card(ctx: AutocompleteContext) -> None:
-    card = ctx.kwargs.get('card')
-    if not card:
+    query = ctx.kwargs.get('card')
+    if not query:
         await ctx.send(choices=[])
         return
-    results = searcher().search(card)
+    results = searcher().search(query)
     choices = list(dict.fromkeys(results.get_all_matches()))
-    await ctx.send(choices=list(make_choice(c) for c in choices[:20]))
+    formatted_choices = []
+    for canonical_name in choices[:20]:
+        c = oracle.load_card(canonical_name)
+        alternate_name = oracle.matching_official_alternate_name(c, query, allow_prefix=True)
+        if alternate_name:
+            formatted_choices.append(make_choice(alternate_name, f'{alternate_name} — {canonical_name}'))
+        else:
+            formatted_choices.append(make_choice(canonical_name))
+    await ctx.send(choices=formatted_choices)
 
 class MtgMixin:
     async def send_image_with_retry(self: 'MtgContext', image_file: str, text: str = '') -> None:  # type: ignore
@@ -251,7 +275,7 @@ class MtgMixin:
         elif not isinstance(self.channel, (DM, DMGroup)) and str(self.channel.guild.id) in not_pd:
             show_legality = False
 
-        name = c.name
+        name = card_name_for_display(c)
         info_emoji = emoji.info_emoji(c, show_legality=show_legality)
         text = await emoji.replace_emoji(f(c), self.bot)
         message = f'**{name}** {info_emoji} {text}{stale_card_information_warning()}'
@@ -273,7 +297,7 @@ class MtgMixin:
         if len(cards) == 1:
             text = await single_card_text_internal(self.bot, cards[0], legality_format)
         else:
-            text = ' • '.join('{name} {legal} {price}'.format(name=card.name, legal=(emoji.info_emoji(card, legality_format=legality_format)), price=((card_price.card_price_string(card, True)) if card.get('mode', None) == '$' else '')).strip() for card in cards)
+            text = ' • '.join('{name} {legal} {price}'.format(name=card_name_for_display(card), legal=(emoji.info_emoji(card, legality_format=legality_format)), price=((card_price.card_price_string(card, True)) if card.get('mode', None) == '$' else '')).strip() for card in cards)
         if len(cards) > MAX_CARDS_SHOWN:
             image_file = None
         else:

--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from discordbot import command
 from discordbot.commands import CardConverter, resources
+from magic.models import Card, Printing
 
 
 def test_roughly_matches() -> None:
@@ -52,6 +53,63 @@ def test_results_from_queries() -> None:
     assert result.has_match()
     assert not result.is_ambiguous()
     assert result.get_best_match() == 'Wasteland'
+
+def test_copy_with_mode_preserves_official_alternate_name_and_printing(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = Card({'name': 'Agent Venom', 'flavor_names': 'Rhilex the Accursed'})
+    printing = Printing({'set_code': 'om1', 'system_id': 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'})
+    monkeypatch.setattr(command.oracle, 'preferred_printing_for_alternate_name', lambda _card, _name: printing)
+
+    result = command.copy_with_mode(card, '', requested_name='Rhilex the Accursed')
+
+    assert result.display_name == 'Rhilex the Accursed'
+    assert result.preferred_printing == 'om1'
+    assert result.preferred_printing_system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
+    assert command.card_name_for_display(result) == 'Rhilex the Accursed (Agent Venom)'
+
+def test_copy_with_mode_keeps_canonical_requests_on_the_default_printing() -> None:
+    card = Card({'name': 'Zilortha, Strength Incarnate', 'flavor_names': 'Godzilla, King of the Monsters'})
+
+    result = command.copy_with_mode(card, '', requested_name='Zilortha, Strength Incarnate')
+
+    assert result.get('display_name') is None
+    assert result.preferred_printing is None
+    assert result.get('preferred_printing_system_id') is None
+
+def test_copy_with_mode_keeps_explicit_set_syntax(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = Card({'name': 'Zilortha, Strength Incarnate', 'flavor_names': 'Godzilla, King of the Monsters'})
+    monkeypatch.setattr(
+        command.oracle,
+        'preferred_printing_for_alternate_name',
+        lambda *_args: pytest.fail('An explicit set must take precedence'),
+    )
+
+    result = command.copy_with_mode(card, '', preferred_printing='iko', requested_name='Godzilla, King of the Monsters|iko')
+
+    assert result.display_name == 'Godzilla, King of the Monsters'
+    assert result.preferred_printing == 'iko'
+    assert result.get('preferred_printing_system_id') is None
+
+def test_copy_with_mode_does_not_display_search_only_alias() -> None:
+    card = Card({'name': 'Dark Confidant'})
+
+    result = command.copy_with_mode(card, '', requested_name='bob')
+
+    assert result.get('display_name') is None
+    assert command.card_name_for_display(result) == 'Dark Confidant'
+
+@pytest.mark.asyncio
+async def test_autocomplete_displays_official_alternate_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = Mock()
+    result.get_all_matches.return_value = ['Agent Venom']
+    monkeypatch.setattr(command, 'searcher', lambda: Mock(search=Mock(return_value=result)))
+    monkeypatch.setattr(command.oracle, 'load_card', lambda _name: Card({'name': 'Agent Venom', 'flavor_names': 'Rhilex the Accursed'}))
+    ctx = Mock()
+    ctx.kwargs = {'card': 'rhil'}
+    ctx.send = AsyncMock()
+
+    await command.autocomplete_card(ctx)
+
+    ctx.send.assert_awaited_once_with(choices=[{'name': 'Rhilex the Accursed — Agent Venom', 'value': 'Rhilex the Accursed'}])
 
 
 def test_do_not_choke_on_unicode() -> None:
@@ -144,7 +202,7 @@ async def test_card_converter_uses_buttons_for_ambiguous_names(monkeypatch: pyte
     assert len(sent_components) == 1
     assert [button.label for button in sent_components[0]] == shown_matches
     assert all(button.emoji is None for button in sent_components[0])
-    cards_from_names.assert_called_once_with(['Brainstorm'], '', None)
+    cards_from_names.assert_called_once_with(['Brainstorm'], '', None, 'brain')
     pressed_ctx.edit_origin.assert_awaited_once_with(content='<@123>: Selected **Brainstorm**.', components=[])
     event = ctx.client.wait_for_component.await_args
     assert event.kwargs['components'][1].custom_id is not None

--- a/discordbot/commands/__init__.py
+++ b/discordbot/commands/__init__.py
@@ -42,7 +42,7 @@ class CardConverter:
         try:
             result, mode, printing = command.results_from_queries([argument])[0]
             if result.has_match() and not result.is_ambiguous():
-                return command.cards_from_names_with_mode([result.get_best_match()], mode, printing)[0]
+                return command.cards_from_names_with_mode([result.get_best_match()], mode, printing, argument)[0]
             if result.is_ambiguous():
                 matches = result.get_ambiguous_matches()[:5]
                 buttons = [Button(style=ButtonStyle.SECONDARY, label=card_name[:80]) for card_name in matches]
@@ -59,7 +59,7 @@ class CardConverter:
 
                 selected = next(i for i, button in enumerate(buttons) if button.custom_id == event.ctx.custom_id)
                 await event.ctx.edit_origin(content=f'{ctx.author.mention}: Selected **{matches[selected]}**.', components=[])
-                return command.cards_from_names_with_mode([matches[selected]], mode, printing)[0]
+                return command.cards_from_names_with_mode([matches[selected]], mode, printing, argument)[0]
             else:
                 message = await ctx.send(f'{ctx.author.mention}: No matches.')
                 await message.add_reaction('❎')

--- a/magic/image_fetcher.py
+++ b/magic/image_fetcher.py
@@ -21,6 +21,7 @@ def basename(cards: list[Card]) -> str:
     return '_'.join(
         re.sub('[^a-z-]', '-', card.canonicalize(c.name))
         + (f'-{preferred_printing}' if (preferred_printing := c.get('preferred_printing')) else '')
+        + (f'-{preferred_printing_system_id}' if (preferred_printing_system_id := c.get('preferred_printing_system_id')) else '')
         for c in cards
     )
 
@@ -35,11 +36,15 @@ def scryfall_image(c: Card, version: str = '', face: str | None = None) -> str:
         name = c.name.replace(' // ', '/')
     else:
         name = c.name
-    p = oracle.get_printing(c, c.get('preferred_printing'))
-    if p is not None:
-        u = f'https://api.scryfall.com/cards/named?exact={escape(name)}&set={escape(p.set_code)}&format=image'
+    preferred_printing_system_id = c.get('preferred_printing_system_id')
+    if preferred_printing_system_id:
+        u = f'https://api.scryfall.com/cards/{escape(preferred_printing_system_id)}?format=image'
     else:
-        u = f'https://api.scryfall.com/cards/named?exact={escape(name)}&format=image'
+        p = oracle.get_printing(c, c.get('preferred_printing'))
+        if p is not None:
+            u = f'https://api.scryfall.com/cards/named?exact={escape(name)}&set={escape(p.set_code)}&format=image'
+        else:
+            u = f'https://api.scryfall.com/cards/named?exact={escape(name)}&format=image'
     if version:
         u += f'&version={escape(version)}'
     if face and face != 'meld':

--- a/magic/image_fetcher_test.py
+++ b/magic/image_fetcher_test.py
@@ -1,6 +1,10 @@
 from copy import copy
 
 from magic import image_fetcher, oracle
+from magic.models import Card
+
+GODZILLA_PRINTING_ID = '9a0639a0-c898-4a07-975c-a02bdd53175b'
+WRONG_DIGITAL_PRINTING_ID = '1c48ddf5-c2da-4fbc-95f2-8a3f2f5737ba'
 
 
 def test_scryfall_image_uses_default_printing_within_preferred_set() -> None:
@@ -10,4 +14,38 @@ def test_scryfall_image_uses_default_printing_within_preferred_set() -> None:
     assert image_fetcher.basename([c]) == 'sultai-ascendancy-ktk'
     assert image_fetcher.scryfall_image(c, version='border_crop') == (
         'https://api.scryfall.com/cards/named?exact=sultai+ascendancy&set=ktk&format=image&version=border_crop'
+    )
+
+def test_scryfall_image_uses_exact_preferred_printing_id() -> None:
+    c = Card({
+        'name': 'Zilortha, Strength Incarnate',
+        'preferred_printing': 'iko',
+        'preferred_printing_system_id': GODZILLA_PRINTING_ID,
+    })
+
+    assert image_fetcher.scryfall_image(c, version='border_crop') == (
+        f'https://api.scryfall.com/cards/{GODZILLA_PRINTING_ID}?format=image&version=border_crop'
+    )
+    assert image_fetcher.basename([c]) == f'zilortha--strength-incarnate-iko-{GODZILLA_PRINTING_ID}'
+
+def test_exact_printings_in_the_same_set_have_distinct_cache_keys() -> None:
+    godzilla = Card({
+        'name': 'Zilortha, Strength Incarnate',
+        'preferred_printing': 'iko',
+        'preferred_printing_system_id': GODZILLA_PRINTING_ID,
+    })
+    digital = Card({
+        'name': 'Zilortha, Strength Incarnate',
+        'preferred_printing': 'iko',
+        'preferred_printing_system_id': WRONG_DIGITAL_PRINTING_ID,
+    })
+
+    assert image_fetcher.basename([godzilla]) != image_fetcher.basename([digital])
+
+def test_canonical_card_uses_default_printing() -> None:
+    c = Card({'name': 'Zilortha, Strength Incarnate'})
+
+    assert image_fetcher.basename([c]) == 'zilortha--strength-incarnate'
+    assert image_fetcher.scryfall_image(c, version='border_crop') == (
+        'https://api.scryfall.com/cards/named?exact=zilortha%2c+strength+incarnate&format=image&version=border_crop'
     )

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -13,6 +13,7 @@ from shared.pd_exception import InvalidArgumentException, InvalidDataException, 
 
 LEGAL_CARDS: list[str] = []
 CARDS_BY_NAME: dict[str, Card] = {}
+OMENPATHS_SET_CODE = 'om1'
 
 def init(force: bool = False) -> None:
     if len(CARDS_BY_NAME) == 0 or force:
@@ -74,6 +75,39 @@ def load_cards(names: Iterable[str] | None = None, where: str | None = None) -> 
 
 def cards_by_name() -> dict[str, Card]:
     return CARDS_BY_NAME
+
+def official_alternate_names(c: Card) -> list[str]:
+    """Return official printed/flavor names suitable for display, rather than search-only aliases."""
+    aliases = [name for name in (c.get('flavor_names') or '').split('|') if name]
+    combined_aliases = [name for name in aliases if ' // ' in name]
+    combined_faces = {face for name in combined_aliases for face in name.split(' // ')}
+    return sorted(set(combined_aliases + [name for name in aliases if name not in combined_faces]))
+
+def matching_official_alternate_name(c: Card, query: str, allow_prefix: bool = False) -> str | None:
+    normalized_query = card.canonicalize(query)
+    aliases = [name for name in (c.get('flavor_names') or '').split('|') if name]
+    for alias in aliases:
+        if card.canonicalize(alias) == normalized_query:
+            return alias
+    if allow_prefix:
+        matches = [name for name in official_alternate_names(c) if card.canonicalize(name).startswith(normalized_query)]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+def preferred_printing_for_alternate_name(c: Card, alternate_name: str) -> Printing | None:
+    printings = get_printings(c)
+    for printing in printings:
+        if printing.flavor_name == alternate_name:
+            return printing
+    # Through the Omenpaths is a one-time MTGO treatment. Scryfall exposes its
+    # card names as printed_name rather than flavor_name, so that name is not
+    # retained on our printing row. An official alias plus an OM1 printing is
+    # therefore enough to identify the requested printing without new storage.
+    for printing in printings:
+        if str(printing.set_code).lower() == OMENPATHS_SET_CODE:
+            return printing
+    return None
 
 def load_cards_with_flavor_names() -> list[Card]:
     sql = multiverse.cached_base_query('c.flavor_names IS NOT NULL')

--- a/magic/oracle_test.py
+++ b/magic/oracle_test.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 import pytest
 
 from magic import oracle, seasons
-from magic.models import Card
+from magic.models import Card, Printing
 from shared.pd_exception import InvalidDataException
 
 
@@ -37,6 +37,58 @@ def test_valid_name_returns_canonical_name_for_alias_front(monkeypatch: pytest.M
     card = Card({'name': 'Peter Parker', 'flavor_names': 'Surris, Spidersilk Innovator'})
     monkeypatch.setitem(oracle.CARDS_BY_NAME, 'Surris, Spidersilk Innovator', card)
     assert oracle.valid_name('Surris, Spidersilk Innovator // Surris, Silk-Tech Vanguard') == 'Peter Parker'
+
+def test_official_alternate_names_prefers_combined_double_faced_name() -> None:
+    card = Card({
+        'name': 'Peter Parker',
+        'flavor_names': 'Surris, Silk-Tech Vanguard|Surris, Spidersilk Innovator // Surris, Silk-Tech Vanguard|Surris, Spidersilk Innovator',
+    })
+
+    assert oracle.official_alternate_names(card) == [
+        'Surris, Spidersilk Innovator // Surris, Silk-Tech Vanguard',
+    ]
+
+def test_matching_official_alternate_name_supports_exact_and_unique_prefix() -> None:
+    card = Card({'name': 'Agent Venom', 'flavor_names': 'Rhilex the Accursed'})
+
+    assert oracle.matching_official_alternate_name(card, 'Rhilex the Accursed') == 'Rhilex the Accursed'
+    assert oracle.matching_official_alternate_name(card, 'rhil', allow_prefix=True) == 'Rhilex the Accursed'
+    assert oracle.matching_official_alternate_name(card, 'Agent Venom') is None
+
+def test_preferred_printing_uses_matching_flavor_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = Card({'id': 1, 'name': 'Zilortha, Strength Incarnate'})
+    printings = [
+        Printing({
+            'set_code': 'iko',
+            'system_id': '1c48ddf5-c2da-4fbc-95f2-8a3f2f5737ba',
+            'flavor_name': None,
+        }),
+        Printing({
+            'set_code': 'iko',
+            'system_id': '9a0639a0-c898-4a07-975c-a02bdd53175b',
+            'flavor_name': 'Godzilla, King of the Monsters',
+        }),
+    ]
+    monkeypatch.setattr(oracle, 'get_printings', lambda _card: printings)
+
+    printing = oracle.preferred_printing_for_alternate_name(card, 'Godzilla, King of the Monsters')
+
+    assert printing is not None
+    assert printing.system_id == '9a0639a0-c898-4a07-975c-a02bdd53175b'
+
+def test_preferred_printing_uses_omenpaths_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    card = Card({'id': 1, 'name': 'Agent Venom'})
+    printings = [
+        Printing({'set_code': 'spm', 'system_id': 'spm-id', 'flavor_name': None}),
+        Printing({'set_code': 'om1', 'system_id': 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760', 'flavor_name': None}),
+    ]
+    monkeypatch.setattr(oracle, 'get_printings', lambda _card: printings)
+
+    printing = oracle.preferred_printing_for_alternate_name(card, 'Rhilex the Accursed')
+
+    assert printing is not None
+    assert printing.set_code == 'om1'
+    assert printing.system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
 
 def test_init_rebuilds_names_and_ignores_alias_collisions(monkeypatch: pytest.MonkeyPatch) -> None:
     canonical = Card({'name': 'Shared Name'})

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -604,6 +604,11 @@ Color attributes are mostly found with their related structural elements in this
     cursor: default;
 }
 
+.alternate-card-name {
+    color: var(--deemphasized-text);
+    font-size: var(--table-font-size);
+}
+
 /* Dark Mode */
 
 html.dark-mode {


### PR DESCRIPTION
## Summary
- display official alternate card names in Discord and decksite
- preserve the exact Scryfall printing UUID for alternate-name images
- keep explicit set selection, OM1 fallback, and canonical default-printing behavior
- separate exact printings in the image cache

## Testing
- `uv run python dev.py lint`
- `uv run python dev.py mypy`
- `uv run pytest magic/oracle_test.py magic/image_fetcher_test.py discordbot decksite/controllers/metagame_test.py decksite/main_test.py decksite/prepare_test.py decksite/views/card_test.py` (98 passed, 1 skipped)
- manually verified the Godzilla alias and canonical Zilortha decksite pages locally