### PR TITLE
Remove broken status.pennydreadfulmagic.com link from /about/ (#12714)

### DIFF
--- a/decksite/templates/aboutpdm.mustache
+++ b/decksite/templates/aboutpdm.mustache
@@ -1,7 +1,6 @@
 <article>
     <p>Penny Dreadful Magic is a site for everything to do with the <a href="{{about_url}}">Penny Dreadful Magic Online format</a>.</p>
     <p>Penny Dreadful Magic is run by the folks from <a class="external" href="https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/">Penny Dreadful Tools</a>. Feel free to <a class="external" href="https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools//issues">open a ticket</a> for a problem or feature request.</p>
-    <p><a class="external" href="https://status.pennydreadfulmagic.com/">Status</a></p>
     <p>{{_ This site is currently translated into:}} {{languages}}
     <br/>
     <a href="https://poeditor.com/join/project/sZ94JeTk1V">{{TT_HELP_TRANSLATE}}</a>


### PR DESCRIPTION
## What was wrong

The `/about/` page linked to `https://status.pennydreadfulmagic.com/` which has an SSL certificate error. The HTTP endpoint redirects to HTTPS but the HTTPS endpoint fails to connect, confirming the site is abandoned/broken.

## What changed

Removed the single `<p>` line containing the broken status link from `decksite/templates/aboutpdm.mustache` (line 4). No other changes.

## How it was validated

- Verified the site is unreachable via `curl -isk https://status.pennydreadfulmagic.com/` (no response) and HTTP redirects to the broken HTTPS endpoint
- `uv run --frozen python dev.py lint` passed on the touched file
- Unit tests were not run (no database available in this environment; lint is the minimum bar for a mustache-only change)

Fixes #12714