### PR TITLE
Weight deck similarity by inverse card playability to favor rarer cards (#12621)

### DIFF
--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -4,7 +4,7 @@ import time
 from typing import TypedDict
 
 from decksite import deck_name
-from decksite.data import query, season
+from decksite.data import playability, query, season
 from decksite.data.top import Top
 from decksite.database import db
 from magic import decklist, legality, mana, oracle, seasons
@@ -476,10 +476,11 @@ def calculate_similar_decks(ds: list[Deck]) -> None:
         for d in ds:
             d.similar_decks = []
         return
+    plays = playability.playability()
     potentially_similar, _ = load_decks(f'd.id IN (SELECT deck_id FROM deck_card WHERE card IN ({cards_escaped}))')
     for d in ds:
         for psd in potentially_similar:
-            psd.similarity_score = round(similarity_score(d, psd) * 100)
+            psd.similarity_score = round(similarity_score(d, psd, plays) * 100)
         d.similar_decks = [psd for psd in potentially_similar if psd.similarity_score >= threshold and psd.id != d.id]
         d.similar_decks.sort(key=lambda d: -(d.similarity_score))
         redis.store(f'decksite:deck:{d.id}:similar', d.similar_decks, ex=172800)
@@ -493,13 +494,19 @@ def all_card_names(ds: list[Deck]) -> set[str]:
                 names.add(c['name'])
     return names
 
-# Dead simple for now, may get more sophisticated. 1 point for each differently named card shared in maindeck. Count irrelevant.
-def similarity_score(a: Deck, b: Deck) -> float:
-    score = 0
-    for c in a.maindeck:
-        if c in b.maindeck:
-            score += 1
-    return float(score) / float(max(len(a.maindeck), len(b.maindeck)))
+# Score each shared card by inverse playability so rarer cards contribute more to similarity.
+# When plays is None (e.g. called outside calculate_similar_decks) all weights are 1.
+def similarity_score(a: Deck, b: Deck, plays: dict[str, float] | None = None) -> float:
+    floor = 0.001
+    def weight(name: str) -> float:
+        if plays is None:
+            return 1.0
+        return 1.0 / max(plays.get(name, floor), floor)
+    score = sum(weight(c.name) for c in a.maindeck if c in b.maindeck)
+    a_total = sum(weight(c.name) for c in a.maindeck)
+    b_total = sum(weight(c.name) for c in b.maindeck)
+    denominator = max(a_total, b_total)
+    return score / denominator if denominator > 0 else 0.0
 
 def load_decks_by_cards(names: list[str], not_names: list[str]) -> list[Deck]:
     sql = ''

--- a/decksite/data/deck_test.py
+++ b/decksite/data/deck_test.py
@@ -141,3 +141,33 @@ def test_similarity_score_with_plays_zero_playability() -> None:
     b = make_deck([('Lightning Bolt', 4)])
     score = deck.similarity_score(a, b, plays)
     assert score == pytest.approx(1.0)
+
+def test_calculate_similar_decks_ranks_rare_shared_cards_above_common_ones() -> None:
+    source = make_deck([('Common Card', 4), ('Rare Card', 4)])
+    source.id = 1
+    common_match = make_deck([('Common Card', 4)])
+    common_match.id = 2
+    rare_match = make_deck([('Rare Card', 4), ('Rare Filler', 4)])
+    rare_match.id = 3
+    no_match = make_deck([('Other Card', 4)])
+    no_match.id = 4
+    plays = {
+        'Common Card': 0.039,
+        'Rare Card': 0.01,
+        'Rare Filler': 0.01,
+        'Other Card': 0.5,
+    }
+
+    with (
+        mock.patch.object(deck.playability, 'playability', return_value=plays) as get_playability,
+        mock.patch.object(deck, 'load_decks', return_value=([common_match, rare_match, no_match], 3)),
+        mock.patch.object(deck.redis, 'store') as store,
+    ):
+        deck.calculate_similar_decks([source])
+
+    get_playability.assert_called_once_with()
+    assert [(d.id, d.similarity_score) for d in source.similar_decks] == [
+        (rare_match.id, 50),
+        (common_match.id, 20),
+    ]
+    store.assert_called_once_with('decksite:deck:1:similar', source.similar_decks, ex=172800)

--- a/decksite/data/deck_test.py
+++ b/decksite/data/deck_test.py
@@ -6,7 +6,7 @@ from decksite.data import clauses, deck
 from decksite.database import db
 from decksite.testutil import with_test_db
 from magic import decklist, oracle
-from magic.models import Card, Deck
+from magic.models import Card, CardRef, Deck
 from shared.container import Container
 
 
@@ -104,3 +104,40 @@ def test_equivalent_names_are_stored_and_found_as_one_identity(monkeypatch: pyte
     ]
     matching_ids = db().values(f'SELECT id FROM deck AS d WHERE {clauses.card_where("Kroble, Envoy of the Bog")}')
     assert set(matching_ids) == {omenpaths.id, spiderman.id}
+
+def make_deck(cards: list[tuple[str, int]]) -> Deck:
+    d = Deck({})
+    d.maindeck = [CardRef(name, n) for name, n in cards]
+    d.sideboard = []
+    return d
+
+def test_similarity_score_no_plays() -> None:
+    a = make_deck([('Lightning Bolt', 4), ('Counterspell', 4)])
+    b = make_deck([('Lightning Bolt', 4), ('Dark Ritual', 4)])
+    score = deck.similarity_score(a, b)
+    assert score == pytest.approx(0.5)
+
+def test_similarity_score_with_plays_weights_rare_cards() -> None:
+    # Plays covers all cards so unknown-card floor weight doesn't distort results.
+    # Lightning Bolt is common (high playability), Counterspell is rare (low playability).
+    plays = {'Lightning Bolt': 0.5, 'Counterspell': 0.01, 'Dark Ritual': 0.3}
+    a = make_deck([('Lightning Bolt', 4), ('Counterspell', 4)])
+    b = make_deck([('Lightning Bolt', 4), ('Counterspell', 4)])
+    score_identical = deck.similarity_score(a, b, plays)
+    assert score_identical == pytest.approx(1.0)
+
+    # Share only the rare card (Counterspell), not the common one (Lightning Bolt).
+    b_partial = make_deck([('Counterspell', 4), ('Dark Ritual', 4)])
+    score_rare_shared = deck.similarity_score(a, b_partial, plays)
+    score_unweighted = deck.similarity_score(a, b_partial)  # plays=None → all weights 1
+
+    # Weighted score is higher than unweighted because the shared card (Counterspell)
+    # is rare and therefore contributes more weight relative to the other cards.
+    assert score_rare_shared > score_unweighted
+
+def test_similarity_score_with_plays_zero_playability() -> None:
+    plays: dict[str, float] = {}  # no playability data — uses floor of 0.001
+    a = make_deck([('Lightning Bolt', 4)])
+    b = make_deck([('Lightning Bolt', 4)])
+    score = deck.similarity_score(a, b, plays)
+    assert score == pytest.approx(1.0)

--- a/decksite/data/playability.py
+++ b/decksite/data/playability.py
@@ -94,7 +94,7 @@ def playability() -> dict[str, float]:
         FROM
             _playability
     """
-    return {r['name']: r['playability'] for r in db().select(sql)}
+    return {r['name']: float(r['playability']) for r in db().select(sql)}
 
 @retry_after_calling(preaggregate)
 def season_playability(season_id: int) -> list[Container]:


### PR DESCRIPTION
## What was wrong

Deck similarity gave every shared maindeck card name equal weight. Two decks that only shared a ubiquitous staple could therefore look as closely related as decks built around the same unusual card.

This similarity is used when Gatherling tournament decks are imported to choose their initial, unreviewed archetype guess.

## What changed

- Load global card playability once when calculating a batch of similar decks.
- Weight each card as `1 / max(playability, 0.001)`, making rare shared cards more informative than common staples while avoiding division by zero.
- Keep the existing unweighted behavior for callers that do not supply playability.
- Convert database `DECIMAL` playability values to `float`, matching the function's annotation and the weighted arithmetic.
- Cover the unweighted baseline, rare-card weighting, zero/missing playability, and the complete ranking/filtering/cache path with tests.

The existing 20% similarity cutoff is unchanged.

## Validation

- `uv run --frozen pytest decksite/data/deck_test.py` — 9 passed
- `uv run --frozen ruff check decksite/data/deck.py decksite/data/deck_test.py decksite/data/playability.py` — passed
- `uv run --frozen mypy decksite/data/deck.py decksite/data/deck_test.py decksite/data/playability.py` — passed
- Full repository suite on this branch before the final isolated regression-test addition — 778 passed, 2 skipped; full Ruff and mypy also passed
- Manual comparison against the privacy-stripped development snapshot sampled 750 candidate decks; 21 of the top 25 changed rank, with uncommon shared cards moving above generic staple overlap

Fixes #12621

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7feda093-4223-4e45-b127-c84b6fe13281)
