### PR TITLE
Fix colors column sort detection on /admin/archetypes (#12618)

### DIFF
--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -131,7 +131,7 @@ PD.initTables = function() {
     $.tablesorter.addParser({
         "id": "colors",
         "is": function(_s, _table, _td, $td) {
-            return $td.find("span.mana").length > 0;
+            return $td.hasClass("contains-mana-bar") || $td.find("span.mana").length > 0;
         },
         "format": function(_s, _table, td) {
             var i,


### PR DESCRIPTION
## What was wrong

The `colors` tablesorter parser in `shared_web/static/js/pd.js` used `$td.find('span.mana').length > 0` to auto-detect whether a column should be sorted by color. However, `colors_html()` in `decksite/prepare.py` only emits a bare `span.mana` element for colorless decks (when `total == 0`). Colored decks get `span.mana-W`, `span.mana-U`, etc. — never a plain `span.mana`. This meant the parser's `is()` function returned `false` for any row with a colored deck, so tablesorter would not select the colors parser for the column, breaking color-based sorting on `/admin/archetypes`.

## What changed

`shared_web/static/js/pd.js` line 134: the `is` function now also checks `$td.hasClass('contains-mana-bar')`. The template (`decksite/templates/editarchetypes.mustache:18`) always sets this class on the colors `<td>`, making detection reliable regardless of the mana composition of individual rows.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 687 passed, 1 skipped (18.97s)

Fixes #12618