### PR TITLE
Skip test modules during Discord command loading

### DIFF
--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -4,9 +4,19 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from discordbot import command
+from discordbot import command, commands
 from discordbot.commands import CardConverter, resources
 from magic.models import Card, Printing
+
+
+def test_command_setup_does_not_load_test_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    bot = Mock()
+    monkeypatch.setattr(commands.glob, 'glob', Mock(return_value=['/commands/spoiler.py', '/commands/spoiler_test.py', '/commands/__init__.py']))
+    monkeypatch.setattr(commands.path, 'isfile', Mock(return_value=True))
+
+    commands.setup(bot)
+
+    bot.load_extension.assert_called_once_with('.spoiler', 'discordbot.commands')
 
 
 def test_roughly_matches() -> None:

--- a/discordbot/commands/__init__.py
+++ b/discordbot/commands/__init__.py
@@ -15,7 +15,7 @@ from magic.models import Card
 def setup(bot: Client) -> None:
     Card.convert = CardConverter.convert
     modules = glob.glob(path.join(path.dirname(__file__), '*.py'))
-    files = [path.basename(f)[:-3] for f in modules if path.isfile(f) and not f.endswith('__init__.py')]
+    files = [path.basename(f)[:-3] for f in modules if path.isfile(f) and not f.endswith(('__init__.py', '_test.py'))]
 
     for mod in files:
         try:


### PR DESCRIPTION
## Summary

- exclude colocated `*_test.py` files from Discord command extension discovery
- add a regression test verifying test modules are not loaded at bot startup

## Testing

- `uv run --frozen pytest --confcutdir=discordbot discordbot/command_test.py -k command_setup --no-cov`
- `uv run --frozen ruff check discordbot/commands/__init__.py discordbot/command_test.py`

The full test bootstrap requires the external `cards` database and Whoosh index, which are unavailable in the cloud workspace.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b6d3efc8-c9ff-40b1-8be6-61207261db2e)
