### PR TITLE
Show archetype description tooltips on hover in /admin/archetypes queue (#12617)

### DIFF
--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -19,7 +19,7 @@
                         <td><a href="{{url}}" title="{{decklist}}">{{name}} ({{id}})</a></td>
                         <td><a href="{{source_url}}">{{source_name}}</a></td>
                         <td>
-                            <a href="{{archetype_url}}">{{archetype_name}}</a>
+                            <a href="{{archetype_url}}" title="{{archetype_description}}">{{archetype_name}}</a>
                             {{#archetype_id}}<a class="use-guess" title="Assign this deck to {{archetype_name}}" data-archetype_id="{{archetype_id}}">[✓]</a>{{/archetype_id}}
                         </td>
                         <td class="n">
@@ -28,7 +28,7 @@
                                 <span class="add-rule-prompt"><a title="This deck has been played more than once, create a rule?" href="{{edit_rules_url}}">[+]</a></span>
                             {{/show_add_rule_prompt}}
                         </td>
-                        <td><a href="{{rule_archetype_url}}">{{rule_archetype_name}}</a></td>
+                        <td><a href="{{rule_archetype_url}}" title="{{rule_archetype_description}}">{{rule_archetype_name}}</a></td>
                         <td>
                             <input type="hidden" name="deck_id" value="{{id}}">
                             {{> archetypedropdown}}

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -15,11 +15,14 @@ class EditArchetypes(View):
         self.queue = ds
         deck.load_queue_similarity(self.queue)
         rule.apply_rules_to_decks(self.queue)
+        archetype_descriptions = {a.id: a.description for a in archetypes}
         for d in self.queue:
             prepare.prepare_deck(d)
             d.archetype_url = url_for('.archetype', archetype_id=d.archetype_name)
+            d.archetype_description = archetype_descriptions.get(d.get('archetype_id'), '')
             if d.get('rule_archetype_id'):
                 d.rule_archetype_url = url_for('.archetype', archetype_id=d.rule_archetype_name)
+                d.rule_archetype_description = archetype_descriptions.get(d.rule_archetype_id, '')
                 d.archetypes = []
                 for a in self.archetypes:
                     if a.id == d.rule_archetype_id:


### PR DESCRIPTION
## What was wrong

In `/admin/archetypes`, the "Current" and "Matches Rule" columns showed archetype names as links but gave no additional context on hover, making similar archetypes harder to distinguish while reviewing the queue.

## What changed

- Build an archetype ID-to-description lookup from the archetypes already loaded by `EditArchetypes`.
- Attach the current and rule-matched archetype descriptions to each queued deck.
- Render those descriptions as browser-native tooltips on the corresponding archetype links.
- Preserve the current-archetype quick-assign `[✓]` control added on `master`.
- Fall back to an empty tooltip when an archetype ID has no matching description.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py mypy` — passed across 361 source files
- `uv run --frozen pytest` — 807 passed, 2 skipped
- Browser-tested `/admin/archetypes/` against the stripped development snapshot, including both tooltip columns and rows with missing descriptions

Fixes #12617

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ef8fe13b-279d-40f6-b413-bb300486bf43)
