### PR TITLE
Stop split card pages redirecting to themselves forever

### DIFF
--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -1,3 +1,4 @@
+import re
 import urllib.parse
 
 from flask import redirect, request, url_for
@@ -81,13 +82,24 @@ def card(name: str, deck_type: str | None = None) -> str | wrappers.Response:
         canonical_name = parse_card_name(name)
         c = cs.load_card(canonical_name, tournament_only=tournament_only, season_id=get_season_id())
         alternate_name = oracle.matching_official_alternate_name(c, submitted_name)
-        if submitted_name != canonical_name and alternate_name is None:
+        if not is_canonical_url_name(submitted_name, canonical_name) and alternate_name is None:
             assert request.endpoint is not None
             return redirect(url_for(request.endpoint, name=canonical_name, deck_type=deck_type))
         view = Card(c, tournament_only, alternate_name)
         return view.page()
     except InvalidDataException as e:
         raise DoesNotExistException(e) from e
+
+def is_canonical_url_name(submitted_name: str, canonical_name: str) -> bool:
+    """Whether the submitted name already gets you as close to the canonical URL as a URL can get.
+
+    The proxies in front of us merge repeated slashes, so `/cards/Bedeck // Bedazzle/` arrives here as
+    `Bedeck / Bedazzle`. Redirecting to the double-slashed URL would only get it merged again, forever.
+    """
+    return merge_slashes(submitted_name) == merge_slashes(canonical_name)
+
+def merge_slashes(name: str) -> str:
+    return re.sub(r'\s*/+\s*', '/', name)
 
 def parse_card_name(name: str) -> str:
     return oracle.valid_name(decode_card_name(name))

--- a/decksite/controllers/metagame_test.py
+++ b/decksite/controllers/metagame_test.py
@@ -90,3 +90,40 @@ def test_alias_card_page_redirect_preserves_the_season(monkeypatch: pytest.Monke
 
     assert response.status_code == 302
     assert response.location == '/seasons/5/cards/Origin%20of%20Spider-Man/tournament/'
+
+
+def test_split_cards_do_not_redirect_when_the_proxy_has_merged_the_slashes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The proxies in front of us merge `//` into `/`, so redirecting to the canonical spelling loops forever.
+    monkeypatch.setattr(
+        metagame.oracle,
+        'valid_name',
+        lambda name: 'Bedeck // Bedazzle' if name in ('Bedeck / Bedazzle', 'Bedeck // Bedazzle') else name,
+    )
+    monkeypatch.setattr(metagame.cs, 'load_card', lambda *_args, **_kwargs: Card({'name': 'Bedeck // Bedazzle'}))
+
+    class FakeCardView:
+        def __init__(self, _card: object, _tournament_only: bool, alternate_name: str | None) -> None:
+            assert alternate_name is None
+
+        def page(self) -> str:
+            return 'split card page'
+
+    monkeypatch.setattr(metagame, 'Card', FakeCardView)
+    with APP.test_request_context('/cards/Bedeck%20/%20Bedazzle/'):
+        response = cast(Any, metagame.card).__wrapped__(name='Bedeck / Bedazzle')
+
+    assert response == 'split card page'
+
+
+@pytest.mark.parametrize(
+    ('submitted', 'canonical', 'expected'),
+    [
+        ('Bedeck / Bedazzle', 'Bedeck // Bedazzle', True),
+        ('Bedeck // Bedazzle', 'Bedeck // Bedazzle', True),
+        ('Bedeck//Bedazzle', 'Bedeck // Bedazzle', True),
+        ('Origin of Spiderman', 'Origin of Spider-Man', False),
+        ('Fire / Ice', 'Bedeck // Bedazzle', False),
+    ],
+)
+def test_is_canonical_url_name(submitted: str, canonical: str, expected: bool) -> None:
+    assert metagame.is_canonical_url_name(submitted, canonical) == expected


### PR DESCRIPTION
Fixes the `ERR_TOO_MANY_REDIRECTS` on every split card page, e.g. https://pennydreadfulmagic.com/cards/Bedeck%20//%20Bedazzle/

## Cause

8b9596e3 added a redirect from alias card names to the canonical page:

```python
if submitted_name != canonical_name and alternate_name is None:
    return redirect(url_for(request.endpoint, name=canonical_name, deck_type=deck_type))
```

The proxies in front of decksite merge repeated slashes in the path, so `/cards/Bedeck%20//%20Bedazzle/` reaches Flask as `Bedeck / Bedazzle`. That isn't `==` the canonical `Bedeck // Bedazzle`, so we redirect to the double-slashed URL, which gets merged straight back. Infinite loop, on every split card, from every card link on the site.

In production before this change:

```
/cards/Bedeck%20//%20Bedazzle/ -> 302 https://pennydreadfulmagic.com/cards/Bedeck%20//%20Bedazzle/   (to itself)
/cards/Fire%20//%20Ice/        -> 302 https://pennydreadfulmagic.com/cards/Fire%20//%20Ice/
//cards/Island/                -> 200 with no 308, confirming the merge happens upstream, not in werkzeug
```

## Fix

Only redirect when the difference is something a URL can actually express — treat a slash-only difference as already canonical.

## Verification

Ran the dev server against real card data:

| path | before | after |
| --- | --- | --- |
| `/cards/Bedeck%20/%20Bedazzle/` (what the proxy delivers) | 302 → `…//…`, loops | 200 |
| `/cards/Bedeck%20//%20Bedazzle/` | 200 | 200 |
| `/cards/Fire%20/%20Ice/` | 302, loops | 200 |
| `/cards/Bedeck%20/%20Bedazzle/tournament/` | 302, loops | 200 |
| `/cards/island/` | 302 → `/cards/Island/` | 302 → `/cards/Island/` |

Alias redirects (`Origin of Spiderman` → `Origin of Spider-Man`), case redirects and season preservation are unchanged. Added a test for the merged-slash request path plus a parametrized unit test of the comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c665dc02-7c74-49e6-a753-e964b78d3144)
