### PR TITLE
Fix oldstyle numeric figures on /matchups/ archetype names (#12762)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -491,6 +491,7 @@ div:not(.table-header):after, header:after, nav:after, main:after, footer:after,
 
 .versus {
     text-align: center;
+    font-variant-numeric: normal;
 }
 
 .matchup-calculator button {


### PR DESCRIPTION
## What was wrong

The `/matchups/` page displayed archetype names with oldstyle (text) numeric figures — numbers that hang below the baseline — which looked out of place in the context of deck/archetype names. This happens because the site's font activates oldstyle numerals by default, and the `.versus` block that wraps these names inherited that setting.

## What changed

Added `font-variant-numeric: normal;` to the `.versus` CSS rule in `shared_web/static/css/pd.css`. This resets numeric figure style to lining (standard) figures for the matchup header block, matching the visual treatment everywhere else on the site.

## Validation

- `uv run --frozen python dev.py lint` — passed (exit 0)
- No unit tests cover CSS; the change is a single CSS property addition with no Python logic impact.

Fixes #12762