### PR TITLE
Warn when Decksite card data is stale

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -18,6 +18,7 @@ from decksite.data.achievements import Achievement
 from decksite.data.clauses import DEFAULT_GRID_PAGE_SIZE, DEFAULT_LIVE_TABLE_PAGE_SIZE
 from decksite.prepare import colors_html, prepare_archetypes, prepare_cards, prepare_decks, prepare_leaderboard, prepare_matches, prepare_people
 from decksite.views import DeckEmbed
+from magic import database as magic_database
 from magic import image_fetcher, layout, oracle, seasons, tournaments
 from magic.colors import find_colors
 from magic.models import Card, Deck
@@ -697,6 +698,7 @@ def hide_intro() -> Response:
 @auth.load_person
 def person_status() -> Response:
     username = auth.mtgo_username()
+    stale_card_information_age = magic_database.stale_card_information_age()
     r = {
         'mtgo_username': username,
         'discord_id': auth.discord_id(),
@@ -704,6 +706,7 @@ def person_status() -> Response:
         'demimod': session.get('demimod', False),
         'hide_intro': request.cookies.get('hide_intro', False) or auth.hide_intro() or username or auth.discord_id(),
         'in_guild': session.get('in_guild', False),
+        'card_information_warning': f'Card data last updated {dtutil.display_time(stale_card_information_age.total_seconds(), 1)} ago' if stale_card_information_age is not None else '',
     }
     if username:
         d = guarantee_at_most_one_or_retire(league.active_decks_by(username))

--- a/decksite/controllers/api_test.py
+++ b/decksite/controllers/api_test.py
@@ -1,0 +1,28 @@
+import json
+from typing import Any, cast
+
+import pytest
+
+from decksite.controllers import api
+from decksite.main import APP
+
+
+def test_status_includes_stale_card_information_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api.magic_database, 'stale_card_information_age', lambda: api.datetime.timedelta(days=4))
+    monkeypatch.setattr(api.league, 'active_league', lambda: None)
+
+    with APP.test_request_context('/api/status'):
+        response = cast(Any, api.person_status).__wrapped__()
+
+    data = json.loads(response.get_data(as_text=True))
+    assert data['card_information_warning'] == 'Card data last updated 4 days ago'
+
+def test_status_omits_recent_card_information_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api.magic_database, 'stale_card_information_age', lambda: None)
+    monkeypatch.setattr(api.league, 'active_league', lambda: None)
+
+    with APP.test_request_context('/api/status'):
+        response = cast(Any, api.person_status).__wrapped__()
+
+    data = json.loads(response.get_data(as_text=True))
+    assert data['card_information_warning'] == ''

--- a/decksite/templates/header.mustache
+++ b/decksite/templates/header.mustache
@@ -39,6 +39,7 @@
                     <input class="typeahead" type="text" placeholder="Search">
                 </div>
             </header>
