### PR TITLE
Refine alternate card name presentation

### DIFF
--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -40,10 +40,20 @@ def prepare_card(c: Card, tournament_only: bool = False, season_id: int | str | 
     else:
         c.display_rank = str(c.rank)
     c.alternate_printed_names = [
-        {'name': name, 'url': url_for_card_name(name, tournament_only, season_id)}
-        for name in oracle.official_alternate_names(c)
+        {
+            'name': name,
+            'url': url_for_card_name(name, tournament_only, season_id),
+            'separator': '' if i == 0 else ', ',
+        }
+        for i, name in enumerate(oracle.official_alternate_names(c))
     ]
     c.has_alternate_printed_names = bool(c.alternate_printed_names)
+    c.decklist_alternate_printed_names = [
+        alternate
+        for alternate in c.alternate_printed_names
+        if (printing := oracle.preferred_printing_for_alternate_name(c, alternate['name'])) is not None
+        and str(printing.set_code).lower() == oracle.OMENPATHS_SET_CODE
+    ]
 
 def prepare_card_urls(c: Card, tournament_only: bool = False, season_id: int | str | None = None) -> None:
     c.url = url_for_card(c, tournament_only, season_id)

--- a/decksite/prepare_test.py
+++ b/decksite/prepare_test.py
@@ -3,7 +3,7 @@ import pytest
 from decksite import prepare
 from decksite.main import APP
 from magic import seasons
-from magic.models import Card
+from magic.models import Card, Printing
 from shared_web import template
 
 
@@ -24,8 +24,11 @@ def test_season_icon_link_uses_site_colors(monkeypatch: pytest.MonkeyPatch) -> N
     assert 'ss-rare' not in current
     assert 'ss-grad' not in current
 
+
 def test_prepare_card_adds_official_alternate_name_links(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    printing = Printing({'set_code': 'om1', 'system_id': 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'})
+    monkeypatch.setattr(prepare.oracle, 'preferred_printing_for_alternate_name', lambda _card, _name: printing)
     card = Card({
         'name': 'Agent Venom',
         'flavor_names': 'Rhilex the Accursed',
@@ -38,10 +41,42 @@ def test_prepare_card_adds_official_alternate_name_links(monkeypatch: pytest.Mon
         rendered = template.render_name('entry', {'name': card.name, 'n': 4, 'card': card})
 
     assert card.alternate_printed_names == [
-        {'name': 'Rhilex the Accursed', 'url': '/cards/Rhilex%20the%20Accursed/'},
+        {
+            'name': 'Rhilex the Accursed',
+            'url': '/cards/Rhilex%20the%20Accursed/',
+            'separator': '',
+        },
     ]
+    assert card.decklist_alternate_printed_names == card.alternate_printed_names
     assert '4 Agent Venom' in rendered
-    assert 'class="alternate-card-name" title="Alternate printed name">· Rhilex the Accursed</a>' in rendered
+    assert 'class="alternate-card-name">· Rhilex the Accursed</a>' in rendered
+    assert 'class="card alternate-card-name"' not in rendered
+
+
+def test_prepare_card_omits_non_omenpaths_names_from_decklists(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    printing = Printing({'set_code': 'sld', 'system_id': 'a49bdd0b-fc8d-4706-b614-14d1731fddc0'})
+    monkeypatch.setattr(prepare.oracle, 'preferred_printing_for_alternate_name', lambda _card, _name: printing)
+    card = Card({
+        'name': 'Phantasmal Image',
+        'flavor_names': 'Absolutely Accurate Actor',
+        'layout': 'normal',
+        'legalities': None,
+    })
+
+    with APP.test_request_context('/'):
+        prepare.prepare_card(card)
+        rendered = template.render_name('entry', {'name': card.name, 'n': 4, 'card': card})
+
+    assert card.alternate_printed_names == [
+        {
+            'name': 'Absolutely Accurate Actor',
+            'url': '/cards/Absolutely%20Accurate%20Actor/',
+            'separator': '',
+        },
+    ]
+    assert card.decklist_alternate_printed_names == []
+    assert 'Absolutely Accurate Actor' not in rendered
 
 def test_prepare_card_uses_preferred_printing_for_image(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')

--- a/decksite/templates/card.mustache
+++ b/decksite/templates/card.mustache
@@ -1,19 +1,13 @@
-{{#alternate_name}}
-    <section>
-        <p><b>{{alternate_name}}</b> is an alternate printing of <a class="card" href="{{canonical_url}}">{{canonical_name}}</a>.</p>
-    </section>
-{{/alternate_name}}
-{{^alternate_name}}
-    {{#card.has_alternate_printed_names}}
-        <section>
-            {{#card.alternate_printed_names}}
-                <p>Also printed as <a class="card" href="{{url}}">{{name}}</a>.</p>
-            {{/card.alternate_printed_names}}
-        </section>
-    {{/card.has_alternate_printed_names}}
-{{/alternate_name}}
-<section>
+<section class="card-image-block">
     <img src="{{img_url}}" alt="{{display_name}}" class="card-img {{card_img_class}}">
+    {{#alternate_name}}
+        <p class="alternate-printing-note {{card_img_class}}">Alternate printing of <a class="card" href="{{canonical_url}}">{{canonical_name}}</a>.</p>
+    {{/alternate_name}}
+    {{^alternate_name}}
+        {{#card.has_alternate_printed_names}}
+            <p class="alternate-printing-note {{card_img_class}}">Also printed as {{#card.alternate_printed_names}}{{separator}}<a href="{{url}}">{{name}}</a>{{/card.alternate_printed_names}}.</p>
+        {{/card.has_alternate_printed_names}}
+    {{/alternate_name}}
     {{#bugs}}
         <p class="bug-desc {{card_img_class}}"><b>{{classification}} bug</b> {{description}}</p>
     {{/bugs}}

--- a/decksite/templates/entry.mustache
+++ b/decksite/templates/entry.mustache
@@ -1,5 +1,5 @@
 <li class="cardrow" data-cardname="{{name}}">
-    <a href="{{card.url}}" class="card {{#show_interesting}}{{#interestingness}}interesting interestingness-{{interestingness}}{{/interestingness}}{{/show_interesting}}">{{#n}}{{n}} {{/n}}{{name}}</a>{{^card.pd_legal}}<span class="illegal"></span>{{/card.pd_legal}}{{#card.alternate_printed_names}} <a href="{{url}}" class="alternate-card-name" title="Alternate printed name">· {{name}}</a>{{/card.alternate_printed_names}}
+    <a href="{{card.url}}" class="card {{#show_interesting}}{{#interestingness}}interesting interestingness-{{interestingness}}{{/interestingness}}{{/show_interesting}}">{{#n}}{{n}} {{/n}}{{name}}</a>{{^card.pd_legal}}<span class="illegal"></span>{{/card.pd_legal}}{{#card.decklist_alternate_printed_names}} <a href="{{url}}" class="alternate-card-name">· {{name}}</a>{{/card.decklist_alternate_printed_names}}
     {{#card.bugs}}
         <a href="{{card.url}}" class="bug" title="{{description}} ({{classification}})">🐞</a>
     {{/card.bugs}}

--- a/decksite/views/card_test.py
+++ b/decksite/views/card_test.py
@@ -26,13 +26,17 @@ def test_alternate_card_page_uses_alternate_name_and_printing(monkeypatch: pytes
     assert view.page_title() == 'Rhilex the Accursed'
     assert card.preferred_printing == 'om1'
     assert card.preferred_printing_system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
-    assert '<b>Rhilex the Accursed</b> is an alternate printing of' in content
+    assert '<section class="card-image-block">' in content
+    assert '<p class="alternate-printing-note ">Alternate printing of' in content
     assert 'href="/cards/Agent%20Venom/">Agent Venom</a>' in content
     assert 'src="/image/Agent Venom/?printing=om1&amp;printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760"' in content
+    assert content.index('src="/image/Agent Venom/?printing=om1') < content.index('Alternate printing of')
 
 
 def test_canonical_card_page_links_to_alternate_printing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    printing = Printing({'set_code': 'om1', 'system_id': 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'})
+    monkeypatch.setattr(oracle, 'preferred_printing_for_alternate_name', lambda _card, _name: printing)
     card = Card({
         'name': 'Agent Venom',
         'flavor_names': 'Rhilex the Accursed',
@@ -47,4 +51,30 @@ def test_canonical_card_page_links_to_alternate_printing(monkeypatch: pytest.Mon
         content = view.render_content()
 
     assert view.page_title() == 'Agent Venom'
-    assert 'Also printed as <a class="card" href="/cards/Rhilex%20the%20Accursed/">Rhilex the Accursed</a>.' in content
+    assert '<p class="alternate-printing-note ">Also printed as <a href="/cards/Rhilex%20the%20Accursed/">Rhilex the Accursed</a>.</p>' in content
+    assert '<a class="card" href="/cards/Rhilex%20the%20Accursed/">' not in content
+    assert content.index('class="card-img ') < content.index('Also printed as')
+
+
+def test_canonical_card_page_lists_alternate_printings_in_one_sentence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    printing = Printing({'set_code': 'sld', 'system_id': 'sld-id'})
+    monkeypatch.setattr(oracle, 'preferred_printing_for_alternate_name', lambda _card, _name: printing)
+    card = Card({
+        'name': 'Command Tower',
+        'flavor_names': 'Croft Manor|Cybertron|The Spire',
+        'layout': 'normal',
+        'legalities': None,
+        'played_competitively': False,
+        'bugs': None,
+    })
+
+    with APP.test_request_context('/cards/Command%20Tower/'):
+        content = CardView(card).render_content()
+
+    assert (
+        'Also printed as <a href="/cards/Croft%20Manor/">Croft Manor</a>, '
+        '<a href="/cards/Cybertron/">Cybertron</a>, '
+        '<a href="/cards/The%20Spire/">The Spire</a>.'
+    ) in content
+    assert content.count('Also printed as') == 1

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1924,8 +1924,17 @@ Cards are 445px tall images that are usually 312px wide but may be wider if they
 .card-img {
     border: solid black 0.3rem;
     border-radius: var(--button-rounded-corners);
+    display: block;
     height: 15rem;
     margin-top: 1rem;
+    width: 10.517rem;
+}
+
+/* Keep alternate-printing context visually attached to the card instead of giving it a separate content column. */
+p.alternate-printing-note {
+    color: var(--deemphasized-text);
+    font-size: var(--table-font-size);
+    margin-top: 0.422em;
     width: 10.517rem;
 }
 
@@ -1935,7 +1944,7 @@ p.bug-desc {
 }
 
 /* When we have a DFC or a Meld card and show two images side-by-side allow them (and bug text below) to be twice the width of a normal card image. */
-.card-img.two-faces, p.bug-desc.two-faces {
+.card-img.two-faces, p.alternate-printing-note.two-faces, p.bug-desc.two-faces {
     width: 21.034rem;
 }
 


### PR DESCRIPTION
## Summary

- Keep alternate-printing information directly beneath the card image in a compact, wrapping caption.
- Render multiple official alternate names as one comma-separated sentence.
- Show pale alternate names in decklists only for the OM1 Omenpaths mappings.
- Avoid unreliable Deckbox previews on alternate-name links while retaining links to their local card pages.

## Testing

- `uv run --frozen python dev.py unit` — 687 passed, 1 skipped, 89 deselected
- `uv run --frozen python dev.py sort`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`