### PR TITLE
Remove date column from Latest Tournament Top 8 (#12761)

### DIFF
--- a/decksite/templates/deckrow.mustache
+++ b/decksite/templates/deckrow.mustache
@@ -30,9 +30,11 @@
             {{#top8_safe}}</a>{{/top8_safe}}
         </td>
     {{/hide_top8}}
-    <td data-text="{{date_sort}}">
-        {{display_date}}
-    </td>
+    {{^hide_date}}
+        <td data-text="{{date_sort}}">
+            {{display_date}}
+        </td>
+    {{/hide_date}}
     {{#show_season_icon}}
         <td>
             {{{season_icon}}}

--- a/decksite/templates/decktable.mustache
+++ b/decksite/templates/decktable.mustache
@@ -20,7 +20,9 @@
             {{^hide_top8}}
                 <th class="c">Top 8</th>
             {{/hide_top8}}
-            <th data-sortInitialOrder="desc">Date</th>
+            {{^hide_date}}
+                <th data-sortInitialOrder="desc">Date</th>
+            {{/hide_date}}
             {{#show_season_icon}}
                 <th>Season</th>
             {{/show_season_icon}}

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -1,7 +1,6 @@
 {{#deck_tables}}
     <section>
-        <h2>{{title}}</h2>
-        {{#subtitle}}<p class="subtitle">{{subtitle}}</p>{{/subtitle}}
+        <h2>{{title}}{{#subtitle}} <span class="subtitle">{{subtitle}}</span>{{/subtitle}}</h2>
         {{> decktable}}
         <p><a href="{{url}}">{{link_text}}</a></p>
     </section>

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -1,6 +1,7 @@
 {{#deck_tables}}
     <section>
         <h2>{{title}}</h2>
+        {{#subtitle}}<p class="subtitle">{{subtitle}}</p>{{/subtitle}}
         {{> decktable}}
         <p><a href="{{url}}">{{link_text}}</a></p>
     </section>

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -67,7 +67,9 @@ class Home(View):
             self.deck_tables.append(
                 {
                     'hide_source': True,
+                    'hide_date': True,
                     'title': gettext('Latest Tournament Top 8'),
+                    'subtitle': dtutil.display_date(tournament_decks[0].active_date),
                     'url': url_for('competition', competition_id=tournament_id),
                     'link_text': gettext('View Tournament…'),
                     'decks': tournament_decks,


### PR DESCRIPTION
## What was wrong

The "Latest Tournament Top 8" section on the home page showed a Date column, but every deck in the table has the same date (they all come from the same tournament). The column is noise.

## What changed

- `decksite/templates/decktable.mustache`: wrapped the `<th>Date</th>` in `{{^hide_date}}...{{/hide_date}}`
- `decksite/templates/deckrow.mustache`: wrapped the date `<td>` in `{{^hide_date}}...{{/hide_date}}`
- `decksite/templates/home.mustache`: added `{{#subtitle}}<p class="subtitle">{{subtitle}}</p>{{/subtitle}}` below the section `<h2>` so the date can be surfaced as a subtitle instead
- `decksite/views/home.py`: added `'hide_date': True` and `'subtitle': dtutil.display_date(tournament_decks[0].active_date)` to the tournament deck table dict, hiding the column and showing the shared date below the heading

## Validation

- `uv run --frozen python dev.py lint` — passed (exit 0)
- `uv run --frozen python dev.py unit` — 687 passed, 1 skipped, 89 deselected

Fixes #12761

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8cd4064e-6d43-4f72-bad9-61a6ab459c40)
