### PR TITLE
Hide empty archetype sorting badge

### DIFF
--- a/decksite/templates/menu.mustache
+++ b/decksite/templates/menu.mustache
@@ -4,7 +4,7 @@
         <li class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}">
             {{#badge}}
                 <div class="badge-holder">
-                    <a class="admin demimod badge {{class_name}}" href="{{url}}">{{text}}</a>
+                    <a class="badge {{class_name}}" href="{{url}}">{{text}}</a>
                 </div>
             {{/badge}}
             <a class="item {{#current}}current{{/current}}" href="{{url}}">

--- a/decksite/view_test.py
+++ b/decksite/view_test.py
@@ -67,7 +67,7 @@ def test_menu_badge_is_entirely_linked() -> None:
             },
         }]})
 
-    assert '<a class="admin demimod badge edit_archetypes" href="/admin/archetypes/">12</a>' in rendered
+    assert '<a class="badge edit_archetypes" href="/admin/archetypes/">12</a>' in rendered
 
 def test_build_menu_uses_endpoint_override_for_active_league() -> None:
     with APP.test_request_context('/competitions/123/'):

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2668,6 +2668,11 @@ Notification Badges
     top: 13px;
 }
 
+/* Personalization reveals this badge only when there are decks waiting for archetype sorting. */
+.edit_archetypes {
+    display: none;
+}
+
 /* Menu links have padding, and links are oldstyle-nums where digits sit at differing heights. Both push the count off-center in its circle. */
 a.badge, .badge a {
     font-variant-numeric: normal;

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -476,7 +476,9 @@ PD.initPersonalization = function() {
             $(".demimod").show();
         }
         if ((data.admin || data.demimod) && (data.archetypes_to_tag > 0)) {
-            $(".edit_archetypes").text(data.archetypes_to_tag);
+            $(".edit_archetypes").text(data.archetypes_to_tag).show();
+        } else {
+            $(".edit_archetypes").hide();
         }
         if (!data.hide_intro && !PD.getUrlParam("hide_intro")) {
             $(".intro-container").show();


### PR DESCRIPTION
## Summary
- keep the archetype-sorting badge hidden by default
- reveal it only for authorized users when the pending deck count is greater than zero
- hide it again if a later status response reports no decks to sort

## Verification
- direct Mustache template rendering passed
- Python lint passed
- JavaScript lint passed
- git diff --check passed

Follow-up to #15011, which merged before this zero-count correction was pushed.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/08003a75-9261-4535-b203-2dd7ce4bf052)
