### PR TITLE
Even out the seasons grid on player pages

### DIFF
--- a/decksite/templates/person.mustache
+++ b/decksite/templates/person.mustache
@@ -46,10 +46,12 @@
 {{/has_decks}}
 <section>
     <h2>Seasons</h2>
-    {{#seasons_active}}
-        {{#url}}<a href="{{url}}">{{/url}}<i title="Season {{season_id}}" class="ss {{className}}"></i>{{#url}}</a>{{/url}}
-        {{#edge}}<br>{{/edge}}
-    {{/seasons_active}}
+    <p class="season-grid" style="--season-grid-columns: {{seasons_grid_columns}}">
+        {{#seasons_active}}
+            {{#url}}<a class="season-icon-link" href="{{url}}" title="Season {{season_id}}"><i class="ss {{className}}"></i></a>{{/url}}
+            {{^url}}<span class="season-icon-link" title="Season {{season_id}}"><i class="ss {{className}}"></i></span>{{/url}}
+        {{/seasons_active}}
+    </p>
 </section>
 {{#has_unique_cards}}
     <section class="card-lists">

--- a/decksite/views/person.py
+++ b/decksite/views/person.py
@@ -90,7 +90,7 @@ class Person(View):
     def setup_active_seasons(self, seasons_active: Sequence[int]) -> None:
         all_seasons = self.all_seasons()[1:]  # remove "all time" which is not shown here
         total_seasons = len(all_seasons)
-        cube_side_length = math.ceil(math.sqrt(total_seasons))
+        self.seasons_grid_columns = math.ceil(math.sqrt(total_seasons))  # Lay the seasons out in a square.
         for i, setcode in enumerate([s.get('code') for s in all_seasons]):
             season_id = total_seasons - i
             if season_id > seasons.current_season_num():
@@ -104,6 +104,5 @@ class Person(View):
                 'season_id': season_id,
                 'className': class_name,
                 'url': url_for('seasons.person', person_id=self.person.id, season_id=season_id) if active else '',
-                'edge': (i + 1) % cube_side_length == 0,
             }
             self.seasons_active.append(season)

--- a/decksite/views/person_test.py
+++ b/decksite/views/person_test.py
@@ -30,3 +30,18 @@ def test_long_trailblazer_card_list_uses_disclosure_link() -> None:
     assert '<a class="trailblazer-card-list-toggle"' in html
     assert '>Show all 134…</a>' in html
     assert '<button class="trailblazer-card-list-toggle"' not in html
+
+def test_seasons_grid_gives_every_season_a_cell() -> None:
+    with APP.test_request_context('/'):
+        html = template.render_name('person', {
+            'seasons_grid_columns': 7,
+            'seasons_active': [
+                {'season_id': 2, 'className': 'ss-kld season-icon', 'url': '/seasons/2/'},
+                {'season_id': 1, 'className': 'ss-emn season-icon inactive', 'url': ''},
+            ],
+        })
+
+    assert '<p class="season-grid" style="--season-grid-columns: 7">' in html
+    assert '<a class="season-icon-link" href="/seasons/2/" title="Season 2"><i class="ss ss-kld season-icon"></i></a>' in html
+    assert '<span class="season-icon-link" title="Season 1"><i class="ss ss-emn season-icon inactive"></i></span>' in html
+    assert '<br>' not in html

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2528,11 +2528,14 @@ Season Symbols
     white-space: nowrap;
 }
 
-.ss-grid .season-icon-link {
+.ss-grid .season-icon-link, .season-grid .season-icon-link {
     border-radius: var(--text-rounded-corners);
+    line-height: var(--table-line-height);
+}
+
+.ss-grid .season-icon-link {
     display: inline-block;
     justify-self: start;
-    line-height: var(--table-line-height);
     margin-right: 0.317rem;
     padding: 0.178em 0.317rem;
 }
@@ -2541,7 +2544,7 @@ Season Symbols
     margin-right: 0;
 }
 
-main .ss-grid a.season-icon-link:hover {
+main .ss-grid a.season-icon-link:hover, main .season-grid a.season-icon-link:hover {
     background-color: var(--highlight);
 }
 
@@ -2549,9 +2552,31 @@ main .ss-grid a.season-icon-link:hover {
     color: var(--current-season-icon);
 }
 
+/* The legality list on card and deck pages, where each icon is followed by its season number. */
 .ss-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
+}
+
+/* The seasons played list on player pages. One square cell per season, however wide the symbol is. */
+.season-grid {
+    display: grid;
+    gap: 0.178rem;
+    grid-template-columns: repeat(var(--season-grid-columns, 7), minmax(1.777rem, max-content));
+    justify-content: start;
+}
+
+.season-grid .season-icon-link {
+    align-items: center;
+    box-sizing: border-box; /* So the padding doesn't push the cells past their minimum size. */
+    display: flex;
+    justify-content: center;
+    min-height: 1.777rem;
+    padding: 0 0.238rem;
+}
+
+.season-grid .season-icon, .season-grid .season-icon::before {
+    margin-right: 0; /* These are centered in a cell of their own, not followed by text. */
 }
 
 .ss-num {


### PR DESCRIPTION
The played-seasons grid on player pages had each icon as a bare inline `<i>` separated by `<br>`, so the hover highlight was just the line box. Keyrune's `.ss::before` adds a `margin-right` and a `vertical-align` nudge, which pushed the glyph off-centre inside that box — hence the odd shapes with the icon in a corner.

Lay the seasons out in a real grid instead: one square cell per season, icon centred, in the same spirit as the legality grid on card pages (#12708-era work). Unplayed seasons get the same cell as played ones, so columns line up whether or not the icon is a link. The column count still comes from the view (`ceil(sqrt(n))`, 7 today), passed through as a `--season-grid-columns` custom property instead of counting `<br>`s.

The card-page legality grid is unchanged. I tried sharing one container class, but that list has season numbers next to each icon and centring them in max-content columns made the numbers ragged. The two grids share `.season-icon-link` and the hover rule and differ only in layout.

Verified visually against the real `pd.css` in light and dark mode. Added `test_seasons_grid_gives_every_season_a_cell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)