### PR TITLE
Make archetype sorting badge fully clickable

### DIFF
--- a/decksite/templates/menu.mustache
+++ b/decksite/templates/menu.mustache
@@ -4,7 +4,7 @@
         <li class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}">
             {{#badge}}
                 <div class="badge-holder">
-                    <span class="admin demimod badge {{class_name}}"><a href="{{url}}">{{text}}</a></span>
+                    <a class="admin demimod badge {{class_name}}" href="{{url}}">{{text}}</a>
                 </div>
             {{/badge}}
             <a class="item {{#current}}current{{/current}}" href="{{url}}">

--- a/decksite/view_test.py
+++ b/decksite/view_test.py
@@ -55,6 +55,20 @@ def test_intro_deck_links() -> None:
         rendered = template.render_name('faqsbody', v)
         assert 'href="/metagame/"' in rendered
 
+def test_menu_badge_is_entirely_linked() -> None:
+    with APP.test_request_context('/'):
+        rendered = template.render_name('menu', {'menu': [{
+            'name': 'Metagame',
+            'url': '/metagame/',
+            'badge': {
+                'url': '/admin/archetypes/',
+                'text': '12',
+                'class_name': 'edit_archetypes',
+            },
+        }]})
+
+    assert '<a class="admin demimod badge edit_archetypes" href="/admin/archetypes/">12</a>' in rendered
+
 def test_build_menu_uses_endpoint_override_for_active_league() -> None:
     with APP.test_request_context('/competitions/123/'):
         g.menu_endpoint_override = 'current_league'

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2669,7 +2669,7 @@ Notification Badges
 }
 
 /* Menu links have padding, and links are oldstyle-nums where digits sit at differing heights. Both push the count off-center in its circle. */
-.badge a {
+a.badge, .badge a {
     font-variant-numeric: normal;
     padding: 0;
 }

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -476,7 +476,7 @@ PD.initPersonalization = function() {
             $(".demimod").show();
         }
         if ((data.admin || data.demimod) && (data.archetypes_to_tag > 0)) {
-            $(".edit_archetypes").children()[0].text = data.archetypes_to_tag;
+            $(".edit_archetypes").text(data.archetypes_to_tag);
         }
         if (!data.hide_intro && !PD.getUrlParam("hide_intro")) {
             $(".intro-container").show();


### PR DESCRIPTION
## Summary
- make the complete archetype-sorting badge the link target
- preserve badge sizing and live count updates
- add a regression test for the linked badge markup

## Verification
- direct Mustache template rendering passed
- Python lint passed
- JavaScript lint passed
- git diff --check passed

Full pytest could not run locally because the configured cards MySQL database is unavailable in this cloud workspace.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/08003a75-9261-4535-b203-2dd7ce4bf052)
