### PR TITLE
Add a one-click link to accept the machine-guessed archetype (#12712)

### DIFF
--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -14,11 +14,14 @@
             </thead>
             <tbody>
                 {{#queue}}
-                    <tr data-archetype-id="{{archetype_id}}">
+                    <tr>
                         <td class="contains-mana-bar">{{{colors_safe}}}</td>
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{source_url}}">{{source_name}}</a></td>
-                        <td><a href="{{archetype_url}}">{{archetype_name}}</a></td>
+                        <td>
+                            <a href="{{archetype_url}}">{{archetype_name}}</a>
+                            {{#archetype_id}}<a class="use-guess" title="Assign this deck to {{archetype_name}}" data-archetype_id="{{archetype_id}}">[✓]</a>{{/archetype_id}}
+                        </td>
                         <td class="n">
                             {{similarity}}
                             {{#show_add_rule_prompt}}

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -14,7 +14,7 @@
             </thead>
             <tbody>
                 {{#queue}}
-                    <tr>
+                    <tr data-archetype-id="{{archetype_id}}">
                         <td class="contains-mana-bar">{{{colors_safe}}}</td>
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{source_url}}">{{source_name}}</a></td>

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2397,6 +2397,11 @@ td.archetype-description {
     cursor: pointer;
 }
 
+/* Link to fill in the machine-guessed archetype on the "Edit Archetypes" page */
+.use-guess {
+    cursor: pointer;
+}
+
 /*
 
 News

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -14,6 +14,7 @@ PD.init = function() {
     PD.initTooltips();
     PD.initTypeahead();
     PD.initSearchShortcut();
+    PD.initArchetypeGuess();
     PD.initReassign();
     PD.initRuleForms();
     $("input[type=file]").on("change", PD.loadDeck).on("change", PD.toggleDrawDropdown);
@@ -252,6 +253,16 @@ PD.initSearchShortcut = function() {
             $(".typeahead").val("");
             $(".typeahead").focus();
             e.preventDefault();
+        }
+    });
+};
+
+PD.initArchetypeGuess = function() {
+    $("tr[data-archetype-id]").each(function() {
+        var archetypeId = $(this).data("archetype-id");
+        var select = $(this).find("select[name$='archetype_id']");
+        if (archetypeId && select.val() === "") {
+            select.val(archetypeId);
         }
     });
 };

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -14,7 +14,7 @@ PD.init = function() {
     PD.initTooltips();
     PD.initTypeahead();
     PD.initSearchShortcut();
-    PD.initArchetypeGuess();
+    PD.initUseGuess();
     PD.initReassign();
     PD.initRuleForms();
     $("input[type=file]").on("change", PD.loadDeck).on("change", PD.toggleDrawDropdown);
@@ -257,13 +257,10 @@ PD.initSearchShortcut = function() {
     });
 };
 
-PD.initArchetypeGuess = function() {
-    $("tr[data-archetype-id]").each(function() {
-        var archetypeId = $(this).data("archetype-id");
-        var select = $(this).find("select[name$='archetype_id']");
-        if (archetypeId && select.val() === "") {
-            select.val(archetypeId);
-        }
+PD.initUseGuess = function() {
+    $(".use-guess").click(function() {
+        $(this).closest("tr").find("select[name$='archetype_id']").val($(this).data("archetype_id"));
+        return false;
     });
 };
 


### PR DESCRIPTION
## What this does

On `/admin/archetypes`, each queue row shows the deck's current machine-guessed archetype in the **Current** column. There is now a small `[✓]` link next to it. Clicking it fills in that row's **Assign To** dropdown with that archetype; you still press **Assign** to submit.

Deliberately *not* done: pre-selecting the guess on page load, or any way to accept them all at once. The guesses are often wrong, and a pre-filled dropdown makes it far too easy to assign a bad archetype by just hitting Assign. This is only a shortcut for the case where you read the guess and agree with it, saving you from hunting the archetype down in a long dropdown.

## Changes

- **`decksite/templates/editarchetypes.mustache`** — the `[✓]` link in the Current column, rendered only when the deck actually has a guessed `archetype_id`.
- **`shared_web/static/js/pd.js`** — `PD.initUseGuess()`, called from `PD.init()`. On click it sets that row's `<select>` only, scoped via `closest("tr")`. No other row is touched.
- **`shared_web/static/css/pd.css`** — `cursor: pointer` for the link, matching the existing `.reassign` link on the Edit Rules page.

Decks matched by a *rule* are unaffected: the view still pre-selects the rule's archetype server-side, as before.

The first commit on this branch implemented the pre-select-everything version; the second commit replaces it with this one-at-a-time link.

## Validation

- Ran decksite against a local DB: `/admin/archetypes/` returns 200 and renders the link on the 9 of the 20 queued decks that have a guess, and on none of the rest.
- Confirmed the updated `pd.js` is served by the app.
- `dev.py lint` passes, and `eslint shared_web/static/js/pd.js` is clean.
- I did not script a browser to perform the click, so the handler itself is reviewed by eye rather than automated.

Fixes #12712

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3a5f43b9-7ef7-4389-8ff5-ad87ae1a90c9)
