### PR TITLE
Show quality score in metagame grid (#12708)

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -4,7 +4,7 @@ import titlecase
 from anytree import NodeMixin
 from anytree.iterators import PreOrderIter
 
-from decksite.data import deck, preaggregation, query
+from decksite.data import clauses, deck, preaggregation, query
 from decksite.database import db
 from magic.models import Competition
 from shared.container import Container
@@ -617,7 +617,8 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
             SUM(tournament_top8s) AS tournament_top8s,
             IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent,
             COUNT(*) OVER () AS total,
-            SUM(wins + losses + draws) / tc.total_matches AS meta_share
+            SUM(wins + losses + draws) / tc.total_matches AS meta_share,
+            {clauses.wilson_lower_bound_sql()} AS quality_score
         FROM
             archetype AS a
         LEFT JOIN

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2804,10 +2804,20 @@ Metagame
     text-align: right;
 }
 
-.metagame-grid .additional {
+/* Without this a smaller cell sits at the top of the row rather than on the same baseline as its taller neighbor. */
+.metagame-grid .baseline {
+    align-items: baseline;
+}
+
+.metagame-grid .additional, .metagame-grid .quality {
     color: var(--deemphasized-text);
     font-size: calc(12rem / 20);
     line-height: calc(15 / 12);
+}
+
+.metagame-grid .quality-star {
+    font-size: 1.7em; /* The star is about half height compared to the numbers at its natural size. */
+    line-height: 0; /* Don't mess up row spacing because the star is big. */
 }
 
 .metagame-grid .additional span {

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -48,7 +48,7 @@ const renderItem = (grid, archetype) => (
                 <span className={"additional"} title="Win-Loss Record">
                     {n(archetype.wins)}–{n(archetype.losses)}
                 </span>
-                {archetype.qualityScore != null && (
+                {typeof archetype.qualityScore === "number" && (
                     <span className={"additional"} title="Quality Score">
                         Q:{Number(archetype.qualityScore * 100).toFixed(1)}%
                     </span>

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -48,6 +48,11 @@ const renderItem = (grid, archetype) => (
                 <span className={"additional"} title="Win-Loss Record">
                     {n(archetype.wins)}–{n(archetype.losses)}
                 </span>
+                {archetype.qualityScore != null && (
+                    <span className={"additional"} title="Quality Score">
+                        Q:{Number(archetype.qualityScore * 100).toFixed(1)}%
+                    </span>
+                )}
             </div>
         </div>
         <div className="row flex-row">

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -39,21 +39,24 @@ const renderItem = (grid, archetype) => (
         <div className="row">
             <div className="colors" title="Deck Colors" dangerouslySetInnerHTML={{__html: archetype.colorsSafe}}></div>
         </div>
-        <div className="row">
+        <div className="row flex-row baseline">
             <div className="percentage-with-additional">
                 <span className={"percentage"} title="Win %">
                     {n(archetype.winPercent)}%
                 </span>
-                {" "}
-                <span className={"additional"} title="Win-Loss Record">
-                    {n(archetype.wins)}–{n(archetype.losses)}
-                </span>
-                {typeof archetype.qualityScore === "number" && (
-                    <span className={"additional"} title="Quality Score">
-                        Q:{Number(archetype.qualityScore * 100).toFixed(1)}%
+                <span className="additional">
+                    <span title="Win-Loss Record">
+                        {n(archetype.wins)}–{n(archetype.losses)}
                     </span>
-                )}
+                </span>
             </div>
+            {typeof archetype.qualityScore === "number" && (
+                <div className="cell r quality">
+                    <span title="Quality">
+                        <span className="quality-star">★</span>{Number(archetype.qualityScore * 100).toFixed(0)}
+                    </span>
+                </div>
+            )}
         </div>
         <div className="row flex-row">
             <div className="cell">


### PR DESCRIPTION
## What was wrong

The metagame grid already sorted archetypes by a Wilson lower-bound quality score, but that value was never returned to the frontend — it was only used in the `ORDER BY` clause. Users had no way to see the quality score that drives the default sort.

## What changed

**`decksite/data/archetype.py`** — imported `clauses` and added `{clauses.wilson_lower_bound_sql()} AS quality_score` to the `SELECT` list in `load_disjoint_archetypes()`. The field is camelized automatically by `return_camelized_json`, so it surfaces as `qualityScore` in the API response.

**`shared_web/static/js/metagamegrid.jsx`** — added a `Q:{value}%` span with `title="Quality Score"` adjacent to the existing win-% display, guarded by a null check so it degrades gracefully if the field is absent.

## Validation

- `uv run --frozen python dev.py lint` — all checks passed
- `uv run --frozen python dev.py unit` — 687 passed, 1 skipped, 89 deselected (full suite, no database-dependent tests affected)

Fixes #12708

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c253d43a-2ed9-4d79-9ef1-f399033c6a7a)
