### PR TITLE
Fix bug_blog always being False by reading 'From Bug Blog' label (#12719)

### DIFF
--- a/modo_bugs/update.py
+++ b/modo_bugs/update.py
@@ -146,7 +146,7 @@ def process_issue(issue: Issue) -> None:
             'last_updated': str(issue.updated_at),
             'issue_number': issue.number,
             'pd_legal': card in pd_legal_cards(),
-            'bug_blog': False,
+            'bug_blog': 'From Bug Blog' in labels,
             'breaking': cat in BADCATS,
             'bannable': bannable,
             'url': issue.html_url,


### PR DESCRIPTION
## What was wrong

In `modo_bugs/update.py` line 149, the `bug_blog` field in every `BugData` entry was hardcoded to `False`, regardless of whether the GitHub issue had the `'From Bug Blog'` label. This meant `card_bug.from_bug_blog` was always stored as `False` in the database, making the field meaningless.

## What changed

Changed `'bug_blog': False` to `'bug_blog': 'From Bug Blog' in labels` (one line in `process_issue`). The `labels` list is already computed earlier in the same function from `issue.labels`, so no additional API calls are needed.

## Validation

- `uv run --frozen python dev.py lint` — All checks passed
- `uv run --frozen python dev.py unit modo_bugs` — 687 passed, 1 skipped (the skipped test is a pre-existing functional test skip unrelated to this change)

Fixes #12719