### PR TITLE
Make player names links on /admin/people/notes (#12717)

### DIFF
--- a/decksite/templates/playernotes.mustache
+++ b/decksite/templates/playernotes.mustache
@@ -11,8 +11,8 @@
         <tbody>
             {{#notes}}
                 <tr class="wide">
-                    <td class="person">{{subject}}</td>
-                    <td class="person">{{creator}}</td>
+                    <td class="person"><a href="{{subject_url}}">{{subject}}</a></td>
+                    <td class="person"><a href="{{creator_url}}">{{creator}}</a></td>
                     <td data-text="{{date_sort}}">
                         {{display_date}}
                     </td>

--- a/decksite/views/player_notes.py
+++ b/decksite/views/player_notes.py
@@ -1,5 +1,7 @@
 from collections.abc import Iterable
 
+from flask import url_for
+
 from decksite.data.person import Person
 from decksite.view import View
 from shared import dtutil
@@ -12,6 +14,8 @@ class PlayerNotes(View):
         for n in notes:
             n.date_sort = dtutil.dt2ts(n.created_date)
             n.display_date = dtutil.display_date(n.created_date)
+            n.subject_url = url_for('person', person_id=n.subject_id)
+            n.creator_url = url_for('person', person_id=n.creator_id)
         self.notes = notes
         self.people = people
 


### PR DESCRIPTION
## What was wrong

On `/admin/people/notes`, the Subject and Creator columns showed player names as plain text with no hyperlinks, making it hard to navigate to a player's profile from the notes admin page.

## What changed

- `decksite/views/player_notes.py`: Added `from flask import url_for` and, in the `__init__` loop, set `n.subject_url = url_for('person', person_id=n.subject_id)` and `n.creator_url = url_for('person', person_id=n.creator_id)` on each note.
- `decksite/templates/playernotes.mustache`: Wrapped the `{{subject}}` and `{{creator}}` cells in `<a href="{{subject_url}}">` and `<a href="{{creator_url}}">` respectively.

## Validation

- `uv run --frozen python dev.py lint` — passed (All checks passed)
- `uv run --frozen python dev.py unit` — 687 passed, 1 skipped, 89 deselected

Fixes #12717