### PR TITLE
Fix close button placement and font coverage (#12665)

### DIFF
--- a/maintenance/fonts.py
+++ b/maintenance/fonts.py
@@ -201,7 +201,7 @@ def subset_font(font: TTFont, graphemes: set[str]) -> TTFont:
 
 
 def find_base_graphemes() -> set[str]:
-    return set('①②③④⑤⑥⑦⑧⑯Ⓣ⇅⊕⸺▪🐞🚫🏆📰💻▾△🛈✅☐☑⚔🏅☰🏠☼🌙✨')
+    return set('①②③④⑤⑥⑦⑧⑯Ⓣ⇅⊕⸺▪🐞🚫🏆📰💻▾△🛈✅☐☑⚔🏅☰🏠☼🌙✨✕')
 
 def encode(font: TTFont) -> str:
     _, tmp_in = tempfile.mkstemp()

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -939,6 +939,7 @@ nav.showing {
 
 nav.showing .menu {
     display: flex;
+    padding-top: 48px; /* Leave room for the close button so it doesn't sit on top of the first menu item. */
     width: var(--main-menu-width);
 }
 
@@ -962,14 +963,20 @@ nav.showing:has(.current ~ .submenu) {
 .close-menu {
     background: none;
     border: none;
-    color: var(--color);
+    color: var(--text);
     cursor: pointer;
     display: none;
-    font-size: 1.5rem;
-    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    left: 0; /* Pin to the main menu column, not the right of the nav, which is wider when a submenu is showing. */
+    line-height: 1;
+    margin: 0; /* Undo the form control margin and max-width that all buttons get at narrow widths. */
+    max-width: none;
+    padding: 12px;
     position: absolute;
-    right: 0;
+    text-align: left;
     top: 0;
+    width: var(--main-menu-width);
+    z-index: 1; /* .menu is position: relative and comes after this in the html so otherwise it paints over the button. */
 }
 
 nav.showing .close-menu {


### PR DESCRIPTION
Follow-up to #12665. The ✕ that was added to dismiss the popover menu was invisible and, where you could find it, clicking it navigated to Home instead of closing the menu.

## What was wrong

- `.menu` is `position: relative` and comes after the button in the html, so it painted over the button. Every point inside the button's box hit-tested to the Home menu item, and `.icon.home` has an opaque background, so the glyph was hidden underneath it too.
- The narrow-width form control rule (`button, main input, select, textarea`) gives every button `max-width: 80%` and a top margin, which was silently resizing and offsetting it.
- It was pinned to the right edge of the nav, which is 360px rather than 120px wide on pages where a submenu is showing, so it drifted over the submenu.
- `color: var(--color)` — that variable doesn't exist, so the declaration was invalid and the button just inherited its colour. Now `var(--text)`.
- ✕ (U+2715) wasn't in `find_base_graphemes()`, so it wasn't in `symbols.woff2` and fell back to a system font — fine on macOS, tofu elsewhere. Added, and the font rebuilt.

## Now

The button is pinned to the main menu column with a `z-index` so it paints above `.menu`, `.menu` gets top padding so the two don't overlap, and it sits small and left-aligned at the top of the drawer rather than competing with the menu items.

## Testing

Manual, at ≤900px (above 901px the hamburger is hidden and none of this is reachable). On both the 120px drawer and the 360px submenu drawer: open with ☰, then dismiss with Escape, with the ✕, and by clicking the scrim, re-opening with ☰ after each to confirm the state doesn't get stuck.

Not covered: logsite has its own `menu.mustache` and shares this css and js, so it gets Escape and scrim-click but no ✕ button.