### PR TITLE
Tone down the archetypes-to-tag badge

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -588,6 +588,10 @@ Color attributes are mostly found with their related structural elements in this
     --tertiary-background: var(--light-gray);
     --tertiary-text: var(--black);
 
+    /* Notification badges. The page colors inverted: the same ink the menu is drawn in, so it stands out against the menu without introducing a color, and the count reads at full text contrast. */
+    --badge-background: var(--text);
+    --badge-text: var(--background);
+
     /* Colors of Magic (avoid using these to represent anything else). */
     --w-mana: #fffcda;
     --u-mana: #ace2fa;
@@ -2573,26 +2577,30 @@ Notification Badges
     position: relative;
 }
 
+/*
+    Don't center this with flexbox. jQuery show() puts an inline display on the badge when it reveals it to a mod,
+    which beats anything we say here, so line-height (which survives being blockified by position: absolute) does the centering.
+*/
 .badge {
-    background-color: var(--red);
-    border-radius: 50%;
-    color: white;
-    font-size: var(--table-font-size);
-    height: 1.333em;
-    line-height: var(--reading-line-height);
-    min-width: 1.333em;
-    padding: 0;
+    background-color: var(--badge-background);
+    border-radius: 0.85em; /* Half the height, so one or two digits is a circle and a rare three-digit count is a tidy pill rather than spilling out of one. */
+    box-sizing: border-box; /* So the min-width is the whole circle, padding included. */
+    color: var(--badge-text);
+    font-size: 0.6rem; /* Smaller than the smallest text token. A badge hangs off an icon so it has to read as smaller than one. */
+    height: 1.7em;
+    line-height: 1.7em; /* Equal to the height so the number sits in the middle of the circle. */
+    min-width: 1.7em; /* Equal to the height so one or two digits is a circle. */
+    padding: 0 0.15em; /* Narrow enough that two digits still fit within the min-width, wide enough that three don't touch the sides. */
     position: absolute;
-    right: 1.333rem;
+    right: 1.5rem; /* With the top, hangs the badge off the top-right corner of the menu icon rather than floating away from it. */
     text-align: center;
-    top: 8px;
+    top: 13px;
 }
 
-@media only screen and (max-width: 640px) {
-    .badge {
-        right: 0.75em;
-        top: 0.75em;
-    }
+/* Menu links have padding, and links are oldstyle-nums where digits sit at differing heights. Both push the count off-center in its circle. */
+.badge a {
+    font-variant-numeric: normal;
+    padding: 0;
 }
 
 /*


### PR DESCRIPTION
The mod/demimod archetypes-to-tag count on the Metagame menu item was a loud red circle. This draws it in the menu's own ink instead, and fixes what was wrong with it besides the color.

| before | after (light) | after (dark) |
|---|---|---|
| loud red circle, count sitting high, floating clear of the icon | acajou disc, snow numerals, hung off the triangle's corner | silver disc, night numerals |

### The count was never centred

`$(".admin").show()` writes an inline `display: inline` onto the badge when it reveals it to a mod. An inline style beats anything the stylesheet says, so flexbox centring could not apply — `position: absolute` then blockified it and `line-height: 1` parked the digits at the top of the box. `line-height` equal to the height survives that and does the centring. Measured against the circle's centre, ink bounding box vs geometric centre:

| count | before | after |
|---|---|---|
| 5 | 22.0% high | 0.4% |
| 80 | 22.3% high | 0.0% |
| 137 | 22.5% high | 0.7% |

### It was not actually a circle

Width grew with the digit count while `border-radius: 50%` followed along, so two digits rendered an oval. Width is now pinned to the height via `min-width`, with padding narrow enough that two digits stay inside it. A three-digit count becomes a short pill rather than spilling out of the circle.

### It was bigger than the icon it belongs to, and detached from it

The `△` glyph draws only 16 x 16px of ink inside its 32px box, while the badge was ~25px sitting 11px clear of it. It is now 12px type in a 20.4px disc hung off the icon's top-right corner.

### The count did not meet AA

Acajou on Spanish gray is **4.40:1**, under the 4.5:1 floor for text this size, and the old `color: white` was a literal rather than a token so it stayed white in dark mode. No gray in the palette carries dark text at AA — Acajou on Isabelline passes at 10.8:1 but is too close to the menu behind it to read as a badge. So the fill inverts:

```css
--badge-background: var(--text);       /* Acajou / Silver */
--badge-text: var(--background);       /* Snow / Night */
```

**11.91:1** in light mode, **12.51:1** in dark — the site's own body-text contrast. No new color: it is the same ink the menu text is already drawn in, and both aliases flip with the palette rather than needing a dark-mode override.

### Narrow screens

Dropped the `max-width: 640px` offsets. The hamburger drawer uses the same 120px menu column as the wide-screen strip, so they only moved the badge back off the icon.

### Testing

Rendered against the real stylesheet at 1000px wide (the badge's own media query means anything narrower silently tests the drawer rules instead), with the inline `display` the JS applies, in both themes, at one, two and three digits. Contrast ratios computed from the palette's OKLCH values and confirmed against sampled pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f9f40591-dd3b-4677-a0b4-508d26223a45)
