### PR TITLE
Keep the bot's card data fresh without restarting it

### DIFF
--- a/discordbot/background.py
+++ b/discordbot/background.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import logging
 import os
+import sys
 import urllib.parse
 
 from interactions import MISSING, Absent, Client, Extension, listen
@@ -10,13 +11,17 @@ from interactions.client.utils import timestamp_converter
 from interactions.models.discord import Embed, GuildText, MessageableMixin, ScheduledEventType
 from interactions.models.internal.tasks import IntervalTrigger, Task
 
-from discordbot import error_handling, reboot_utils
-from magic import fetcher, image_fetcher, multiverse, rotation, seasons, tournaments
+from discordbot import command, error_handling, reboot_utils
+from magic import database, fetcher, image_fetcher, multiverse, oracle, rotation, seasons, tournaments
 from shared import configuration, dtutil, fetch_tools, redis_wrapper
+
+# Run in a subprocess because the rebuild is minutes of blocking work that would stall the gateway if we did it in here.
+UPDATE_CARDS_COMMAND = (sys.executable, 'run.py', 'init-cards')
 
 
 class BackgroundTasks(Extension):
     rotation_hype_channel: GuildText
+    updating_cards = False
 
     @listen()
     async def on_startup(self) -> None:
@@ -28,6 +33,7 @@ class BackgroundTasks(Extension):
         redis_wrapper.clear(reboot_utils.REBOOT_CHANNEL_KEY)
         await self.announce_reboot_complete()
         self.background_task_reboot.start()
+        self.background_task_update_cards.start()
 
         await self.prepare_tournaments()
         await self.prepare_hype()
@@ -101,6 +107,36 @@ class BackgroundTasks(Extension):
             except TimeoutError:
                 logging.warning('Graceful reboot shutdown timed out; forcing process exit')
             os._exit(0)
+
+    @Task.create(IntervalTrigger(hours=1))
+    async def background_task_update_cards(self) -> None:
+        if self.updating_cards:
+            return  # Tasks fire on a timer without waiting for the previous run, so don't pile up if an update outlives its interval.
+        if configuration.prevent_cards_db_updates.get():
+            return
+        if os.path.exists('.rotation.lock'):
+            return  # The rotation script has the cards db in pieces, leave it alone.
+        self.updating_cards = True
+        try:
+            ours = database.last_updated()
+            try:
+                theirs = await fetcher.scryfall_last_updated_async()
+            except fetcher.FetchException as e:
+                logging.warning('Could not ask Scryfall how fresh its card data is: %s', e)
+                return
+            if theirs <= ours:
+                return
+            logging.info('Card data is stale (ours %s, Scryfall %s), updating', ours, theirs)
+            returncode, output = await reboot_utils.run_command(*UPDATE_CARDS_COMMAND)
+            # init-cards exits non-zero both when it fails and when something else got there first, so believe the timestamp rather than the exit code.
+            if database.last_updated() <= ours:
+                logging.error('Card data update failed (status %s): %s', returncode, error_handling.redact(output))
+                return
+            oracle.init(force=True)
+            command.searcher().refresh()  # The index itself is on disk, rebuilt by the subprocess, but our view of it isn't.
+            logging.info('Card data updated to %s', database.last_updated())
+        finally:
+            self.updating_cards = False
 
     async def send_reboot_message(self, channel_id: int, message: str) -> None:
         try:

--- a/discordbot/background_test.py
+++ b/discordbot/background_test.py
@@ -1,11 +1,15 @@
+import asyncio
+import datetime
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from discordbot import background as background_module
 from discordbot import error_handling, reboot_utils
 from discordbot.background import BackgroundTasks
+from magic import fetcher
 
 
 @pytest.mark.asyncio
