### PR TITLE
Reindex Whoosh after card database rebuild

### DIFF
--- a/run.py
+++ b/run.py
@@ -106,9 +106,11 @@ def modo_bugs(argv: tuple[str]) -> None:
 @cli.command()
 @click.option('--force', is_flag=True, help='Force a rebuild of the database')
 def init_cards(force: bool = False) -> None:
-    from magic import multiverse
+    from magic import multiverse, whoosh_write
     success = multiverse.init(force=force)
     multiverse.rebuild_cache()
+    if success:
+        whoosh_write.reindex()
     sys.exit(0 if success else 1)
 
 

--- a/run_test.py
+++ b/run_test.py
@@ -1,0 +1,39 @@
+import pytest
+from click.testing import CliRunner
+
+import run
+from magic import multiverse, whoosh_write
+
+
+def test_init_cards_force_rebuilds_search_index(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, bool | None]] = []
+
+    def init(force: bool = False) -> bool:
+        calls.append(('init', force))
+        return True
+
+    monkeypatch.setattr(multiverse, 'init', init)
+    monkeypatch.setattr(multiverse, 'rebuild_cache', lambda: calls.append(('rebuild_cache', None)))
+    monkeypatch.setattr(whoosh_write, 'reindex', lambda: calls.append(('reindex', None)))
+
+    result = CliRunner().invoke(run.cli, ['init-cards', '--force'])
+
+    assert result.exit_code == 0
+    assert calls == [('init', True), ('rebuild_cache', None), ('reindex', None)]
+
+
+def test_init_cards_does_not_rebuild_search_index_after_failed_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(multiverse, 'init', lambda force=False: False)
+    monkeypatch.setattr(multiverse, 'rebuild_cache', lambda: None)
+    reindex_calls = 0
+
+    def reindex() -> None:
+        nonlocal reindex_calls
+        reindex_calls += 1
+
+    monkeypatch.setattr(whoosh_write, 'reindex', reindex)
+
+    result = CliRunner().invoke(run.cli, ['init-cards', '--force'])
+
+    assert result.exit_code == 1
+    assert reindex_calls == 0


### PR DESCRIPTION
## Summary

- rebuild the Whoosh card-search index after a successful init-cards database update
- preserve the existing index when the database update fails
- cover successful forced rebuilds and failed updates

## Testing

- uv run --frozen pytest -q --noconftest run_test.py
- uv run --frozen ruff check run.py run_test.py
- uv run --frozen mypy run.py run_test.py

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/346df81f-c404-4a46-86a0-4727ab0b4418)
