### PR TITLE
Hide forbidden admin menu items from demimod users (#12709)

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -38,7 +38,10 @@ def admin_menu() -> Menu:
 @APP.route('/admin/')
 @auth.demimod_required
 def admin_home() -> wrappers.Response:
-    view = Admin(admin_menu())
+    menu = admin_menu()
+    if not session.get('admin'):
+        menu = Menu([item for item in menu if item.permission_required == 'demimod'])
+    view = Admin(menu)
     return view.response()
 
 @APP.route('/admin/aliases/')

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -47,6 +47,16 @@ def test_validate_card_names_canonicalizes_and_ignores_blank_lines(monkeypatch: 
     assert errors == ['Card not found: Not a Card']
 
 
+def test_admin_menu_hides_admin_only_items_from_demimod() -> None:
+    with APP.test_request_context('/admin/'):
+        with APP.test_request_context('/admin/', environ_base={'HTTP_HOST': 'localhost'}):
+            full_menu = admin.admin_menu()
+            demimod_items = [item for item in full_menu if item.permission_required == 'demimod']
+            admin_items = [item for item in full_menu if item.permission_required != 'demimod']
+            assert len(demimod_items) > 0, 'Expected at least one demimod item'
+            assert len(admin_items) > 0, 'Expected at least one admin-only item'
+
+
 def test_all_admin_routes_require_permission() -> None:
     unprotected_routes = sorted({
         rule.rule


### PR DESCRIPTION
## What was wrong

The `/admin/` landing page listed all admin menu items (including admin-only pages like Aliases, Matches, Prizes, Rotation, etc.) regardless of whether the logged-in user was a full admin or only a demimod. Demimods who clicked those links would be redirected to the unauthorized page, but they could still see and navigate to the URLs.

## What changed

In `admin_home()` (`decksite/controllers/admin.py`), the full menu is now filtered before being passed to the `Admin` view: if the session does not have `admin` truthy, only menu items with `permission_required == 'demimod'` are included. Full admins continue to see the complete list.

A test was added to `admin_test.py` to assert that `admin_menu()` contains both demimod and admin-only items, confirming the partitioning the filter relies on is correct.

## How it was validated

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit decksite/controllers/admin_test.py` — 688 passed, 1 skipped, all tests in the full unit suite green

Fixes #12709