### PR TITLE
Add Escape key and close button to dismiss the popover menu (#12665)

### DIFF
--- a/decksite/templates/menu.mustache
+++ b/decksite/templates/menu.mustache
@@ -1,3 +1,4 @@
+<button class="close-menu" aria-label="Close menu">✕</button>
 <ul class="menu badges">
     {{#menu}}
         <li class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}">

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -959,6 +959,23 @@ nav.showing:has(.current ~ .submenu) {
     text-align: center;
 }
 
+.close-menu {
+    background: none;
+    border: none;
+    color: var(--color);
+    cursor: pointer;
+    display: none;
+    font-size: 1.5rem;
+    padding: 0.5rem 1rem;
+    position: absolute;
+    right: 0;
+    top: 0;
+}
+
+nav.showing .close-menu {
+    display: block;
+}
+
 .submenu .item {
     font-family: var(--main-text-font-family);
     font-size: 16px;

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -40,6 +40,15 @@ PD.initDismiss = function() {
     });
 };
 
+PD.closeMenu = function() {
+    document.querySelectorAll(".scrim").forEach((scrim) => {
+        scrim.classList.remove("showing");
+    });
+    document.querySelectorAll("nav").forEach((nav) => {
+        nav.classList.remove("showing");
+    });
+};
+
 PD.initMenu = function() {
     document.querySelectorAll(".hamburger").forEach((e) => {
         e.onclick = () => {
@@ -52,12 +61,15 @@ PD.initMenu = function() {
         };
     });
     document.querySelectorAll(".scrim").forEach((e) => {
-        e.onclick = () => {
-            e.classList.toggle("showing");
-            document.querySelectorAll("nav").forEach((nav) => {
-                nav.classList.toggle("showing");
-            });
-        };
+        e.onclick = PD.closeMenu;
+    });
+    document.querySelectorAll(".close-menu").forEach((e) => {
+        e.onclick = PD.closeMenu;
+    });
+    document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+            PD.closeMenu();
+        }
     });
     $(".contains-dropdown").hoverIntent({
         over: PD.onDropdownHover,


### PR DESCRIPTION
## What was wrong

The mobile popover nav menu could only be dismissed by clicking the scrim overlay or selecting a menu item — there was no keyboard shortcut and no explicit close button, making it awkward especially for keyboard users.

## What changed

- **`shared_web/static/js/pd.js`**: Extracted a `PD.closeMenu()` helper (removes `.showing` from all `.scrim` and `nav` elements). Wired it to the scrim click handler (replacing the toggle with a deterministic remove), to any `.close-menu` button click, and to a `document` `keydown` listener that fires on `Escape`.
- **`decksite/templates/menu.mustache`**: Added a `<button class="close-menu" aria-label="Close menu">✕</button>` at the top of the nav template.
- **`shared_web/static/css/pd.css`**: Styled `.close-menu` as a hidden absolute-positioned button that becomes visible (`display: block`) only when `nav.showing` is active, placing the ✕ in the top-right corner of the open drawer.

## Validation

- `uv run --frozen python dev.py lint` — passed (ruff: All checks passed)
- `uv run --frozen python dev.py unit` — 687 passed, 1 skipped (unrelated functional test)
- JS/CSS changes are not covered by the Python unit suite; manual inspection of the diff confirms correctness.

Fixes #12665

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/6635a6c5-8f3f-4446-8805-b26d4f6b83e4)
