### PR TITLE
Silence duplicate-entry stack trace in /spoiler command (#12647)

### DIFF
--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Iterable, Sequence
 
 from magic import card, layout, mana, multiverse, seasons, whoosh_write
@@ -7,7 +8,7 @@ from magic.models import Card, Printing
 from shared import configuration, fetch_tools, guarantee
 from shared.container import Container
 from shared.database import sqlescape, sqllikeescape
-from shared.pd_exception import InvalidArgumentException, InvalidDataException, TooFewItemsException
+from shared.pd_exception import DatabaseException, InvalidArgumentException, InvalidDataException, TooFewItemsException
 
 # Primary public interface to the magic package. Call `oracle.init()` after setting up application context and before using any methods.
 
@@ -182,7 +183,13 @@ async def scryfall_import_async(name: str) -> bool:
         return False
     except InvalidDataException:
         print(f"Adding {sfcard['name']} to the database as we don't have it.")
-        await add_cards_and_update_async([sfcard])
+        try:
+            await add_cards_and_update_async([sfcard])
+        except DatabaseException as e:
+            if '1062' in str(e):
+                logging.warning(f"Card {sfcard['name']} was added by another process while we were importing it, ignoring duplicate.")
+                return False
+            raise
         return True
 
 def pd_rotation_changes(season_id: int) -> tuple[Sequence[Card], Sequence[Card]]:

--- a/magic/oracle_test.py
+++ b/magic/oracle_test.py
@@ -1,10 +1,11 @@
 from collections.abc import Iterable
+from unittest.mock import AsyncMock
 
 import pytest
 
 from magic import oracle, seasons
 from magic.models import Card, Printing
-from shared.pd_exception import InvalidDataException
+from shared.pd_exception import DatabaseException, InvalidDataException
 
 
 def test_legality() -> None:
@@ -119,6 +120,22 @@ def test_deck_sort_x_last() -> None:
     cards_by_name = {c.name: c for c in cards}
     assert oracle.deck_sort(cards_by_name['Ghitu Fire']) < oracle.deck_sort(cards_by_name['Flash of Insight'])
     assert oracle.deck_sort(cards_by_name['Ghitu Fire']) > oracle.deck_sort(cards_by_name['Frantic Search'])
+
+@pytest.mark.asyncio
+async def test_scryfall_import_async_handles_duplicate_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    sfcard = {'object': 'card', 'name': 'Waterlogged Teachings // Inundated Archive'}
+    monkeypatch.setattr('magic.oracle.fetch_tools.fetch_json_async', AsyncMock(return_value=sfcard))
+
+    def raise_invalid(name: str) -> str:
+        raise InvalidDataException('not found')
+    monkeypatch.setattr('magic.oracle.valid_name', raise_invalid)
+
+    duplicate_exc = DatabaseException("Failed to execute ... because of (1062, \"Duplicate entry 'x' for key 'oracle_id'\")")
+    monkeypatch.setattr('magic.oracle.add_cards_and_update_async', AsyncMock(side_effect=duplicate_exc))
+
+    result = await oracle.scryfall_import_async('Waterlogged Teachings')
+
+    assert result is False
 
 # Check that the list of legal cards is being fetched correctly.
 @pytest.mark.functional


### PR DESCRIPTION
## What was wrong

When a user ran `/spoiler` for a newly spoiled card (e.g. "Waterlogged Teachings // Inundated Archive"), there was a race condition: `valid_name()` found the card absent from the DB, so `scryfall_import_async` attempted to insert it via `add_cards_and_update_async`. If the bulk-data importer had inserted that card between those two calls, MySQL raised error 1062 (duplicate entry on `oracle_id`). This `DatabaseException` propagated all the way up to the Discord interaction handler and produced a large, user-visible stack trace in chat.

## What changed

In `magic/oracle.py:scryfall_import_async`, the call to `add_cards_and_update_async` is now wrapped in a `try/except DatabaseException`. If the exception message contains `'1062'` (MySQL duplicate entry), the function logs a `logging.warning` and returns `False` (treating it as "card already exists") instead of re-raising. Any other `DatabaseException` is still re-raised as before. A new `logging` import and `DatabaseException` import were added.

A unit test (`test_scryfall_import_async_handles_duplicate_entry`) was added to `magic/oracle_test.py` to cover this path using mocks — no live database required.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 688 passed, 1 skipped (full suite including the new test)

Fixes #12647

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/1d20ba3e-5677-42b7-bf2f-029653a78230)
