### PR TITLE
Ease submenu transitions without hover gaps (#12664)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -851,8 +851,9 @@ nav, .menu, .submenu {
 
 .submenu {
     background: var(--background);
+    box-shadow: inset 1px 0 var(--border);
     font-size: 20px;
-    left: var(--main-menu-width);
+    left: calc(var(--main-menu-width) - 1px);
     position: absolute;
     top: 0;
 }
@@ -884,7 +885,7 @@ When you are in a middle width the main menu is always shown but the submenu is 
 */
 @media only screen and (max-width: 900px), only screen and (min-width: 1601px) {
     /* Expand nav width when hovering over a menu item with a submenu */
-    nav:has(li:hover > .item + .submenu) {
+    nav:has(li:hover > .item + .submenu), nav:has(li.submenu-open > .item + .submenu) {
         width: var(--full-menu-width);
         z-index: 4;
     }
@@ -915,17 +916,23 @@ When you are in a middle width the main menu is always shown but the submenu is 
     nav:has(li:hover > .item + .submenu) {
         width: var(--main-menu-width);
     }
-    nav li > .item + .submenu {
-        display: block;
-        opacity: 0;
-        pointer-events: none;
-        transition: opacity 0.2s ease;
-        width: var(--submenu-width);
-    }
-    nav li:hover > .item + .submenu {
-        opacity: 1;
-        pointer-events: auto;
-    }
+}
+
+/* Fade hover submenus at every width. Touch navigation does not sustain this hover state. */
+nav li > .item + .submenu {
+    display: block;
+    opacity: 0;
+    transition:
+        opacity 0.2s ease,
+        visibility 0s linear 0.2s;
+    visibility: hidden;
+    width: var(--submenu-width);
+}
+nav li.submenu-open > .item + .submenu {
+    opacity: 1;
+    transition-delay: 0s;
+    visibility: visible;
+    z-index: 5;
 }
 
 /* Once you get properly wide we just show the main menu and the submenu if there is one in the flow of the page. */
@@ -933,8 +940,10 @@ When you are in a middle width the main menu is always shown but the submenu is 
     nav:has(.current ~ .submenu) {
         width: var(--full-menu-width);
     }
-    .current + .submenu {
+    nav li > .current + .submenu {
         display: block;
+        opacity: 1;
+        visibility: visible;
         width: var(--submenu-width);
     }
 }
@@ -974,6 +983,8 @@ nav.showing .menu {
 
 nav.showing .current + .submenu {
     display: block;
+    opacity: 1;
+    visibility: visible;
     width: var(--submenu-width);
     z-index: 3;
 }

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -915,9 +915,16 @@ When you are in a middle width the main menu is always shown but the submenu is 
     nav:has(li:hover > .item + .submenu) {
         width: var(--main-menu-width);
     }
+    nav li > .item + .submenu {
+        display: block;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease;
+        width: var(--submenu-width);
+    }
     nav li:hover > .item + .submenu {
-        top: 0;
-        position: absolute;
+        opacity: 1;
+        pointer-events: auto;
     }
 }
 

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -78,7 +78,12 @@ PD.initMenu = function() {
         interval: 50,
         timeout: 250
     });
+    $(".menu > li").has(".submenu").hoverIntent({over: PD.onSubmenuHover, out: PD.onSubmenuLeave, interval: 50, timeout: 350});
 };
+PD.onSubmenuHover = function() {
+    $(this).addClass("submenu-open").siblings(".submenu-open").removeClass("submenu-open");
+};
+PD.onSubmenuLeave = function() { $(this).removeClass("submenu-open"); };
 
 PD.onDropdownHover = function() {
     if (window.matchMedia("only screen and (min-width: 641px)").matches) {


### PR DESCRIPTION
## What was wrong

Hover submenus appeared and disappeared instantly. The 1px divider between the main menu and submenu was also a dead hit-test strip, so crossing it could close the submenu, and diagonal movement through another menu row could switch or close the panel.

## What changed

- Fade hover submenus in and out over 200ms at every viewport width.
- Keep touch/current submenus visible normally in the hamburger drawer and wide layout.
- Use the existing hover-intent plugin with a 350ms leave grace period so diagonal movement into the submenu stays open.
- Draw the divider inside the submenu and overlap the menu edge by 1px, preserving the visible line while making that pixel part of the submenu hit area.
- Keep the nav expanded while its intent-managed submenu is open.

## Validation

- Actual-site Chromium browser checks at 900, 901, 1200, 1600, and 1601px.
- Diagonal hover routes and click targets for Metagame, League, Competitions, Resources, and About.
- Firefox 140 checks at 500, 652, 1200, and 1728px, including parking on the divider for 600ms.
- Touch/mobile emulation confirms the current submenu remains visible in the drawer.
- Full JavaScript lint passed.
- git diff --check passed.

Fixes #12664

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ab406b5c-00da-444f-8f75-87da4ddf5a1a)
