### PR TITLE
Retry Discord command sync before bot startup

### DIFF
--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 from typing import Any, cast
 
-from interactions import Client, listen
+from interactions import MISSING, Client, listen
 from interactions.api.events import CommandError, MemberAdd, MessageCreate, MessageReactionAdd, PresenceUpdate
 from interactions.client.errors import CommandCheckFailure, CommandOnCooldown, MaxConcurrencyReached
 from interactions.models import ActivityType, Guild, GuildText, Intents, Member, Role
@@ -55,7 +55,8 @@ class Bot(Client):
                 else:
                     await self._cache_interactions(warn_missing=False)
 
-                command_names = {cmd.resolved_name for cmd in self.application_commands}
+                synced_scopes = set(self._get_sync_scopes(cast(Any, MISSING)))
+                command_names = {cmd.resolved_name for cmd in self.application_commands if synced_scopes.intersection(cmd.scopes)}
                 group_names: set[str] = set()
                 for command_name in command_names:
                     parts = command_name.split()

--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -55,7 +55,12 @@ class Bot(Client):
                 else:
                     await self._cache_interactions(warn_missing=False)
 
-                missing_commands = {cmd.resolved_name for cmd in self.application_commands} - self._interaction_lookup.keys()
+                command_names = {cmd.resolved_name for cmd in self.application_commands}
+                group_names: set[str] = set()
+                for command_name in command_names:
+                    parts = command_name.split()
+                    group_names.update(' '.join(parts[:depth]) for depth in range(1, len(parts)))
+                missing_commands = command_names - group_names - self._interaction_lookup.keys()
                 if missing_commands:
                     raise RuntimeError(f'Discord command cache is missing {len(missing_commands)} application commands')
                 if attempt > 1:

--- a/discordbot/bot.py
+++ b/discordbot/bot.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import logging
+import os
 import subprocess
 from typing import Any, cast
 
@@ -16,6 +17,9 @@ from magic import fetcher, multiverse, oracle, whoosh_write
 from shared import configuration, perf, repo
 from shared import redis_wrapper as redis
 from shared.settings import with_config_file
+
+COMMAND_SYNC_ATTEMPTS = 3
+COMMAND_SYNC_RETRY_SECONDS = 5
 
 
 class Bot(Client):
@@ -42,6 +46,29 @@ class Bot(Client):
         self.load_extension('discordbot.background')
 
         self.add_global_autocomplete(command.autocomplete_card)
+
+    async def _init_interactions(self) -> None:
+        for attempt in range(1, COMMAND_SYNC_ATTEMPTS + 1):
+            try:
+                if self.sync_interactions:
+                    await self.synchronise_interactions()
+                else:
+                    await self._cache_interactions(warn_missing=False)
+
+                missing_commands = {cmd.resolved_name for cmd in self.application_commands} - self._interaction_lookup.keys()
+                if missing_commands:
+                    raise RuntimeError(f'Discord command cache is missing {len(missing_commands)} application commands')
+                if attempt > 1:
+                    logging.info('Discord command sync succeeded on attempt %d', attempt)
+                return
+            except Exception:
+                if attempt == COMMAND_SYNC_ATTEMPTS:
+                    logging.critical('Discord command sync failed after %d attempts; exiting for restart', attempt, exc_info=True)
+                    os._exit(1)
+                    return
+                delay = COMMAND_SYNC_RETRY_SECONDS * 2 ** (attempt - 1)
+                logging.warning('Discord command sync failed on attempt %d/%d; retrying in %d seconds', attempt, COMMAND_SYNC_ATTEMPTS, delay, exc_info=True)
+                await asyncio.sleep(delay)
 
     async def stop(self) -> None:
         async with self._shutdown_lock:

