### PR TITLE
Fix menu and submenu to scroll independently (#12666)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -799,11 +799,12 @@ nav {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    position: relative;
 }
 
 .menu {
     flex: 1;
-    position: relative;
+    overflow-y: auto;
 }
 
 .submenu {


### PR DESCRIPTION
## What was wrong

When the main menu (`.menu`) had many items and the user scrolled down, hovering over an item with a submenu would cause the submenu to appear at `top: 0` relative to `.menu` (its positioned ancestor via `position: relative`). Since the user had scrolled `.menu` downward, the submenu appeared off-screen above the visible area.

Additionally, `.menu` had no `overflow-y: auto`, so it couldn't scroll at all — the content would overflow the nav silently.

## What changed (`shared_web/static/css/pd.css`)

- **`nav`**: Added `position: relative`. This makes `nav` the containing block for the absolutely-positioned `.submenu`, anchoring the submenu to the full nav height (which does not scroll) rather than to `.menu`.
- **`.menu`**: Replaced `position: relative` with `overflow-y: auto`. The menu items can now scroll within `.menu`'s bounds without dragging the submenu with them.

The medium-width media query already sets `position: relative` on `nav`, so this change makes base styles consistent with that existing pattern.

## Validation

- `uv run --frozen python dev.py lint` — passed (exit 0)
- No unit tests cover CSS layout; the change is pure CSS with no Python logic path.

Fixes #12666

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6ca372bf-6511-4ad8-9d8b-85e1c2be0cc7)
