### PR TITLE
Make archetypes-to-assign badge a real circle badge (#12715)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2573,6 +2573,9 @@ Notification Badges
 }
 
 .badge {
+    background-color: var(--red);
+    border-radius: 50%;
+    color: white;
     font-size: var(--table-font-size);
     height: 1.333em;
     line-height: var(--reading-line-height);


### PR DESCRIPTION
## What was wrong

The `.badge` span used to display the archetypes-to-assign count in the site nav had no background, so the number floated over menu items with no visual container — it didn't read as a notification badge.

## What changed

Three CSS properties were added to `.badge` in `shared_web/static/css/pd.css`:

- `background-color: var(--red)` — uses the site's existing red variable (which adapts for dark mode).
- `border-radius: 50%` — turns the already-square element (`height: 1.333em`, `min-width: 1.333em`) into a true circle.
- `color: white` — hardcoded white so text is always legible over the red background in both light and dark mode (using `var(--white)` would invert to near-black in dark mode).

No template or Python changes were needed.

## Validation

`uv run --frozen python dev.py lint` exits 0. No unit tests cover pure CSS; the badge rendering can be verified visually by loading the decksite with an admin account that has archetypes to assign.

Fixes #12715