### PR TITLE
Add Price of Progress to promo explanation list (#12730)

### DIFF
--- a/discordbot/commands/explain.py
+++ b/discordbot/commands/explain.py
@@ -316,6 +316,7 @@ def promo_explanation() -> tuple[str, dict[str, str]]:
         'Buried Alive',
         'Crystal Vein',
         'Lake of the Dead',
+        'Price of Progress',
     ]
     legal_cheap_promos = [c for c in oracle.load_cards(have_cheap_promos) if c.pd_legal]
     if len(legal_cheap_promos) > 0:


### PR DESCRIPTION
## What was wrong

The `promo_explanation()` function in `discordbot/commands/explain.py` lists cards that have cheap promotional versions so users know where to look for affordable copies. 'Price of Progress' (the Fire and Lightning promo version) is significantly cheaper than other printings, but it was missing from this list.

## What changed

Added `'Price of Progress'` to the `have_cheap_promos` list in `promo_explanation()` (line 319). The existing filter on line 320 already checks PD legality, so it will only appear in the explanation when the card is legal in Penny Dreadful.

## How it was validated

- `uv run --frozen python dev.py lint` — passed (all checks passed)
- `uv run --frozen python dev.py unit discordbot` — 687 passed, 1 skipped, 89 deselected

Fixes #12730