### PR TITLE
Fix League > Records menu not highlighting when viewing active league (#12760)

### DIFF
--- a/decksite/__init__.py
+++ b/decksite/__init__.py
@@ -86,7 +86,7 @@ def build_menu() -> Menu:
             MenuItem(gettext('Contact Us'), endpoint='contact_us'),
         ])),
         MenuItem(gettext('Admin'), endpoint='admin_home', submenu=admin.admin_menu(), permission_required='demimod'),
-    ], current_endpoint=request.endpoint)
+    ], current_endpoint=g.get('menu_endpoint_override', request.endpoint))
     return menu
 
 

--- a/decksite/controllers/competitions.py
+++ b/decksite/controllers/competitions.py
@@ -1,3 +1,5 @@
+from flask import g
+
 from decksite import APP, SEASONS, auth, get_season_id
 from decksite.cache import cached
 from decksite.data import achievements as achs
@@ -6,6 +8,7 @@ from decksite.data import competition as comp
 from decksite.data import deck as ds
 from decksite.data import person as ps
 from decksite.views import PD500, Achievements, Competition, Competitions, KickOff, SuperSaturday, TournamentHosting, TournamentLeaderboards, Tournaments
+from shared import dtutil
 
 
 @APP.route('/competitions/')
@@ -19,7 +22,10 @@ def competitions() -> str:
 @cached()
 def competition(competition_id: int) -> str:
     ars = archetype.load_competition_archetypes(competition_id)
-    view = Competition(comp.load_competition(competition_id, should_load_decks=False), ars)
+    c = comp.load_competition(competition_id, should_load_decks=False)
+    if c.type == 'League' and c.start_date <= dtutil.now() <= c.end_date:
+        g.menu_endpoint_override = 'current_league'
+    view = Competition(c, ars)
     return view.page()
 
 @APP.route('/tournaments/')

--- a/decksite/view_test.py
+++ b/decksite/view_test.py
@@ -1,6 +1,8 @@
 from unittest.mock import Mock, patch
 
-from decksite import view
+from flask import g
+
+from decksite import build_menu, view
 from decksite.main import APP
 from decksite.views.person_achievements import PersonAchievements
 from magic import seasons
@@ -52,3 +54,12 @@ def test_intro_deck_links() -> None:
         v = view.View()
         rendered = template.render_name('faqsbody', v)
         assert 'href="/metagame/"' in rendered
+
+def test_build_menu_uses_endpoint_override_for_active_league() -> None:
+    with APP.test_request_context('/competitions/123/'):
+        g.menu_endpoint_override = 'current_league'
+        menu = build_menu()
+    league_item = next(item for item in menu if item.name == 'League')
+    competitions_item = next(item for item in menu if item.name == 'Competitions')
+    assert league_item.current, 'League should be current when viewing the active league'
+    assert not competitions_item.current, 'Competitions should not be current when viewing the active league'


### PR DESCRIPTION
## What was wrong

The "Records" item under the League menu submenu points to the `current_league` endpoint (`/league/current/`), which immediately redirects to `/competitions/<active_id>/`. That URL is served by the `competition` endpoint, so `build_menu()` saw `request.endpoint == 'competition'` and highlighted "Competition Results" under Competitions — not "Records" under League.

## What changed

- **`decksite/controllers/competitions.py`**: In `competition()`, after loading the competition, check whether it is an active league (`c.type == 'League'` and current date falls within `c.start_date`/`c.end_date`). If so, set `g.menu_endpoint_override = 'current_league'`. This reuses data already fetched by `comp.load_competition()` — no extra DB query.
- **`decksite/__init__.py`**: In `build_menu()`, pass `g.get('menu_endpoint_override', request.endpoint)` as `current_endpoint` instead of `request.endpoint` directly, so the override takes effect when set.
- **`decksite/view_test.py`**: Added a unit test verifying that setting `g.menu_endpoint_override = 'current_league'` causes `build_menu()` to mark the League item (not Competitions) as current.

## Validation

- `uv run --frozen python dev.py lint` — passed (all checks)  
- `uv run --frozen python dev.py unit` — 688 passed, 1 skipped (1 new test added)

Fixes #12760