### PR TITLE
Stop dropping old price data by removing cleanup() call (#12781)

### DIFF
--- a/price_grabber/price_grabber.py
+++ b/price_grabber/price_grabber.py
@@ -30,10 +30,9 @@ def fetch() -> None:
         all_prices[url] = parser.parse_cardhoarder_prices(s)
     if not timestamps:
         raise TooFewItemsException(f'Did not get any prices when fetching {list(itertools.chain(configuration.cardhoarder_urls.get()))} ({all_prices})')
-    count = store(min(timestamps), all_prices)
-    cleanup(count)
+    store(min(timestamps), all_prices)
 
-def store(timestamp: float, all_prices: dict[str, parser.PriceListType]) -> int:
+def store(timestamp: float, all_prices: dict[str, parser.PriceListType]) -> None:
     DATABASE.begin('store')
     lows: dict[str, int] = {}
     for code in all_prices:
@@ -58,7 +57,6 @@ def store(timestamp: float, all_prices: dict[str, parser.PriceListType]) -> int:
             values.extend([timestamp, name, cents])
         execute(sql, values)
     DATABASE.commit('store')
-    return count * 20
 
 def cleanup(count: int = 0) -> None:
     beginning_of_season = seasons.last_rotation()


### PR DESCRIPTION
## What was wrong

`fetch()` in `price_grabber/price_grabber.py` called `cleanup(count)` after every price fetch, which deleted all `low_price` rows older than one month (or last rotation, whichever was more recent). Now that there is enough disk space, this data loss is unnecessary.

## What changed

- Removed the `cleanup(count)` call from `fetch()`. The `cleanup()` function itself is left in place (dormant) so it can be repurposed for a future archival strategy if query performance requires it.
- Cleaned up the now-dead return value from `store()` (changed return type from `int` to `None`, removed `return count * 20`).

## How it was validated

- `uv run --frozen python dev.py lint` — passed (all checks passed).
- `uv run --frozen python dev.py unit` — 687 passed, 1 skipped, 89 deselected.

Fixes #12781