--- a/discordbot/bot_test.py
+++ b/discordbot/bot_test.py
@@ -79,6 +79,33 @@ async def test_command_sync_retries_when_local_cache_is_incomplete(monkeypatch: 
 
 
 @pytest.mark.asyncio
+async def test_command_sync_does_not_require_group_roots_in_local_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    synchronise_interactions = AsyncMock()
+    sleep = AsyncMock()
+    exit_process = Mock()
+    bot = cast(
+        Bot,
+        SimpleNamespace(
+            sync_interactions=True,
+            synchronise_interactions=synchronise_interactions,
+            application_commands=[
+                SimpleNamespace(resolved_name='dreadrise'),
+                SimpleNamespace(resolved_name='dreadrise search'),
+            ],
+            _interaction_lookup={'dreadrise search': Mock()},
+        ),
+    )
+    monkeypatch.setattr('discordbot.bot.asyncio.sleep', sleep)
+    monkeypatch.setattr('discordbot.bot.os._exit', exit_process)
+
+    await Bot._init_interactions(bot)
+
+    synchronise_interactions.assert_awaited_once_with()
+    sleep.assert_not_awaited()
+    exit_process.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_stop_closes_gateway_before_http_and_only_once() -> None:
     calls = Mock()
     ready = Mock()

--- a/discordbot/bot_test.py
+++ b/discordbot/bot_test.py
@@ -5,7 +5,77 @@ from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
-from discordbot.bot import Bot
+from discordbot.bot import COMMAND_SYNC_ATTEMPTS, Bot
+
+
+@pytest.mark.asyncio
+async def test_command_sync_retries_before_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    synchronise_interactions = AsyncMock(side_effect=[RuntimeError('Discord unavailable'), None])
+    sleep = AsyncMock()
+    exit_process = Mock()
+    bot = cast(
+        Bot,
+        SimpleNamespace(
+            sync_interactions=True,
+            synchronise_interactions=synchronise_interactions,
+            application_commands=[SimpleNamespace(resolved_name='history')],
+            _interaction_lookup={'history': Mock()},
+        ),
+    )
+    monkeypatch.setattr('discordbot.bot.asyncio.sleep', sleep)
+    monkeypatch.setattr('discordbot.bot.os._exit', exit_process)
+
+    await Bot._init_interactions(bot)
+
+    assert synchronise_interactions.await_count == 2
+    sleep.assert_awaited_once_with(5)
+    exit_process.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_command_sync_exits_after_retries_are_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    synchronise_interactions = AsyncMock(side_effect=RuntimeError('Discord unavailable'))
+    sleep = AsyncMock()
+    exit_process = Mock()
+    bot = cast(
+        Bot,
+        SimpleNamespace(
+            sync_interactions=True,
+            synchronise_interactions=synchronise_interactions,
+            application_commands=[SimpleNamespace(resolved_name='history')],
+            _interaction_lookup={},
+        ),
+    )
+    monkeypatch.setattr('discordbot.bot.asyncio.sleep', sleep)
+    monkeypatch.setattr('discordbot.bot.os._exit', exit_process)
+
+    await Bot._init_interactions(bot)
+
+    assert synchronise_interactions.await_count == COMMAND_SYNC_ATTEMPTS
+    assert [call.args[0] for call in sleep.await_args_list] == [5, 10]
+    exit_process.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_command_sync_retries_when_local_cache_is_incomplete(monkeypatch: pytest.MonkeyPatch) -> None:
+    synchronise_interactions = AsyncMock()
+    bot = cast(
+        Bot,
+        SimpleNamespace(
+            sync_interactions=True,
+            synchronise_interactions=synchronise_interactions,
+            application_commands=[SimpleNamespace(resolved_name='history')],
+            _interaction_lookup={},
+        ),
+    )
+    monkeypatch.setattr('discordbot.bot.asyncio.sleep', AsyncMock())
+    exit_process = Mock()
+    monkeypatch.setattr('discordbot.bot.os._exit', exit_process)
+
+    await Bot._init_interactions(bot)
+
+    assert synchronise_interactions.await_count == COMMAND_SYNC_ATTEMPTS
+    exit_process.assert_called_once_with(1)
 
 
 @pytest.mark.asyncio

--- a/discordbot/bot_test.py
+++ b/discordbot/bot_test.py
@@ -4,6 +4,7 @@ from typing import cast
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
+from interactions import GLOBAL_SCOPE
 
 from discordbot.bot import COMMAND_SYNC_ATTEMPTS, Bot
 
@@ -18,7 +19,8 @@ async def test_command_sync_retries_before_startup(monkeypatch: pytest.MonkeyPat
         SimpleNamespace(
             sync_interactions=True,
             synchronise_interactions=synchronise_interactions,
-            application_commands=[SimpleNamespace(resolved_name='history')],
+            _get_sync_scopes=Mock(return_value=[GLOBAL_SCOPE]),
+            application_commands=[SimpleNamespace(resolved_name='history', scopes=[GLOBAL_SCOPE])],
             _interaction_lookup={'history': Mock()},
         ),
     )
@@ -42,7 +44,8 @@ async def test_command_sync_exits_after_retries_are_exhausted(monkeypatch: pytes
         SimpleNamespace(
             sync_interactions=True,
             synchronise_interactions=synchronise_interactions,
-            application_commands=[SimpleNamespace(resolved_name='history')],
+            _get_sync_scopes=Mock(return_value=[GLOBAL_SCOPE]),
+            application_commands=[SimpleNamespace(resolved_name='history', scopes=[GLOBAL_SCOPE])],
             _interaction_lookup={},
         ),
     )
@@ -64,7 +67,8 @@ async def test_command_sync_retries_when_local_cache_is_incomplete(monkeypatch: 
         SimpleNamespace(
             sync_interactions=True,
             synchronise_interactions=synchronise_interactions,
-            application_commands=[SimpleNamespace(resolved_name='history')],
+            _get_sync_scopes=Mock(return_value=[GLOBAL_SCOPE]),
+            application_commands=[SimpleNamespace(resolved_name='history', scopes=[GLOBAL_SCOPE])],
             _interaction_lookup={},
         ),
     )
@@ -88,11 +92,42 @@ async def test_command_sync_does_not_require_group_roots_in_local_cache(monkeypa
         SimpleNamespace(
             sync_interactions=True,
             synchronise_interactions=synchronise_interactions,
+            _get_sync_scopes=Mock(return_value=[GLOBAL_SCOPE]),
             application_commands=[
-                SimpleNamespace(resolved_name='dreadrise'),
-                SimpleNamespace(resolved_name='dreadrise search'),
+                SimpleNamespace(resolved_name='dreadrise', scopes=[GLOBAL_SCOPE]),
+                SimpleNamespace(resolved_name='dreadrise search', scopes=[GLOBAL_SCOPE]),
             ],
             _interaction_lookup={'dreadrise search': Mock()},
+        ),
+    )
+    monkeypatch.setattr('discordbot.bot.asyncio.sleep', sleep)
+    monkeypatch.setattr('discordbot.bot.os._exit', exit_process)
+
+    await Bot._init_interactions(bot)
+
+    synchronise_interactions.assert_awaited_once_with()
+    sleep.assert_not_awaited()
+    exit_process.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_command_sync_does_not_require_commands_outside_synced_scopes(monkeypatch: pytest.MonkeyPatch) -> None:
+    synchronise_interactions = AsyncMock()
+    sleep = AsyncMock()
+    exit_process = Mock()
+    bot = cast(
+        Bot,
+        SimpleNamespace(
+            sync_interactions=True,
+            synchronise_interactions=synchronise_interactions,
+            _get_sync_scopes=Mock(return_value=[GLOBAL_SCOPE]),
+            application_commands=[
+                SimpleNamespace(resolved_name='history', scopes=[GLOBAL_SCOPE]),
+                SimpleNamespace(resolved_name='queue join', scopes=[123]),
+                SimpleNamespace(resolved_name='queue leave', scopes=[123]),
+                SimpleNamespace(resolved_name='sync', scopes=[456]),
+            ],
+            _interaction_lookup={'history': Mock()},
         ),
     )
     monkeypatch.setattr('discordbot.bot.asyncio.sleep', sleep)


### PR DESCRIPTION
## Summary

- retry Discord application-command synchronization three times with exponential backoff
- verify every invokable application-command leaf reached the local dispatch cache before startup completes
- allow non-invokable command-group roots that `interactions.py` intentionally omits from that cache
- exit with status 1 after exhausted retries so the process supervisor can restart the bot

This prevents a transient command-sync failure, such as the observed Discord API 503, from leaving the bot online but unable to dispatch slash commands.

## Testing

- `uv run --frozen pytest --confcutdir=discordbot discordbot/bot_test.py --no-cov`
- `uv run --frozen ruff check discordbot/bot.py discordbot/bot_test.py`
- `uv run --frozen mypy discordbot/bot.py discordbot/bot_test.py`