@@ -96,3 +100,126 @@ async def test_startup_announces_completed_reboot(monkeypatch: pytest.MonkeyPatc
 
     clear.assert_called_once_with(reboot_utils.REBOOT_COMPLETE_CHANNEL_KEY)
     send_reboot_message.assert_awaited_once_with(123, 'Reboot complete. Loaded `12345678`')
+
+
+def stale_cards_background(scryfall: datetime.datetime, ours: list[datetime.datetime], run_command: AsyncMock, monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    monkeypatch.setattr('discordbot.background.configuration.prevent_cards_db_updates', SimpleNamespace(get=lambda: False))
+    monkeypatch.setattr('discordbot.background.os.path.exists', Mock(return_value=False))
+    monkeypatch.setattr('discordbot.background.database.last_updated', Mock(side_effect=ours))
+    monkeypatch.setattr('discordbot.background.fetcher.scryfall_last_updated_async', AsyncMock(return_value=scryfall))
+    monkeypatch.setattr(reboot_utils, 'run_command', run_command)
+    return SimpleNamespace(updating_cards=False)
+
+
+@pytest.mark.asyncio
+async def test_stale_cards_are_updated_out_of_process_and_reloaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    old, new = datetime.datetime(2026, 8, 23, tzinfo=datetime.UTC), datetime.datetime(2026, 8, 27, tzinfo=datetime.UTC)
+    run_command = AsyncMock(return_value=(0, 'done'))
+    background = stale_cards_background(new, [old, new, new], run_command, monkeypatch)
+    oracle_init = Mock()
+    monkeypatch.setattr('discordbot.background.oracle.init', oracle_init)
+    searcher = Mock()
+    monkeypatch.setattr('discordbot.background.command.searcher', Mock(return_value=searcher))
+
+    await BackgroundTasks.background_task_update_cards.callback(background)
+
+    run_command.assert_awaited_once_with(*background_module.UPDATE_CARDS_COMMAND)
+    oracle_init.assert_called_once_with(force=True)
+    searcher.refresh.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_fresh_cards_are_left_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    ours = datetime.datetime(2026, 8, 27, tzinfo=datetime.UTC)
+    run_command = AsyncMock()
+    background = stale_cards_background(ours, [ours], run_command, monkeypatch)
+    oracle_init = Mock()
+    monkeypatch.setattr('discordbot.background.oracle.init', oracle_init)
+
+    await BackgroundTasks.background_task_update_cards.callback(background)
+
+    run_command.assert_not_awaited()
+    oracle_init.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cards_are_not_reloaded_if_the_update_did_not_happen(monkeypatch: pytest.MonkeyPatch) -> None:
+    old, new = datetime.datetime(2026, 8, 23, tzinfo=datetime.UTC), datetime.datetime(2026, 8, 27, tzinfo=datetime.UTC)
+    run_command = AsyncMock(return_value=(1, 'Unable to connect to Scryfall.'))
+    background = stale_cards_background(new, [old, old], run_command, monkeypatch)
+    oracle_init = Mock()
+    monkeypatch.setattr('discordbot.background.oracle.init', oracle_init)
+
+    await BackgroundTasks.background_task_update_cards.callback(background)
+
+    run_command.assert_awaited_once()
+    oracle_init.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unreachable_scryfall_does_not_trigger_an_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    ours = datetime.datetime(2026, 8, 23, tzinfo=datetime.UTC)
+    run_command = AsyncMock()
+    background = stale_cards_background(ours, [ours], run_command, monkeypatch)
+    monkeypatch.setattr('discordbot.background.fetcher.scryfall_last_updated_async', AsyncMock(side_effect=fetcher.FetchException('no')))
+
+    await BackgroundTasks.background_task_update_cards.callback(background)
+
+    run_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_frozen_cards_db_is_not_updated(monkeypatch: pytest.MonkeyPatch) -> None:
+    old, new = datetime.datetime(2026, 8, 23, tzinfo=datetime.UTC), datetime.datetime(2026, 8, 27, tzinfo=datetime.UTC)
+    run_command = AsyncMock()
+    background = stale_cards_background(new, [old], run_command, monkeypatch)
+    monkeypatch.setattr('discordbot.background.configuration.prevent_cards_db_updates', SimpleNamespace(get=lambda: True))
+
+    await BackgroundTasks.background_task_update_cards.callback(background)
+
+    run_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cards_are_not_updated_during_rotation(monkeypatch: pytest.MonkeyPatch) -> None:
+    old, new = datetime.datetime(2026, 8, 23, tzinfo=datetime.UTC), datetime.datetime(2026, 8, 27, tzinfo=datetime.UTC)
+    run_command = AsyncMock()
+    background = stale_cards_background(new, [old], run_command, monkeypatch)
+    monkeypatch.setattr('discordbot.background.os.path.exists', Mock(return_value=True))
+
+    await BackgroundTasks.background_task_update_cards.callback(background)
+
+    run_command.assert_not_awaited()
+
+
+def test_the_subprocess_we_shell_out_to_is_a_real_command() -> None:
+    import run
+    _, script, command = background_module.UPDATE_CARDS_COMMAND
+    assert script == 'run.py'
+    assert command in run.cli.commands
+
+
+@pytest.mark.asyncio
+async def test_a_second_tick_does_not_start_a_second_update(monkeypatch: pytest.MonkeyPatch) -> None:
+    old, new = datetime.datetime(2026, 8, 23, tzinfo=datetime.UTC), datetime.datetime(2026, 8, 27, tzinfo=datetime.UTC)
+    started, release, calls = asyncio.Event(), asyncio.Event(), 0
+
+    async def run_command(*args: str) -> tuple[int, str]:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return 0, 'done'
+
+    background = stale_cards_background(new, [old, new, new], cast(AsyncMock, run_command), monkeypatch)
+    monkeypatch.setattr('discordbot.background.oracle.init', Mock())
+    monkeypatch.setattr('discordbot.background.command.searcher', Mock(return_value=Mock()))
+
+    first = asyncio.create_task(BackgroundTasks.background_task_update_cards.callback(background))
+    await started.wait()
+    await BackgroundTasks.background_task_update_cards.callback(background)  # The next tick, while the first is still going.
+    release.set()
+    await first
+
+    assert calls == 1
+    assert background.updating_cards is False

--- a/discordbot/reboot_utils.py
+++ b/discordbot/reboot_utils.py
@@ -26,7 +26,7 @@ async def update() -> RebootUpdateError | None:
     ]
     for display, command in commands:
         try:
-            returncode, output = await _run_command(*command)
+            returncode, output = await run_command(*command)
         except Exception as e:
             return RebootUpdateError(display, None, str(e))
         if returncode != 0:
@@ -34,7 +34,7 @@ async def update() -> RebootUpdateError | None:
     return None
 
 
-async def _run_command(*command: str) -> tuple[int, str]:
+async def run_command(*command: str) -> tuple[int, str]:
     process = await asyncio.create_subprocess_exec(
         *command,
         stdout=asyncio.subprocess.PIPE,

--- a/discordbot/reboot_utils_test.py
+++ b/discordbot/reboot_utils_test.py
@@ -8,7 +8,7 @@ from discordbot import error_handling, reboot_utils
 @pytest.mark.asyncio
 async def test_update_runs_pull_then_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     run_command = AsyncMock(side_effect=[(0, 'pulled'), (0, 'synced')])
-    monkeypatch.setattr(reboot_utils, '_run_command', run_command)
+    monkeypatch.setattr(reboot_utils, 'run_command', run_command)
 
     assert await reboot_utils.update() is None
     assert run_command.await_count == 2
@@ -19,7 +19,7 @@ async def test_update_runs_pull_then_sync(monkeypatch: pytest.MonkeyPatch) -> No
 @pytest.mark.asyncio
 async def test_update_reports_pull_failure_and_does_not_sync(monkeypatch: pytest.MonkeyPatch) -> None:
     run_command = AsyncMock(return_value=(1, 'fatal: pull failed'))
-    monkeypatch.setattr(reboot_utils, '_run_command', run_command)
+    monkeypatch.setattr(reboot_utils, 'run_command', run_command)
 
     failure = await reboot_utils.update()
 
@@ -37,7 +37,7 @@ async def test_update_reports_pull_failure_and_does_not_sync(monkeypatch: pytest
 @pytest.mark.asyncio
 async def test_update_reports_sync_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     run_command = AsyncMock(side_effect=[(0, 'pulled'), (2, 'sync failed')])
-    monkeypatch.setattr(reboot_utils, '_run_command', run_command)
+    monkeypatch.setattr(reboot_utils, 'run_command', run_command)
 
     failure = await reboot_utils.update()
 

--- a/magic/whoosh_search.py
+++ b/magic/whoosh_search.py
@@ -84,6 +84,11 @@ class WhooshSearcher:
     DIST = 2
 
     def __init__(self) -> None:
+        self.refresh()
+
+    # Whoever rebuilds the index has to call this, we can't notice on our own: whoosh's FileIndex doesn't override Index.up_to_date,
+    # which unconditionally returns True, and whoosh_write.reindex recreates the index from scratch so the generation doesn't move either.
+    def refresh(self) -> None:
         self.ix = open_dir(WhooshConstants.index_dir)
         self.initialize_trie()
 
@@ -105,9 +110,6 @@ class WhooshSearcher:
             self.trie[name] = canonical_matches.get(name, []) + alias_matches.get(name, [])
 
     def search(self, w: str) -> SearchResult:
-        if not self.ix.up_to_date():
-            self.initialize_trie()  # if the index is not up to date, someone has added cards, so we reinitialize the trie
-
         normalized = list(WhooshConstants.normalized_analyzer(w))[0].text
 
         # If we get matches by prefix, we return that

--- a/magic/whoosh_search_test.py
+++ b/magic/whoosh_search_test.py
@@ -7,6 +7,7 @@ from whoosh.index import create_in
 
 from magic import whoosh_write
 from magic.models import Card
+from magic.whoosh_constants import WhooshConstants
 from magic.whoosh_search import WhooshSearcher
 
 
@@ -117,7 +118,8 @@ class WhooshSearchTest(unittest.TestCase):
 def is_included(name: str, cards: list[str]) -> bool:
     return len([x for x in cards if x == name]) >= 1
 
-def test_canonical_name_wins_alias_collision(tmp_path: Path) -> None:
+def test_canonical_name_wins_alias_collision(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(WhooshConstants, 'index_dir', str(tmp_path))
     ix = create_in(tmp_path, whoosh_write.WhooshWriter().schema)
     writer = ix.writer()
     for card_id, canonical_name, name in [
@@ -137,9 +139,7 @@ def test_canonical_name_wins_alias_collision(tmp_path: Path) -> None:
         )
     writer.commit()
 
-    searcher = WhooshSearcher.__new__(WhooshSearcher)
-    searcher.ix = ix
-    searcher.initialize_trie()
+    searcher = WhooshSearcher()
 
     result = searcher.search('Brainstorm')
     assert result.get_best_match() == 'Brainstorm'
@@ -149,7 +149,8 @@ def test_canonical_name_wins_alias_collision(tmp_path: Path) -> None:
     assert result.get_best_match() == 'Midnight Scavengers'
     assert result.get_all_matches() == ['Midnight Scavengers', 'Graf Rats']
 
-def test_flavor_name_is_searchable(tmp_path: Path) -> None:
+def test_flavor_name_is_searchable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(WhooshConstants, 'index_dir', str(tmp_path))
     ix = create_in(tmp_path, whoosh_write.WhooshWriter().schema)
     card = Card({
         'id': 1,
@@ -160,9 +161,27 @@ def test_flavor_name_is_searchable(tmp_path: Path) -> None:
     })
     whoosh_write.update_index(ix, [card])
 
-    searcher = WhooshSearcher.__new__(WhooshSearcher)
-    searcher.ix = ix
-    searcher.initialize_trie()
+    searcher = WhooshSearcher()
 
     result = searcher.search('Rick, Steadfast Leader')
     assert result.get_best_match() == "Greymond, Avacyn's Stalwart"
+
+
+def test_refresh_picks_up_an_index_rebuilt_by_another_process(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(WhooshConstants, 'index_dir', str(tmp_path))
+    whoosh_write.WhooshWriter().rewrite_index([indexable_card(1, 'Ancestral Recall')])
+    searcher = WhooshSearcher()
+    # Search by prefix rather than by full name, because fuzzy matching reads the index directly and only prefix matching goes through the trie.
+    assert searcher.search('Ancestral Re').get_best_match() == 'Ancestral Recall'
+    assert searcher.search('Black Lo').get_best_match() is None
+
+    whoosh_write.WhooshWriter().rewrite_index([indexable_card(1, 'Ancestral Recall'), indexable_card(2, 'Black Lotus')])
+    assert searcher.search('Black Lo').get_best_match() is None, 'A rebuilt index is not visible until we refresh'
+
+    searcher.refresh()
+
+    assert searcher.search('Black Lo').get_best_match() == 'Black Lotus'
+    assert searcher.search('Ancestral Re').get_best_match() == 'Ancestral Recall'
+
+def indexable_card(card_id: int, name: str) -> Card:
+    return Card({'id': card_id, 'name': name, 'names': name, 'flavor_names': None, 'layout': 'normal'})

--- a/run.py
+++ b/run.py
@@ -105,12 +105,15 @@ def modo_bugs(argv: tuple[str]) -> None:
 
 @cli.command()
 @click.option('--force', is_flag=True, help='Force a rebuild of the database')
+@decorators.interprocess_locked('.task.lock')
 def init_cards(force: bool = False) -> None:
+    """Bring the cards database, and everything derived from it, up to date with Scryfall. Exits non-zero if there was nothing to do."""
     from magic import multiverse, whoosh_write
-    success = multiverse.init(force=force)
-    multiverse.rebuild_cache()
+    success = multiverse.init(force=force)  # Refetches the bugs too, see insert_cards_async.
     if success:
-        whoosh_write.reindex()
+        whoosh_write.reindex()  # init_async's `finally` already rebuilt the cache on this path.
+    else:
+        multiverse.rebuild_cache()  # It may not have, and this command doubles as "regenerate my _cache_card". See 79627efc.
     sys.exit(0 if success else 1)
 
 

--- a/run_test.py
+++ b/run_test.py
@@ -19,12 +19,18 @@ def test_init_cards_force_rebuilds_search_index(monkeypatch: pytest.MonkeyPatch)
     result = CliRunner().invoke(run.cli, ['init-cards', '--force'])
 
     assert result.exit_code == 0
-    assert calls == [('init', True), ('rebuild_cache', None), ('reindex', None)]
+    assert calls == [('init', True), ('reindex', None)]  # init_async's `finally` already rebuilt the cache.
 
 
 def test_init_cards_does_not_rebuild_search_index_after_failed_update(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(multiverse, 'init', lambda force=False: False)
-    monkeypatch.setattr(multiverse, 'rebuild_cache', lambda: None)
+    rebuild_calls = 0
+
+    def rebuild_cache() -> None:
+        nonlocal rebuild_calls
+        rebuild_calls += 1
+
+    monkeypatch.setattr(multiverse, 'rebuild_cache', rebuild_cache)
     reindex_calls = 0
 
     def reindex() -> None:
@@ -37,3 +43,4 @@ def test_init_cards_does_not_rebuild_search_index_after_failed_update(monkeypatc
 
     assert result.exit_code == 1
     assert reindex_calls == 0
+    assert rebuild_calls == 1  # We can't know whether init rebuilt it, and this command doubles as "regenerate my _cache_card".


### PR DESCRIPTION
## The bug

The bot only ever updated the cards database in `prepare_database_async`, which runs once at startup. Nothing refreshed it afterwards, so a bot that had been up for four days answered from four-day-old cards. The `WARNING: card information is 4 days old` message we started seeing was correct, not over-sensitive — Scryfall's `default_cards` was publishing daily throughout.

## The fix

An hourly task that asks Scryfall whether it has anything newer and, if so, shells out to `run.py init-cards`, then reloads the bot's in-memory caches.

The rebuild has to run in a subprocess. `multiverse.init_async` is async in name only — `determine_values_async` loops over ~110k printings and `insert_many` issues single giant inserts, with no awaits in between. That's why startup does it before `client.start()`. Inline, it would stall the gateway heartbeat.

Success is judged by `scryfall_version` advancing, not by the exit code: `multiverse.init` returns `False` both for "failed" and for "nothing to do", so if the cron task runner gets there first, an exit-code check would wrongly skip the reload.

## Also in here

**`WhooshSearcher.refresh()`, replacing a check that never fired.** `search()` had `if not self.ix.up_to_date(): self.initialize_trie()`. whoosh 2.7.4's `FileIndex` never overrides `Index.up_to_date`, whose base implementation is `return True` — the source even has bare `# refresh` / `# up_to_date` comments where the overrides would go. So the trie was built once and never rebuilt. All prefix matching goes through the trie (fuzzy matching reads the index directly), so new cards were unfindable by prefix until a restart, even after `/update`. Generation tracking doesn't work either — `reindex()` uses `create_in`, which resets the generation — so the caller now says when it has rebuilt.

**`.task.lock` on `init-cards`**, so it can't rebuild concurrently with the cron task runner.

**One fewer `rebuild_cache()`.** A real update rebuilt `_cache_card` three times. `init_async` returns `True` only via the path that already ran its `finally`, and nothing mutates card data in between, so `init-cards`' own call is provably redundant there. `False` does *not* imply no rebuild happened — `update_database_async` can return `False` at :149 after the `finally` fired — so the failure path still rebuilds unconditionally, preserving 79627efc's "regenerate my `_cache_card`" behaviour. The remaining two both earn their place: `:191` bounds the window where other processes read a stale cache, and `:43` covers the paths where `insert_cards` never ran or threw partway.

**An in-flight guard.** `Task._fire` creates each run as a new asyncio task without waiting for the previous one, so an update outliving its interval could be joined by the next tick.

## Testing

Unit tests cover the decision logic, both guards, the reload on success and its absence on failure, that `refresh()` picks up a rebuilt index, that the subprocess names a command that exists, and that a second tick can't start a second update. The last two were checked by breaking them deliberately.

Manually, against a local database, with the interval temporarily at one minute:

- `init-cards` exits 1 unchanged when there's nothing to do; rebuilds and advances the stamp when there is; blocks on a held `.task.lock`
- rewinding `scryfall_version` mid-run: the bot logs `Card data is stale`, updates, and the warning disappears — same PID, responsive throughout
- deleting a card from `_cache_card` and reindexing: the bot can't find it by prefix, then finds it after the next tick, without restarting
- `.rotation.lock` and `prevent_cards_db_updates` both suppress the update
- pointing the subprocess at a non-existent command: logs `Card data update failed (status 2)`, doesn't reload, doesn't restart, retries next tick

## Not in here

`insert_cards` opens a transaction at :171 and commits at :192, but `rebuild_cache()` at :191 runs DDL, which forces an implicit commit in MySQL. The `begin`/`commit` pair reads like it protects the whole card swap and doesn't. Pre-existing and orthogonal; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b9794bf1-beb5-4938-ad94-72f833825e64)