+            <div class="card-information-warning" role="status" hidden></div>
             <main>
                 {{> intro}}
                 {{#notice_html}}

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -27,7 +27,6 @@ if TYPE_CHECKING:
 
 DEFAULT_CARDS_SHOWN = 4
 MAX_CARDS_SHOWN = 10
-MAX_CARD_INFORMATION_AGE = datetime.timedelta(days=2)
 HELP_GROUPS: set[str] = set()
 
 @lazy_property
@@ -157,8 +156,8 @@ async def post_nothing(channel: PrefixedContext | InteractionContext | TYPE_MESS
     await message.add_reaction('❎')
 
 def stale_card_information_warning() -> str:
-    age = dtutil.now() - database.last_updated()
-    if age > MAX_CARD_INFORMATION_AGE:
+    age = database.stale_card_information_age()
+    if age is not None:
         return f'\nWARNING: card information is {dtutil.display_time(age.total_seconds(), 1)} old'
     return ''
 

--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -144,16 +144,12 @@ def test_escape_underscores() -> None:
     assert r == 'Adamaro, First to Desire :white_check_mark:'
 
 def test_no_warning_for_recent_card_information(monkeypatch: pytest.MonkeyPatch) -> None:
-    now = datetime.datetime(2026, 8, 21, tzinfo=datetime.UTC)
-    monkeypatch.setattr(command.dtutil, 'now', lambda: now)
-    monkeypatch.setattr(command.database, 'last_updated', lambda: now - command.MAX_CARD_INFORMATION_AGE)
+    monkeypatch.setattr(command.database, 'stale_card_information_age', lambda: None)
 
     assert command.stale_card_information_warning() == ''
 
 def test_warning_for_stale_card_information(monkeypatch: pytest.MonkeyPatch) -> None:
-    now = datetime.datetime(2026, 8, 21, tzinfo=datetime.UTC)
-    monkeypatch.setattr(command.dtutil, 'now', lambda: now)
-    monkeypatch.setattr(command.database, 'last_updated', lambda: now - datetime.timedelta(days=29))
+    monkeypatch.setattr(command.database, 'stale_card_information_age', lambda: datetime.timedelta(days=29))
 
     assert command.stale_card_information_warning() == '\nWARNING: card information is 4 weeks old'
 

--- a/magic/database.py
+++ b/magic/database.py
@@ -10,6 +10,7 @@ from shared.pd_exception import DatabaseException
 
 # Bump this if you modify the schema.
 SCHEMA_VERSION = 110
+MAX_CARD_INFORMATION_AGE = datetime.timedelta(days=2)
 DATABASE = Container()
 
 def db() -> Database:
@@ -33,6 +34,10 @@ def init() -> None:
 
 def last_updated() -> datetime.datetime:
     return dtutil.ts2dt(db().value('SELECT last_updated FROM scryfall_version', [], 0))
+
+def stale_card_information_age() -> datetime.timedelta | None:
+    age = dtutil.now() - last_updated()
+    return age if age > MAX_CARD_INFORMATION_AGE else None
 
 def db_version() -> int:
     return db().value('SELECT version FROM db_version', [], 0)

--- a/magic/database_test.py
+++ b/magic/database_test.py
@@ -1,0 +1,21 @@
+import datetime
+
+import pytest
+
+from magic import database
+
+
+def test_card_information_at_maximum_age_is_not_stale(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.datetime(2026, 8, 21, tzinfo=datetime.UTC)
+    monkeypatch.setattr(database.dtutil, 'now', lambda: now)
+    monkeypatch.setattr(database, 'last_updated', lambda: now - database.MAX_CARD_INFORMATION_AGE)
+
+    assert database.stale_card_information_age() is None
+
+def test_card_information_older_than_maximum_age_is_stale(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.datetime(2026, 8, 21, tzinfo=datetime.UTC)
+    age = datetime.timedelta(days=4)
+    monkeypatch.setattr(database.dtutil, 'now', lambda: now)
+    monkeypatch.setattr(database, 'last_updated', lambda: now - age)
+
+    assert database.stale_card_information_age() == age

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -370,6 +370,22 @@ header {
     display: flex;
 }
 
+.card-information-warning {
+    background: var(--tertiary-background);
+    border-bottom: 0.05rem solid var(--border);
+    color: var(--tertiary-text);
+    font-size: var(--table-font-size);
+    padding: 0.25rem var(--spacing-page-with-marginalia);
+    text-align: center;
+}
+
+@media only screen and (max-width: 900px) {
+    .card-information-warning {
+        padding-left: 1rem;
+        padding-right: 1rem;
+    }
+}
+
 header h1, header .search {
     padding: 3rem 0 1rem 0;
 }

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -445,6 +445,9 @@ PD.initSignupDeckChooser = function() {
 PD.initPersonalization = function() {
     $.get("/api/status", function(data) {
         var text = "";
+        if (data.card_information_warning) {
+            $(".card-information-warning").text("⚠ " + data.card_information_warning).prop("hidden", false);
+        }
         if (data.discord_id) {
             text += "You are logged in";
             if (data.mtgo_username !== null) {


### PR DESCRIPTION
## Summary

- share the two-day card-information staleness policy between Decksite and PDBot
- expose stale Decksite card data through the existing status response
- show a small, neutral warning line beneath the site header
- cover the age boundary and status response

## Tests

- uv run --frozen pytest --confcutdir=magic magic/database_test.py
- uv run --frozen pytest --confcutdir=discordbot discordbot/command_test.py -k "stale_card_information or card_information_warning"
- uv run --frozen ruff check on changed Python files
- uv run --frozen mypy on changed source files
- npx eslint shared_web/static/js/pd.js
- npm run build

The full Decksite test suite was not run locally because this cloud workspace does not have the project MySQL databases running.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/d2c9e376-b34b-4c36-839f-b86447f6b288)
