### PR TITLE
Add reusable backlog sweep tooling

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,21 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+# Shared Conductor settings. Machine-local overrides (run scripts, files to copy)
+# belong in .conductor/settings.local.toml, which takes precedence per-key.
+#
+# The setup script bootstraps CLOUD workspaces only: fresh cloud sandboxes have no
+# uv and no build deps, so without this `uv run` fails. Local workspaces are
+# assumed to already have a working dev environment and are left alone.
+# (A MariaDB server is deliberately NOT set up here to keep workspace creation
+# fast; agents that need to run DB-backed tests can install one — see
+# backlog_sweep/FIXER_PROMPT.md for a verified recipe.)
+
+[scripts]
+setup = """
+set -e
+if [ "${CONDUCTOR_IS_LOCAL:-0}" = "1" ]; then exit 0; fi
+export PATH="$HOME/.local/bin:$PATH"
+command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
+command -v pkg-config >/dev/null 2>&1 || sudo dnf install -y -q pkgconf-pkg-config mariadb-connector-c-devel gcc python3-devel
+uv sync --frozen
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ pyrightconfig.json
 # Zed
 .zed/
 /.venv
+
+backlog_sweep/state/

--- a/backlog_sweep/FIXER_PROMPT.md
+++ b/backlog_sweep/FIXER_PROMPT.md
@@ -1,0 +1,144 @@
+# FIXER_PROMPT — One-Issue Implementation Contract
+
+Rendered by the dispatcher for exactly ONE issue and passed via `--message-file` to a
+fresh workspace. Model: `sonnet-4-6`, effort `high`. One issue per workspace, always —
+this is the structural guarantee against mixed PRs.
+
+The fixer pushes a branch but does **not** open the PR; the dispatcher opens it
+(**as a draft** — see the dispatcher notes at the foot of this file) from the fixer's
+reported title/body after validating scope. The fixer performs no other GitHub
+mutations.
+
+---
+
+## TEMPLATE START
+
+You are a fixer in an automated backlog sweep of
+PennyDreadfulMTG/Penny-Dreadful-Tools. Implement a fix for exactly ONE GitHub issue:
+**#{{ISSUE}} — {{TITLE}}** (task id {{BATCH_ID}}).
+
+Triage sketch (a hint, not gospel — re-derive the real fix yourself):
+{{FIX_SKETCH}}
+
+A deterministic dispatcher reads ONLY your final message's fenced JSON block.
+
+### Hard rules
+
+- Fix ONLY #{{ISSUE}}. No drive-by refactors, formatting sweeps, or "while I'm here"
+  changes. If you discover a second bug, mention it in `notes`; do not touch it.
+- Branch: `{{BRANCH}}` (already-decided name; create from current `origin/master`).
+  Commit and push ONLY this branch. Never push to master, never force-push, never
+  merge, never tag, never delete branches.
+- Do not open a PR, comment on issues, or change any GitHub issue state. Do not use
+  the `conductor` CLI. Never print credentials or env values.
+- Scope budget: aim well under 150 changed lines (excluding lockfiles/snapshots you
+  did not intend to touch — if those change, something is wrong; revert them). If the
+  true fix exceeds the budget or needs a schema/data migration, a product decision,
+  or touches auth/security, STOP coding and report `outcome: "abort-escalate"` with
+  your reasoning. An honest abort is a success.
+- Follow the repo's conventions: match surrounding code style; `AGENTS.md` applies
+  (no Docker; use `uv`).
+
+### Environment bootstrap (do this first, once)
+
+A fresh cloud workspace has `git`, `gh` and system Python but **no `uv`, no build
+dependencies and no database**. This exact sequence was verified end-to-end on
+2026-08-23 and gets you 687 passing unit tests in about 5 minutes. Run it before you
+start coding so you know early whether validation will be possible:
+
+```bash
+command -v uv || { curl -LsSf https://astral.sh/uv/install.sh | sh; export PATH="$HOME/.local/bin:$PATH"; }
+sudo dnf install -y pkgconf-pkg-config mariadb-connector-c-devel gcc python3-devel mariadb105-server
+sudo mariadb-install-db --user=mysql --datadir=/var/lib/mysql
+(sudo -u mysql /usr/sbin/mariadbd --datadir=/var/lib/mysql --socket=/var/lib/mysql/mysql.sock --bind-address=127.0.0.1 &) ; sleep 5
+python3 - <<'SQL' | sudo mysql
+import json
+pw = json.load(open('config.json'))['mysql_passwd'].replace("\\", "\\\\").replace("'", "\\'")
+for host in ("localhost", "%"):
+    print("CREATE USER IF NOT EXISTS 'pennydreadful'@'%s' IDENTIFIED BY '%s';" % (host, pw))
+    print("GRANT ALL PRIVILEGES ON *.* TO 'pennydreadful'@'%s' WITH GRANT OPTION;" % host)
+print("FLUSH PRIVILEGES;")
+SQL
+uv run --frozen python dev.py lint   # ~2s, needs no database
+```
+
+If any step fails, do NOT abandon the fix — `dev.py lint` works without a database
+and is the minimum bar. Record what failed in `tests.detail` and continue.
+Never print the contents of `config.json`; it holds real credentials.
+
+### Method
+
+1. `gh issue view {{ISSUE}} --comments` — understand the actual request, including
+   any narrowing in the comments.
+2. Locate the code path; write the minimal correct fix. Add or update a test when the
+   area has tests and a test is feasible without a live DB.
+3. Validate:
+   - `uv run --frozen python dev.py lint` (must pass on the files you touched)
+   - `uv run --frozen python dev.py unit` for the touched area (takes ~2 min for the
+     full suite once the bootstrap above has run). If the environment cannot run
+     these, record exactly what you ran and what failed for environmental reasons in
+     `tests.detail` — do NOT claim tests passed if they didn't run.
+4. Self-review `git diff origin/master...` — every hunk must serve #{{ISSUE}}.
+5. Commit (imperative one-line summary mentioning the issue, e.g.
+   `Fix <thing> (#{{ISSUE}})`) and push: `git push -u origin {{BRANCH}}`.
+6. Write the PR title/body for the dispatcher. Body must contain: what was wrong,
+   what changed, how it was validated (including any environmental test caveats,
+   honestly disclosed), and the line `Fixes #{{ISSUE}}`.
+
+### Output contract
+
+End your FINAL message with exactly one fenced JSON block:
+
+```json
+{
+  "backlog_sweep": "v1",
+  "role": "fix",
+  "batch_id": "{{BATCH_ID}}",
+  "results": [
+    {
+      "issue": {{ISSUE}},
+      "outcome": "pushed",
+      "branch": "{{BRANCH}}",
+      "head_sha": "abc1234def",
+      "files_changed": 3,
+      "lines_changed": 42,
+      "tests": {"command": "uv run --frozen python dev.py unit foo", "result": "passed", "detail": "12 passed"},
+      "lint": "passed",
+      "pr_title": "Fix <thing> so that <behavior> (#{{ISSUE}})",
+      "pr_body": "full markdown body ending with Fixes #{{ISSUE}}",
+      "risk": "low",
+      "notes": "<=3 sentences: caveats, discovered-but-untouched issues, reviewer pointers"
+    }
+  ]
+}
+```
+
+`outcome` ∈ `pushed | abort-escalate | failed`. For non-`pushed` outcomes set
+`branch`/`head_sha`/`pr_*` to null and explain in `notes` (and revert/delete any
+local work; do not push partial fixes). `tests.result` ∈
+`passed | failed | env-blocked | not-applicable` — never report `passed` unless the
+command ran and passed.
+
+## TEMPLATE END
+
+---
+
+### Dispatcher notes (not part of the fixer message)
+
+- `{{BRANCH}}` = `sweep/{{ISSUE}}-<slug-from-title>`; `{{BATCH_ID}}` = `f-<issue>-<attempt>`.
+- Before dispatching a fixer, the dispatcher checks no open PR already references the
+  issue and the branch doesn't exist (`DISPATCHER_SPEC.md` §6.3).
+- On `pushed`: dispatcher validates the report (branch exists at `head_sha`; diff stat
+  vs `origin/master` within budget; diff touches no forbidden paths:
+  `logsite_migrations/`, `.github/workflows/`, `Dockerfile`, `setup.py`,
+  `pyproject.toml` dependency sections) then opens the PR:
+  `gh pr create --base master --head <branch> --title … --body-file … --draft`
+  (**draft is mandatory** — see `DISPATCHER_SPEC.md` §8; Mergify auto-merges
+  non-draft PRs authored by bakert, so draft is the merge brake, and bakert marks
+  a PR ready for review when he has reviewed it). The dispatcher verifies
+  `isDraft=true` before journaling `PR_OPENED` and closes the PR if it is not.
+  Validation failure ⇒ escalate, do not open the PR.
+- `tests.result != "passed"` does not block the PR but must be disclosed in the body
+  (fixer already includes it; dispatcher verifies the body mentions it).
+- On `failed` after retry, or `abort-escalate`: dispatcher escalates to Opus and (for
+  abandoned pushes) deletes the remote branch if one was created.

--- a/backlog_sweep/FIXUP_PROMPT.md
+++ b/backlog_sweep/FIXUP_PROMPT.md
@@ -1,0 +1,144 @@
+# FIXUP_PROMPT — PR Remediation Contract (follow-up fixer)
+
+Rendered by the dispatcher for exactly ONE issue whose sweep PR is blocked, either by
+a failing check Mergify requires or by a merge conflict with master. Model: `sonnet-4-6`, effort `high`. Dispatched ONLY on an explicit
+manager adjudication (`queue-fixup`), at most once per PR.
+
+This is the one and only case where a fixer pushes to a branch that already exists —
+the branch and its draft PR were created by an earlier fixer and must be reused, not
+recreated.
+
+---
+
+## TEMPLATE START
+
+You are a CI remediation fixer in an automated backlog sweep of
+PennyDreadfulMTG/Penny-Dreadful-Tools.
+
+An earlier agent fixed GitHub issue **#{{ISSUE}} — {{TITLE}}** and opened draft PR
+**#{{PR}}** from branch **`{{BRANCH}}`**. That PR is now blocked. Your ONLY job is to
+unblock it without altering what the fix does (task id {{BATCH_ID}}).
+
+**Problem to fix: {{PROBLEM}}**
+
+Detail:
+
+```
+{{DETAIL}}
+```
+
+If the problem is a **merge conflict**, resolve it by merging master into the branch —
+`git fetch origin && git merge origin/master` — resolving each conflict so that both
+the PR's intent and whatever landed on master afterwards survive, then commit the
+merge normally. Do NOT rebase and do NOT force-push: a merge commit is fine here and
+keeps the branch append-only. If a conflict is genuinely ambiguous (someone else
+changed the same behaviour on purpose), stop and report `abort-escalate` rather than
+guessing whose change should win.
+
+If the problem is a **failing check**, reproduce it locally first (see Method below).
+
+A deterministic dispatcher reads ONLY your final message's fenced JSON block.
+
+### Environment bootstrap (do this first, once)
+
+A fresh cloud workspace has `git`, `gh` and system Python but no `uv`, no build
+dependencies and no database. This sequence was verified end-to-end and yields 687
+passing unit tests in about 5 minutes:
+
+```bash
+command -v uv || { curl -LsSf https://astral.sh/uv/install.sh | sh; export PATH="$HOME/.local/bin:$PATH"; }
+sudo dnf install -y pkgconf-pkg-config mariadb-connector-c-devel gcc python3-devel mariadb105-server
+sudo mariadb-install-db --user=mysql --datadir=/var/lib/mysql
+(sudo -u mysql /usr/sbin/mariadbd --datadir=/var/lib/mysql --socket=/var/lib/mysql/mysql.sock --bind-address=127.0.0.1 &) ; sleep 5
+python3 - <<'SQL' | sudo mysql
+import json
+pw = json.load(open('config.json'))['mysql_passwd'].replace("\\", "\\\\").replace("'", "\\'")
+for host in ("localhost", "%"):
+    print("CREATE USER IF NOT EXISTS 'pennydreadful'@'%s' IDENTIFIED BY '%s';" % (host, pw))
+    print("GRANT ALL PRIVILEGES ON *.* TO 'pennydreadful'@'%s' WITH GRANT OPTION;" % host)
+print("FLUSH PRIVILEGES;")
+SQL
+```
+
+Never print the contents of `config.json`; it holds real credentials.
+
+### Hard rules
+
+- Work ONLY on branch `{{BRANCH}}`: `git fetch origin && git checkout {{BRANCH}}`.
+  Do not branch off it, do not rebase onto anything, never force-push, never merge,
+  never touch master, never delete branches.
+- Do NOT change what the fix does. Fix the CI failure only: a type annotation, a lint
+  violation, a broken or now-stale test, a missing import. If making CI pass would
+  require changing the behaviour the PR intends, STOP and report
+  `outcome: "abort-escalate"`.
+- Do not open, close, comment on, label or re-title any PR or issue. Do not mark the
+  PR ready for review — it must stay a draft. Do not use the `conductor` CLI.
+- Keep the additional diff small; well under 50 changed lines on top of what is
+  already there. If the real remedy is bigger, that is an `abort-escalate`.
+- If the failure is clearly flaky or infrastructural rather than caused by this
+  change (network timeout, runner death, an unrelated pre-existing failure on
+  master), do NOT paper over it: report `outcome: "flaky"` and say why.
+
+### Method
+
+1. `gh pr view {{PR}} --json title,body` and `git log origin/master..{{BRANCH}}` —
+   understand what the PR is trying to do before you touch it.
+2. Reproduce the failure locally: run the specific failing check.
+   `uv run --frozen python dev.py lint` for `lint`/`mypy`,
+   `uv run --frozen python dev.py unit` for `test`, and for `jslint` use the repo's
+   npm lint script. Confirm you see the same failure CI saw before changing anything.
+3. Make the minimal change that fixes it. Re-run the same command until it passes,
+   then run `uv run --frozen python dev.py lint` and
+   `uv run --frozen python dev.py unit` so you do not trade one red check for another.
+4. `git diff origin/master...` — confirm every hunk still serves #{{ISSUE}} and that
+   your addition is confined to the CI fix.
+5. Commit (`Fix <check> failure (#{{ISSUE}})`) and `git push origin {{BRANCH}}`.
+
+### Output contract
+
+End your FINAL message with exactly one fenced JSON block:
+
+```json
+{
+  "backlog_sweep": "v1",
+  "role": "fix",
+  "batch_id": "{{BATCH_ID}}",
+  "results": [
+    {
+      "issue": {{ISSUE}},
+      "outcome": "pushed",
+      "branch": "{{BRANCH}}",
+      "head_sha": "abc1234def",
+      "files_changed": 1,
+      "lines_changed": 3,
+      "tests": {"command": "uv run --frozen python dev.py unit", "result": "passed", "detail": "687 passed"},
+      "lint": "passed",
+      "pr_title": null,
+      "pr_body": null,
+      "risk": "low",
+      "notes": "<=3 sentences: what was failing, what you changed, anything the reviewer should know"
+    }
+  ]
+}
+```
+
+`outcome` ∈ `pushed | abort-escalate | flaky | failed`. Set `branch`/`head_sha` to
+null for anything other than `pushed`. `pr_title`/`pr_body` are always null here — the
+PR already exists. `tests.result` ∈ `passed | failed | env-blocked | not-applicable`;
+never claim `passed` unless the command ran and passed.
+
+## TEMPLATE END
+
+---
+
+### Dispatcher notes (not part of the fixup message)
+
+- `{{BATCH_ID}}` = `u-<issue>-<attempt>`; dispatched only from a `queue-fixup`
+  adjudication, at most `config.max_fixup_attempts` (1) times per PR.
+- This is the ONLY path that bypasses the branch-must-not-exist and
+  no-open-PR-references-this-issue guards in `DISPATCHER_SPEC.md` §6.3; the bypass is
+  keyed on `issue.fixup` being set by the adjudication.
+- On `pushed` the issue returns to `pr_open` (the PR is adopted, not recreated) and
+  the CI watch resumes on the new head SHA.
+- On `abort-escalate`, `flaky` or `failed`, the issue escalates back to the manager,
+  who decides between a second look and `abandon-pr`.

--- a/backlog_sweep/README.md
+++ b/backlog_sweep/README.md
@@ -1,0 +1,68 @@
+# Backlog Sweep
+
+Tooling for running an AI-assisted sweep of this repo's GitHub issue backlog:
+triaging old issues with evidence, closing dead ones, and turning small isolated
+fixes into draft PRs — at a scale a human wouldn't attempt alone, under controls a
+human stays firmly in charge of.
+
+This directory is the reusable machinery plus the design docs from the first
+campaign (August 2026). It is plain Python (stdlib only), imports nothing from the
+rest of the repo, and nothing in the repo imports it.
+
+## What it did in its first outing (pilot, Aug 2026)
+
+- Read the 40 newest open issues below the previously-triaged frontier (#12787).
+- Closed 7 as verifiably already-fixed/obsolete — each with a comment citing the
+  fixing commit/PR, each independently re-verified by a second agent prompted to
+  refute the claim, and each carrying a "wrongly closed? please reopen" footer.
+- Opened ~20 small draft PRs (one issue per PR, ≤150 lines, lint/tests run and
+  honestly disclosed), all human-reviewed before merging.
+- Deferred every product decision, design call, data-retention change, and
+  ambiguous closure to a human digest instead of acting.
+
+## Safety properties (the important part)
+
+- **Nothing merges automatically.** PRs are opened as drafts, which neither GitHub
+  nor Mergify will merge. A human reviews and marks ready; Mergify takes it from
+  there. The dispatcher verifies `isDraft` after creation and closes the PR if
+  that ever fails.
+- **Closures are evidence-gated and double-checked.** A triage agent must cite a
+  commit/PR/code location; an independent verifier agent re-derives the claim from
+  scratch; the dispatcher re-checks for recent human activity before acting; caps
+  limit closures per day. "Cannot reproduce" never auto-closes.
+- **One issue per PR, structurally.** Each fix runs in its own throwaway
+  workspace on its own `sweep/<issue>-*` branch.
+- **The coordinator is deterministic.** `dispatcher.py` is a plain state machine —
+  no model calls — so leasing, retries, caps, circuit breakers, and audit logging
+  are exact and replayable. Agents only ever act inside contracts defined by the
+  prompt files here.
+- **Everything is auditable.** An append-only journal, plus per-issue evidence
+  files, mirrored to the never-merged `sweep-state` branch. Closure comments on
+  the issues themselves cite the evidence.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `dispatcher.py` | Deterministic coordinator (queue, leases, workspaces, GitHub writes, CI watch) |
+| `test_dispatcher.py` | Unit tests for the pure parts (111 tests, no network/DB) |
+| `WORKER_PROMPT.md`, `VERIFIER_PROMPT.md`, `FIXER_PROMPT.md`, `FIXUP_PROMPT.md` | Contracts handed to worker agents |
+| `config.example.json` | All tunables, shipped with every gate closed |
+| `RUNBOOK.md` | How to run a campaign |
+| `docs/` | Design docs from the first campaign (spec, state schema, plan, manager handoff) |
+
+Runtime state lives in `backlog_sweep/state/` (gitignored) and is mirrored to the
+`sweep-state` orphan branch. Issues, closures, and PRs all live in GitHub itself —
+this directory holds no issue data.
+
+Note: `docs/` reference the original `.context/backlog-sweep/` layout the first
+campaign ran from; the code now lives here, with prompts as siblings of
+`dispatcher.py` and state under `backlog_sweep/state/`.
+
+## Running it
+
+See `RUNBOOK.md`. Short version: it runs from a Conductor cloud workspace, spawns
+small worker agents in throwaway workspaces, and needs a human on the other end
+reviewing drafts and answering escalations. Every mutating capability
+(`spawning_enabled`, `mutations_enabled`, `closures_enabled`, `prs_enabled`)
+ships off in `config.example.json` and must be deliberately switched on.

--- a/backlog_sweep/RUNBOOK.md
+++ b/backlog_sweep/RUNBOOK.md
@@ -28,11 +28,12 @@ start from zero.
 
 ```bash
 cd <repo>
-python3 backlog_sweep/dispatcher.py --help       # sanity check
-cp backlog_sweep/config.example.json backlog_sweep/state/config.json  # after mkdir -p backlog_sweep/state
+uv run --frozen python backlog_sweep/dispatcher.py --help       # sanity check
+mkdir -p backlog_sweep/state
+cp backlog_sweep/config.example.json backlog_sweep/state/config.json
 # edit config: frontier_max/min for this campaign's issue range, pilot_limit, caps
-python3 backlog_sweep/dispatcher.py init         # enumerate the queue from GitHub
-python3 backlog_sweep/dispatcher.py tick --dry-run   # inspect the plan; journals nothing
+uv run --frozen python backlog_sweep/dispatcher.py init         # enumerate the queue from GitHub
+uv run --frozen python backlog_sweep/dispatcher.py tick --dry-run   # inspect the plan; journals nothing
 ```
 
 Then, deliberately and in this order:
@@ -45,7 +46,8 @@ Then, deliberately and in this order:
 4. `config set mutations_enabled=true prs_enabled=true closures_enabled=true`
    only with the owner's explicit sign-off, starting with pilot-sized caps
    (`daily_close_cap=15 daily_pr_cap=10 pilot_limit=40`).
-5. Start the daemon: `python3 backlog_sweep/dispatcher.py daemon` (backgrounded).
+5. Start the daemon:
+   `uv run --frozen python backlog_sweep/dispatcher.py daemon` (backgrounded).
    It ticks every 60 s; it is safe to kill and restart at any time.
 6. **Spot-check everything the pilot mutates** before raising any cap.
 
@@ -70,14 +72,48 @@ workspaces). `dispatcher.py status` prints a one-screen summary.
 
 ## Recovery (sandbox died, daemon crashed, anything)
 
-1. Fresh workspace on this repo. Restore state: check out `sweep-state` into
-   `backlog_sweep/state/` (journal + snapshot + evidence survive; ≤15 min loss).
-2. Re-create `state/.gh_token` (step 3 above).
-3. `python3 backlog_sweep/dispatcher.py recover` — replays the journal and
-   reconciles against live GitHub and live Conductor workspaces (adopts running
-   workers, expires dead leases, settles half-executed mutations, skips issues
-   humans closed meanwhile).
-4. Restart the daemon.
+1. Create a fresh workspace on the branch containing this toolkit (`master` once
+   this change is merged). Restore the mirrored state without switching away
+   from the code branch:
+
+   ```bash
+   git fetch origin sweep-state
+   mkdir -p backlog_sweep/state
+   git archive origin/sweep-state | tar -x -C backlog_sweep/state
+   ```
+
+   The journal, snapshot, evidence, and reports survive with at most the mirror
+   interval of loss. The PAT is deliberately absent.
+2. Re-create `backlog_sweep/state/.gh_token` with the classic `repo`-scoped PAT
+   from prerequisite 3. Enter it interactively so it does not land in shell
+   history:
+
+   ```bash
+   uv run --frozen python - <<'PY'
+   from getpass import getpass
+   from pathlib import Path
+
+   token_file = Path("backlog_sweep/state/.gh_token")
+   token_file.write_text(getpass("Classic GitHub PAT (repo scope): ").strip() + "\n")
+   token_file.chmod(0o600)
+   PY
+   ```
+3. Inspect before changing anything, then reconcile against live GitHub and
+   Conductor. Recovery adopts running workers, expires dead leases, settles
+   half-executed mutations, and skips issues humans closed meanwhile:
+
+   ```bash
+   uv run --frozen python backlog_sweep/dispatcher.py status
+   uv run --frozen python backlog_sweep/dispatcher.py recover --dry-run
+   uv run --frozen python backlog_sweep/dispatcher.py recover
+   uv run --frozen python backlog_sweep/dispatcher.py mirror
+   uv run --frozen python backlog_sweep/dispatcher.py status
+   ```
+
+   Confirm the restored config still has `spawning_enabled=false` before this
+   exercise if the goal is recovery validation rather than resuming work.
+4. Restart the daemon only after the recovery output is understood. Change gates
+   or caps separately, with the owner's explicit approval.
 
 ## Ending a campaign
 

--- a/backlog_sweep/RUNBOOK.md
+++ b/backlog_sweep/RUNBOOK.md
@@ -13,9 +13,10 @@ start from zero.
    (below) exists.
 2. **Claude Max subscription auth** for Conductor's cloud `claude` agents
    (workers bill to subscription, not metered API — verify before scaling).
-3. **A fine-grained GitHub PAT** with a single permission — Issues: Read/Write on
-   this repo only. Conductor's own GitHub token can push branches and manage PRs
-   but cannot comment on or close issues. Put it in
+3. **A classic GitHub PAT with `repo` scope.** This is the credential exercised
+   end-to-end by the pilot. Conductor's own GitHub token can push branches and
+   manage PRs but cannot comment on or close issues; once the PAT is present, the
+   dispatcher uses it for all `gh` operations, including PR operations. Put it in
    `backlog_sweep/state/.gh_token` (gitignored; never mirrored). It dies with
    the sandbox; re-paste on recovery.
 4. **A manager agent** (Opus-class recommended) in the manager workspace, given

--- a/backlog_sweep/RUNBOOK.md
+++ b/backlog_sweep/RUNBOOK.md
@@ -100,7 +100,8 @@ workspaces). `dispatcher.py status` prints a one-screen summary.
    ```
 3. Inspect before changing anything, then reconcile against live GitHub and
    Conductor. Recovery adopts running workers, expires dead leases, settles
-   half-executed mutations, and skips issues humans closed meanwhile:
+   half-executed mutations, skips issues humans closed meanwhile, and rebinds
+   escalation delivery to the current manager session:
 
    ```bash
    uv run --frozen python backlog_sweep/dispatcher.py status

--- a/backlog_sweep/RUNBOOK.md
+++ b/backlog_sweep/RUNBOOK.md
@@ -70,6 +70,30 @@ status, caps used, pause state, alerts (including unregistered `sweep-*`
 workspaces). `dispatcher.py status` prints a one-screen summary.
 `state/reports/` holds daily reports and the human digest.
 
+## Fresh recovery manager prompt
+
+Create an Opus-class manager session in a fresh Conductor cloud workspace on
+the branch containing this toolkit, then use this as its initial prompt:
+
+```text
+Act as the backlog-sweep recovery manager.
+
+Read backlog_sweep/README.md and backlog_sweep/RUNBOOK.md. Do not use
+backlog_sweep/docs/OPUS_HANDOFF.md as current operating instructions.
+
+This is recovery validation only. Keep spawning_enabled=false. Do not start the
+daemon, change gates, spawn workers, or mutate GitHub.
+
+Restore origin/sweep-state into backlog_sweep/state exactly as documented in the
+runbook, then run dispatcher status. Report the issue/status counts, last_seq,
+active workspace count, spawning_enabled value, and restored sweep-state commit.
+Stop before running recovery so I can install the PAT securely.
+```
+
+After the manager stops, enter the PAT through the workspace terminal as shown
+below, then tell it to continue with the dry-run and real recovery steps. Never
+paste the PAT into agent chat.
+
 ## Recovery (sandbox died, daemon crashed, anything)
 
 1. Create a fresh workspace on the branch containing this toolkit (`master` once

--- a/backlog_sweep/RUNBOOK.md
+++ b/backlog_sweep/RUNBOOK.md
@@ -1,0 +1,96 @@
+# Backlog Sweep Runbook
+
+How to run a sweep campaign. The first campaign (Aug 2026) piloted 40 issues; the
+remaining backlog (open issues #790–#12786) is queued for a Phase 2 whenever the
+owner says go. This runbook is written so a fresh manager agent, or a human, can
+start from zero.
+
+## Prerequisites
+
+1. **A Conductor cloud workspace on this repo** — the "manager". The dispatcher
+   daemon and campaign state live here. Cloud sandboxes have a ~24 h max
+   lifetime, which is why state mirrors off-sandbox (step 4) and why recovery
+   (below) exists.
+2. **Claude Max subscription auth** for Conductor's cloud `claude` agents
+   (workers bill to subscription, not metered API — verify before scaling).
+3. **A fine-grained GitHub PAT** with a single permission — Issues: Read/Write on
+   this repo only. Conductor's own GitHub token can push branches and manage PRs
+   but cannot comment on or close issues. Put it in
+   `backlog_sweep/state/.gh_token` (gitignored; never mirrored). It dies with
+   the sandbox; re-paste on recovery.
+4. **A manager agent** (Opus-class recommended) in the manager workspace, given
+   `docs/OPUS_HANDOFF.md`. Humans talk to the manager; nobody talks to workers.
+
+## Start a campaign
+
+```bash
+cd <repo>
+python3 backlog_sweep/dispatcher.py --help       # sanity check
+cp backlog_sweep/config.example.json backlog_sweep/state/config.json  # after mkdir -p backlog_sweep/state
+# edit config: frontier_max/min for this campaign's issue range, pilot_limit, caps
+python3 backlog_sweep/dispatcher.py init         # enumerate the queue from GitHub
+python3 backlog_sweep/dispatcher.py tick --dry-run   # inspect the plan; journals nothing
+```
+
+Then, deliberately and in this order (see `docs/OPUS_HANDOFF.md` for the full
+gate discipline):
+
+1. Run one **canary worker** to validate workspace boot, git push auth, and
+   output parsing.
+2. Create/confirm the **`sweep-state` mirror branch** and set `mirror` in config.
+   Do not proceed on local-only state.
+3. `config set spawning_enabled=true` — triage begins (read-only, safe).
+4. `config set mutations_enabled=true prs_enabled=true closures_enabled=true`
+   only with the owner's explicit sign-off, starting with pilot-sized caps
+   (`daily_close_cap=15 daily_pr_cap=10 pilot_limit=40`).
+5. Start the daemon: `python3 backlog_sweep/dispatcher.py daemon` (backgrounded).
+   It ticks every 60 s; it is safe to kill and restart at any time.
+6. **Spot-check everything the pilot mutates** before raising any cap.
+
+## Operating rules that are not optional
+
+- PRs are **drafts, always** (Mergify auto-merges non-draft green PRs authored by
+  the automerge team — draft is the merge brake). The owner's review action is
+  marking ready-for-review.
+- The sweep **never merges, never force-pushes, never touches labels**, never
+  edits `.github/workflows/`, migrations, or dependency manifests.
+- Product decisions, security-sensitive work, migrations, data-retention changes,
+  and ambiguous closures **escalate to a human digest** — no exceptions.
+- Humans should never chat with `sweep-*` worker windows; anything typed there is
+  invisible to the system. Talk to the manager session.
+
+## Monitoring
+
+`state/metrics.json` (rewritten every tick) is the whole dashboard: counts by
+status, caps used, pause state, alerts (including unregistered `sweep-*`
+workspaces). `dispatcher.py status` prints a one-screen summary.
+`state/reports/` holds daily reports and the human digest.
+
+## Recovery (sandbox died, daemon crashed, anything)
+
+1. Fresh workspace on this repo. Restore state: check out `sweep-state` into
+   `backlog_sweep/state/` (journal + snapshot + evidence survive; ≤15 min loss).
+2. Re-create `state/.gh_token` (step 3 above).
+3. `python3 backlog_sweep/dispatcher.py recover` — replays the journal and
+   reconciles against live GitHub and live Conductor workspaces (adopts running
+   workers, expires dead leases, settles half-executed mutations, skips issues
+   humans closed meanwhile).
+4. Restart the daemon.
+
+## Ending a campaign
+
+`report daily` one last time; write the campaign report from the journal; archive
+all `sweep-*` workspaces (verify they actually archived — the CLI can fail
+silently); push a final mirror; revoke the PAT. Fold any new calibration lessons
+into the prompt files here via a normal PR.
+
+## Lessons register (hard-won, do not relearn)
+
+- The "do not merge" label does nothing in this repo; drafts are the only brake.
+- `updatedAt` is useless as an activity guard (bulk labelling touches everything);
+  use non-bot comments.
+- Data-retention changes are never easy-fixes (#12781).
+- Workers classify off the issue's framing; make them check whether recent
+  commits already settled the question before classifying.
+- Trust nothing you didn't verify: check `isDraft` after PR creation, check
+  workspace state after archiving, fetch before verifying claims against master.

--- a/backlog_sweep/RUNBOOK.md
+++ b/backlog_sweep/RUNBOOK.md
@@ -19,8 +19,10 @@ start from zero.
    dispatcher uses it for all `gh` operations, including PR operations. Put it in
    `backlog_sweep/state/.gh_token` (gitignored; never mirrored). It dies with
    the sandbox; re-paste on recovery.
-4. **A manager agent** (Opus-class recommended) in the manager workspace, given
-   `docs/OPUS_HANDOFF.md`. Humans talk to the manager; nobody talks to workers.
+4. **A manager agent** (Opus-class recommended) in the manager workspace, told to
+   read this runbook and `README.md`. `docs/OPUS_HANDOFF.md` is the historical
+   build handoff from the first campaign, not current operating instructions.
+   Humans talk to the manager; nobody talks to workers.
 
 ## Start a campaign
 
@@ -33,8 +35,7 @@ python3 backlog_sweep/dispatcher.py init         # enumerate the queue from GitH
 python3 backlog_sweep/dispatcher.py tick --dry-run   # inspect the plan; journals nothing
 ```
 
-Then, deliberately and in this order (see `docs/OPUS_HANDOFF.md` for the full
-gate discipline):
+Then, deliberately and in this order:
 
 1. Run one **canary worker** to validate workspace boot, git push auth, and
    output parsing.

--- a/backlog_sweep/VERIFIER_PROMPT.md
+++ b/backlog_sweep/VERIFIER_PROMPT.md
@@ -1,0 +1,98 @@
+# VERIFIER_PROMPT — Independent Closure Verification Contract
+
+Rendered by the dispatcher for each verification batch (up to 5 closure claims) and
+passed via `--message-file` to a FRESH workspace — never the workspace that produced
+the claim. Model: `sonnet-4-6`, effort `high`.
+
+Independence rule: the verifier receives the **claim and its evidence refs only** —
+never the triage worker's notes, reasoning, or transcript. It is prompted as a
+skeptic whose job is to refute.
+
+---
+
+## TEMPLATE START
+
+You are an independent verifier in an automated backlog sweep of
+PennyDreadfulMTG/Penny-Dreadful-Tools. Another agent proposed closing the GitHub
+issues below. Your job is to try to **refute** each closure. A wrong closure hurts
+real users and erodes trust; a wrong refutation only costs a re-check. When in doubt,
+refute or mark uncertain — never confirm to be agreeable.
+
+Claims (batch id {{BATCH_ID}}):
+
+{{CLAIMS}}
+<!-- rendered per claim as:
+- issue: #12781 — "<issue title>"
+  proposed: already-fixed (close COMPLETED) | obsolete (close NOT_PLANNED) | duplicate of #NNNN (close NOT_PLANNED)
+  cited evidence: commit abc1234; decksite/views/foo.py:88
+-->
+
+A deterministic dispatcher reads ONLY your final message's fenced JSON block.
+
+### Hard rules
+
+- READ-ONLY. No file edits, no commits, no pushes, no GitHub mutations of any kind,
+  no PRs, never merge. Do not use the `conductor` CLI. Never print credentials.
+- Verify only the listed issues.
+
+### Method (per claim)
+
+1. Read the issue yourself: `gh issue view <n> --comments`. Form your own model of
+   what the reporter actually wanted — not what the claim says they wanted.
+2. Check the cited evidence directly: does the commit/PR exist, does it do what a
+   fix for THIS issue requires, does current master's code actually behave as
+   claimed? Read the code path, don't trust the citation.
+3. Actively hunt for refuting evidence: parts of the issue the fix doesn't cover,
+   comments that narrow/expand scope, the feature still existing when "obsolete" is
+   claimed, material differences when "duplicate" is claimed, human activity in the
+   last 90 days.
+4. Verdicts:
+   - `CONFIRMED` — you independently reproduced the conclusion from the evidence; a
+     skeptical human would close this without hesitation.
+   - `REFUTED` — the closure is wrong or overbroad; say exactly why.
+   - `UNCERTAIN` — plausible but you could not independently establish it (missing
+     evidence, partial fix, judgment call). Uncertain never closes.
+5. For CONFIRMED: review the proposed closing comment `{{PROPOSED_COMMENT}}` for
+   factual accuracy; supply a corrected `final_comment` if needed (1–3 sentences,
+   factual, cites evidence, no fluff, no apology-speak).
+
+### Output contract
+
+End your FINAL message with exactly one fenced JSON block, one entry per claim:
+
+```json
+{
+  "backlog_sweep": "v1",
+  "role": "verify",
+  "batch_id": "{{BATCH_ID}}",
+  "results": [
+    {
+      "issue": 12781,
+      "verdict": "CONFIRMED",
+      "own_evidence": [
+        {"type": "code", "ref": "decksite/views/foo.py:88", "detail": "independently checked: behavior matches request"}
+      ],
+      "refutation_reason": null,
+      "recent_human_activity": false,
+      "final_comment": "text to post when closing, or null if REFUTED/UNCERTAIN"
+    }
+  ]
+}
+```
+
+All keys present; `own_evidence` must contain at least one entry YOU checked (not a
+restatement of the cited refs). No markdown inside the JSON.
+
+## TEMPLATE END
+
+---
+
+### Dispatcher notes (not part of the verifier message)
+
+- Only `verdict: "CONFIRMED"` with `recent_human_activity: false` advances an issue
+  to `closing`. `REFUTED` and `UNCERTAIN` both escalate with the verifier's reason
+  attached (they are adjudicated by Opus, not retried automatically).
+- `{{BATCH_ID}}` = `v-<first_issue>-<attempt>`.
+- The dispatcher independently re-checks "no human activity in last 90 days" via
+  `gh issue view --json comments,updatedAt` before executing any closure, so a
+  verifier mistake here is not load-bearing.

--- a/backlog_sweep/WORKER_PROMPT.md
+++ b/backlog_sweep/WORKER_PROMPT.md
@@ -1,0 +1,119 @@
+# WORKER_PROMPT — Triage Worker Contract
+
+This is the message template the dispatcher renders (substituting `{{…}}`) and passes
+via `--message-file` to `conductor workspace create` for each triage batch.
+Model: `sonnet-4-6`, effort `high`. Batch size: 5 exact issue numbers.
+
+---
+
+## TEMPLATE START
+
+You are a triage worker in an automated backlog sweep of
+PennyDreadfulMTG/Penny-Dreadful-Tools. You investigate EXACTLY these GitHub issues and
+nothing else: **{{ISSUE_NUMBERS}}** (batch id {{BATCH_ID}}).
+
+A deterministic dispatcher — not a human — reads ONLY your final message, which must
+end with the fenced JSON block defined below. Text outside that block is ignored.
+
+### Hard rules
+
+- READ-ONLY: do not edit files, commit, push, or change any GitHub state. Do not
+  comment on, label, close, or reopen issues. Do not open PRs. Never merge anything.
+- Do not use the `conductor` CLI or Conductor API at all.
+- Never print environment variables or credentials.
+- Investigate only your assigned issue numbers. If an assigned issue is already
+  closed, classify it `skip-closed`.
+- Budget ~10 minutes per issue. If you can't reach a confident classification in that
+  time, use `unclear` — that is a valid, useful answer.
+
+### Method (per issue)
+
+1. `gh issue view <n> --comments` — read the issue and all comments.
+2. Investigate the current code in this workspace (checked out at current master):
+   grep for the feature/page/function, read the relevant code, check
+   `git log --oneline -S'<term>' -- <path>` / `git log --grep` for fixing commits,
+   and `gh pr list --search "<term>" --state merged` when a PR likely fixed it.
+3. If it's a bug report about site behavior you can check statically (templates,
+   routes, SQL, bot commands), read the code path. You do NOT have a running site or
+   database; never claim "cannot reproduce" merely because the environment lacks a
+   server — that is `env-limited`, not evidence.
+4. Classify with evidence. Every claim must cite something checkable by a stranger:
+   a commit SHA, `file.py:123` in current master, a merged PR number, or a duplicate
+   issue number. "I searched and found nothing" is only sufficient for `obsolete`
+   when the feature/page verifiably no longer exists (cite the removal commit or the
+   absent route/template).
+
+### Classifications
+
+| class | meaning | bar |
+|---|---|---|
+| `already-fixed` | The reported problem is verifiably fixed in current master | Cite the fixing commit/PR AND the current code that shows the fixed behavior |
+| `obsolete` | The feature/page/system it concerns no longer exists, or the request is moot | Cite the removal commit or show the code path is gone |
+| `duplicate` | Same underlying request/bug as another OPEN issue | Cite the other issue number; prefer keeping the older or better-specified one open |
+| `easy-fix` | Real, still-valid, and fixable in an isolated low-risk change | ≤ ~150 changed lines, no schema/data migration, **no change to what data is kept or deleted**, no product judgment, no security surface, tests plausible; include a concrete `fix_sketch` naming files |
+| `needs-work` | Real and valid but bigger than easy-fix | Explain scope in one sentence |
+| `question` | It's a discussion/decision, not an actionable defect | — |
+| `cannot-reproduce` | You have positive evidence current code should NOT exhibit the bug, but no identifiable fixing commit | Cite the code; this never auto-closes |
+| `needs-product-decision` | Valid but requires an owner's judgment call | Name the decision |
+| `security-sensitive` | Touches auth, sessions, permissions, secrets, PII, payments | — |
+| `migration-required` | Needs DB schema/data migration | — |
+| `unclear` | Can't determine within budget | Say what's missing |
+| `skip-closed` | Issue already closed when you looked | — |
+
+**Data-retention changes are never `easy-fix`.** If the change alters what data the
+site keeps, deletes, prunes or expires — removing or weakening a `cleanup()`, changing
+how long rows are retained, dropping historical records — classify it
+`needs-product-decision` no matter how small the diff. A one-line change that silently
+keeps or discards data forever is exactly the kind of decision an owner must make.
+(Calibration: #12781 was classified `easy-fix` and produced a tidy green PR that
+bakert rejected on precisely these grounds.)
+
+Confidence: `high` only when a skeptical reviewer following your evidence refs would
+reach the same conclusion without trusting you. Otherwise `medium`/`low`. Closures
+only ever happen from `high`.
+
+### Output contract
+
+End your FINAL message with exactly one fenced block, valid JSON, one result object
+per assigned issue (all of them, always):
+
+```json
+{
+  "backlog_sweep": "v1",
+  "role": "triage",
+  "batch_id": "{{BATCH_ID}}",
+  "results": [
+    {
+      "issue": 12781,
+      "class": "already-fixed",
+      "confidence": "high",
+      "evidence": [
+        {"type": "commit", "ref": "abc1234", "detail": "one line: what this shows"},
+        {"type": "code", "ref": "decksite/views/foo.py:88", "detail": "current behavior matches request"}
+      ],
+      "duplicate_of": null,
+      "proposed_comment": "1-3 sentences, plain factual tone, citing the evidence; null unless class is a closure candidate",
+      "fix_sketch": "null unless easy-fix: files to touch + approach in <=3 sentences",
+      "risk": "low",
+      "notes": "anything the verifier or manager should know, <=2 sentences"
+    }
+  ]
+}
+```
+
+evidence `type` ∈ `commit|code|pr|issue|search|behavior`. `ref` must be a SHA, a
+`path:line`, `#<number>`, or the exact search that came up empty. Keys may be null but
+must be present. No trailing commas, no comments, no markdown inside the JSON.
+
+## TEMPLATE END
+
+---
+
+### Dispatcher notes (not part of the worker message)
+
+- Render `{{ISSUE_NUMBERS}}` as a comma-separated list (`#12781, #12779, …`) and
+  `{{BATCH_ID}}` as `t-<first_issue>-<attempt>`.
+- Malformed/missing JSON handling and the corrective nudge message are specified in
+  `DISPATCHER_SPEC.md` §7.
+- A result for an issue NOT in the batch's lease set is discarded and journaled as
+  `RESULT_REJECTED` (defends against worker scope creep).

--- a/backlog_sweep/config.example.json
+++ b/backlog_sweep/config.example.json
@@ -1,0 +1,73 @@
+{
+  "auto_update_behind_branches": true,
+  "bot_logins": [
+    "github-actions",
+    "dependabot",
+    "codecov",
+    "renovate"
+  ],
+  "bundle_max_age_hours": 6,
+  "bundle_min_gap_hours": 2,
+  "bundle_min_items": 10,
+  "ci_recheck_minutes": 5,
+  "closures_enabled": false,
+  "concurrency_cap": 8,
+  "daily_close_cap": 15,
+  "daily_pr_cap": 10,
+  "forbidden_paths": [
+    "logsite_migrations/",
+    ".github/workflows/",
+    "Dockerfile",
+    "setup.py"
+  ],
+  "frontier_max": 12786,
+  "frontier_min": 790,
+  "github_token_file": "state/.gh_token",
+  "lease_minutes": {
+    "fix": 90,
+    "triage": 60,
+    "verify": 60
+  },
+  "max_fix_lines": 150,
+  "max_fixup_attempts": 1,
+  "max_open_prs": 30,
+  "max_stage_attempts": 2,
+  "max_total_workspaces": 500,
+  "min_session_age_seconds": 120,
+  "mirror": {
+    "interval_minutes": 15,
+    "kind": "branch",
+    "ref": "sweep-state"
+  },
+  "mutations_enabled": false,
+  "opus_session_id": null,
+  "pause_initial_minutes": 30,
+  "pause_max_minutes": 240,
+  "phase": "phase0",
+  "pilot_limit": 40,
+  "project_id": "6da35401-db77-48a7-b9bf-ab9aa3be1a64",
+  "prs_enabled": false,
+  "recent_activity_guard_days": 90,
+  "recent_activity_guard_mode": "comments",
+  "reclaim_orphan_branches": true,
+  "repo": "PennyDreadfulMTG/Penny-Dreadful-Tools",
+  "required_checks": [
+    "mypy",
+    "lint",
+    "test",
+    "jslint"
+  ],
+  "retry_sleeps": [
+    5,
+    25,
+    125
+  ],
+  "schema": 1,
+  "spawning_enabled": false,
+  "stale_transcript_minutes": 20,
+  "subprocess_timeout": 120,
+  "triage_batch_size": 5,
+  "verify_batch_size": 5,
+  "worker_effort": "high",
+  "worker_model": "sonnet-4-6"
+}

--- a/backlog_sweep/dispatcher.py
+++ b/backlog_sweep/dispatcher.py
@@ -1,0 +1,2984 @@
+#!/usr/bin/env python3
+"""Deterministic, restartable, zero-token backlog-sweep dispatcher.
+
+Implements DISPATCHER_SPEC.md / STATE_SCHEMA.md.  Stdlib only, Python 3.9+.
+
+Deviations from the spec (all documented in state/reports/phase0.md):
+  * Conductor is driven through its REST API (/v0/...) via urllib rather than the
+    `conductor` CLI, because the CLI cannot return message *content* at all
+    (`conductor session message` lists ids only, `conductor message get` prints
+    metadata only) and truncates every `conductor sql` cell at ~119 characters.
+    Same credentials, same endpoints the CLI itself calls.
+  * Journal uses RESULT_RECORDED for all three roles (no separate VERIFY_RECORDED)
+    and adds ISSUE_SKIPPED.
+"""
+
+import argparse
+import datetime as dt
+import errno
+import fcntl
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parent
+STATE = BASE / "state"
+EVIDENCE = STATE / "evidence"
+ESCALATIONS = STATE / "escalations"
+REPORTS = STATE / "reports"
+OUTBOX = STATE / "outbox"
+LOCKFILE = STATE / ".lock"
+JOURNAL = STATE / "journal.jsonl"
+SNAPSHOT = STATE / "snapshot.json"
+CONFIG = STATE / "config.json"
+QUEUE = STATE / "queue.json"
+METRICS = STATE / "metrics.json"
+LOGFILE = STATE / "dispatcher.log"
+PIDFILE = STATE / "daemon.pid"
+MIRROR_DIR = STATE / ".mirror"
+
+DEFAULT_CONFIG = {
+    "schema": 1,
+    "phase": "phase0",
+    "repo": "PennyDreadfulMTG/Penny-Dreadful-Tools",
+    "frontier_max": 12786,
+    "frontier_min": 790,
+    "pilot_limit": 40,
+    "concurrency_cap": 8,
+    "daily_close_cap": 15,
+    "daily_pr_cap": 10,
+    # Backpressure: hard ceiling on sweep PRs open on GitHub at once, counted
+    # live because bakert merges and closes them outside our state.
+    "max_open_prs": 30,
+    "max_total_workspaces": 500,
+    "triage_batch_size": 5,
+    "verify_batch_size": 5,
+    "lease_minutes": {"triage": 45, "verify": 45, "fix": 90},
+    "max_stage_attempts": 2,
+    "mutations_enabled": False,
+    # Sub-gates under mutations_enabled. The GH_TOKEN available to this sandbox is a
+    # GitHub App user-to-server token with issues=READ / pull_requests=WRITE, so
+    # closures are off until bakert grants issues:write (verified 2026-08-23).
+    "closures_enabled": False,
+    "prs_enabled": True,
+    "spawning_enabled": True,
+    # The four checks Mergify requires before it will merge (.mergify.yml).
+    "required_checks": ["mypy", "lint", "test", "jslint"],
+    "ci_recheck_minutes": 5,
+    "auto_update_behind_branches": True,
+    "max_fixup_attempts": 1,
+    "reclaim_orphan_branches": True,
+    # Path to a file holding a PAT with Issues:RW + Pull requests:RW on this repo.
+    # Read into memory only, never logged, never mirrored, never passed in argv.
+    "github_token_file": "state/.gh_token",
+    "worker_model": "sonnet-4-6",
+    "worker_effort": "high",
+    "project_id": "6da35401-db77-48a7-b9bf-ab9aa3be1a64",
+    "opus_session_id": None,
+    "mirror": {"kind": "none", "ref": "sweep-state", "interval_minutes": 15},
+    "stale_transcript_minutes": 20,
+    "recent_activity_guard_days": 90,
+    # "comments" (approved by bakert 2026-08-23) or "updated_at" (original spec).
+    # Bulk labelling makes updatedAt meaningless in this repo.
+    "recent_activity_guard_mode": "comments",
+    "min_session_age_seconds": 120,
+    "max_fix_lines": 150,
+    "bundle_min_items": 10,
+    "bundle_max_age_hours": 6,
+    "bundle_min_gap_hours": 2,
+    "pause_initial_minutes": 30,
+    "pause_max_minutes": 240,
+    "subprocess_timeout": 120,
+    "retry_sleeps": [5, 25, 125],
+    "forbidden_paths": [
+        "logsite_migrations/",
+        ".github/workflows/",
+        "Dockerfile",
+        "setup.py",
+    ],
+    "bot_logins": ["github-actions", "dependabot", "codecov", "renovate"],
+}
+
+CLOSURE_CLASSES = {"already-fixed": "completed", "obsolete": "not_planned", "duplicate": "not_planned"}
+REPORT_ONLY_CLASSES = {"needs-work", "question", "cannot-reproduce", "env-limited"}
+ESCALATE_CLASSES = {
+    "needs-product-decision",
+    "security-sensitive",
+    "migration-required",
+    "destructive-action",
+    "unclear",
+}
+TRIAGE_CLASSES = set(CLOSURE_CLASSES) | REPORT_ONLY_CLASSES | ESCALATE_CLASSES | {"easy-fix", "skip-closed"}
+
+TERMINAL = {"closed", "pr_open", "reported", "deferred_human", "failed", "skipped"}
+
+PERMISSION_RE = re.compile(
+    r"Resource not accessible by integration|HTTP 403|Must have admin rights|"
+    r"not authorized|Forbidden", re.I)
+
+LEGAL = {
+    "pending": {"triage_leased", "skipped", "escalated"},
+    "triage_leased": {"triaged", "pending", "escalated", "skipped"},
+    "triaged": {"verify_pending", "fix_pending", "reported", "escalated", "skipped"},
+    "verify_pending": {"verify_leased", "escalated", "skipped"},
+    "verify_leased": {"verified", "escalated", "verify_pending", "skipped"},
+    "verified": {"closing", "escalated", "skipped"},
+    "closing": {"closed", "escalated", "verified"},
+    "closed": {"escalated", "pending"},  # rollback only
+    "fix_pending": {"fix_leased", "escalated", "skipped"},
+    "fix_leased": {"fix_pushed", "fix_pending", "escalated", "skipped"},
+    "fix_pushed": {"pr_open", "escalated", "pr_ci_failed"},
+    "pr_open": {"escalated", "pr_ci_failed", "deferred_human", "closed"},
+    "pr_ci_failed": {"fix_pending", "deferred_human", "escalated", "pr_open", "failed", "closed"},
+    "reported": {"escalated"},
+    "escalated": {
+        "closing", "fix_pending", "reported", "pending", "verify_pending",
+        "verified", "fix_pushed", "deferred_human", "failed", "closed", "skipped",
+    },
+    # Terminal for the sweep's own machinery, but bakert can hand an item back.
+    # Guarded by ADJUDICATION_ONLY so an automatic retry can never resurrect an
+    # issue a human settled (e.g. a PR they closed unmerged).
+    "deferred_human": {"fix_pending", "verify_pending", "pending", "reported", "escalated",
+                       "closing"},
+    "failed": set(),
+    "skipped": set(),
+}
+
+# Statuses only a human adjudication may leave. Automatic machinery (retries,
+# lease expiry) must not move an issue out of these.
+ADJUDICATION_ONLY = {"deferred_human"}
+
+RATE_LIMIT_RE = re.compile(r"rate.?limit|overloaded|429|usage limit|quota", re.I)
+SECRET_RE = re.compile(r"(?i)\b(token|key|secret|authorization|bearer)([=:]\s*|\s+)(\S+)")
+
+
+# --------------------------------------------------------------------------- utils
+
+def utcnow():
+    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+
+
+def iso(t):
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_iso(s):
+    if not s:
+        return None
+    s = s.strip().replace("Z", "+00:00")
+    try:
+        d = dt.datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if d.tzinfo is None:
+        d = d.replace(tzinfo=dt.UTC)
+    return d.astimezone(dt.UTC)
+
+
+def slugify(title, maxlen=40):
+    s = re.sub(r"[^a-z0-9]+", "-", (title or "").lower()).strip("-")
+    if len(s) > maxlen:
+        s = s[:maxlen].rstrip("-")
+    return s or "issue"
+
+
+def write_atomic(path, data):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        fh.write(data)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
+
+
+def write_json(path, obj):
+    write_atomic(path, json.dumps(obj, indent=2, sort_keys=True) + "\n")
+
+
+def read_json(path, default=None):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return default
+
+
+class Scrubber:
+    """Replaces credential-looking substrings in anything we log."""
+
+    ENV_KEYS = (
+        "CONDUCTOR_API_KEY", "CONDUCTOR_API_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+        "CONDUCTOR_INTERNAL_WORKSPACE_AUTH", "CONDUCTOR_INTERNAL_INCOMING_AUTH",
+        "CONDUCTOR_INTERNAL_OTEL_INGEST_TOKEN", "CONDUCTOR_INTERNAL_WDA_VERIFY_KEY",
+    )
+
+    def __init__(self, env=None):
+        env = env if env is not None else os.environ
+        self.values = sorted(
+            {v for k in self.ENV_KEYS for v in [env.get(k)] if v and len(v) >= 8},
+            key=len, reverse=True,
+        )
+
+    def __call__(self, text):
+        if text is None:
+            return None
+        if not isinstance(text, str):
+            text = str(text)
+        for v in self.values:
+            text = text.replace(v, "[REDACTED]")
+        return SECRET_RE.sub(lambda m: "%s%s[REDACTED]" % (m.group(1), m.group(2)), text)
+
+
+SCRUB = Scrubber()
+
+
+def load_gh_token():
+    """Read the operator-supplied PAT, if present, for `gh` subprocesses only.
+
+    Lives in a file rather than the environment so it stays in this workspace: the
+    dispatcher never passes it to a worker workspace, never puts it in argv, and
+    never mirrors it. Reading it also registers it with the log scrubber.
+    """
+    rel = (read_json(CONFIG) or {}).get("github_token_file") or DEFAULT_CONFIG["github_token_file"]
+    path = BASE / rel if not os.path.isabs(rel) else Path(rel)
+    try:
+        token = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return {}
+    if not token:
+        return {}
+    mode = path.stat().st_mode & 0o077
+    if mode:
+        log("WARNING: %s is group/world readable; tighten it with chmod 600" % path.name)
+    if token not in SCRUB.values:
+        SCRUB.values.append(token)
+        SCRUB.values.sort(key=len, reverse=True)
+    return {"GH_TOKEN": token, "GITHUB_TOKEN": token}
+
+
+def gh_token_present():
+    return bool(load_gh_token())
+
+
+def gh_executable():
+    """Resolve which `gh` to run.
+
+    The `gh` on PATH in a Conductor sandbox is a shim that does
+    `GH_TOKEN="$broker_token" exec real_gh ...`, so it silently discards any token
+    we put in the environment. When the operator has supplied a PAT we therefore
+    invoke the real binary directly; otherwise we keep the shim, which is what
+    supplies credentials in the first place.
+    """
+    if not load_gh_token():
+        return "gh"
+    real = os.environ.get("CONDUCTOR_REAL_GH_PATH")
+    if real and os.access(real, os.X_OK):
+        return real
+    log("WARNING: operator token present but CONDUCTOR_REAL_GH_PATH is unusable; "
+        "falling back to the gh shim, which will override it")
+    return "gh"
+
+
+def rotate_log():
+    try:
+        if LOGFILE.exists() and LOGFILE.stat().st_size > 10 * 1024 * 1024:
+            for i in range(4, 0, -1):
+                src = LOGFILE.with_suffix(".log.%d" % i)
+                if src.exists():
+                    src.rename(LOGFILE.with_suffix(".log.%d" % (i + 1)))
+            LOGFILE.rename(LOGFILE.with_suffix(".log.1"))
+    except OSError:
+        pass
+
+
+def log(msg, echo=False):
+    STATE.mkdir(parents=True, exist_ok=True)
+    rotate_log()
+    line = "%s %s\n" % (iso(utcnow()), SCRUB(msg))
+    with open(LOGFILE, "a", encoding="utf-8") as fh:
+        fh.write(line)
+    if echo:
+        sys.stdout.write(line)
+
+
+# ------------------------------------------------------------------- pure helpers
+
+def extract_json_block(text, role=None, batch_id=None):
+    """Return the last fenced JSON object that looks like a backlog_sweep result.
+
+    Falls back to unfenced balanced objects.  Returns None when nothing matches.
+    """
+    if not text:
+        return None
+    candidates = []
+    for m in re.finditer(r"```(?:json|JSON)?[ \t]*\r?\n(.*?)```", text, re.S):
+        candidates.append(m.group(1))
+    if not candidates:
+        candidates = _balanced_objects(text)
+    best = None
+    for raw in candidates:
+        obj = _try_json(raw)
+        if obj is None:
+            continue
+        if not isinstance(obj, dict) or obj.get("backlog_sweep") != "v1":
+            continue
+        if role is not None and obj.get("role") != role:
+            continue
+        if batch_id is not None and obj.get("batch_id") != batch_id:
+            continue
+        best = obj
+    if best is None:
+        # tolerate a correct-shaped block whose role/batch_id drifted
+        for raw in candidates:
+            obj = _try_json(raw)
+            if isinstance(obj, dict) and obj.get("backlog_sweep") == "v1" and "results" in obj:
+                best = obj
+    return best
+
+
+def _try_json(raw):
+    raw = raw.strip()
+    if not raw.startswith("{"):
+        i = raw.find("{")
+        if i < 0:
+            return None
+        raw = raw[i:]
+    try:
+        return json.loads(raw)
+    except ValueError:
+        return None
+
+
+def _balanced_objects(text):
+    out, depth, start, instr, esc = [], 0, None, False, False
+    for i, ch in enumerate(text):
+        if instr:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                instr = False
+            continue
+        if ch == '"':
+            instr = True
+        elif ch == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == "}":
+            if depth:
+                depth -= 1
+                if depth == 0 and start is not None:
+                    out.append(text[start:i + 1])
+    return out
+
+
+def render_template(md_path, mapping):
+    """Extract the region between TEMPLATE START/END and substitute {{KEYS}}."""
+    text = Path(md_path).read_text(encoding="utf-8")
+    m = re.search(r"^##\s+TEMPLATE START\s*$(.*?)^##\s+TEMPLATE END\s*$", text, re.S | re.M)
+    if not m:
+        raise RuntimeError("no TEMPLATE START/END markers in %s" % md_path)
+    body = m.group(1).strip("\n")
+    for k, v in mapping.items():
+        body = body.replace("{{%s}}" % k, "" if v is None else str(v))
+    left = re.findall(r"\{\{([A-Z_]+)\}\}", body)
+    if left:
+        raise RuntimeError("unsubstituted placeholders %s in %s" % (sorted(set(left)), md_path))
+    return body + "\n"
+
+
+def render_claims(claims):
+    """Render verifier claim list (independence rule: no triage notes)."""
+    lines = []
+    for c in claims:
+        cls = c["class"]
+        if cls == "duplicate":
+            proposed = "duplicate of #%s (close NOT_PLANNED)" % c.get("duplicate_of")
+        elif cls == "already-fixed":
+            proposed = "already-fixed (close COMPLETED)"
+        else:
+            proposed = "obsolete (close NOT_PLANNED)"
+        refs = "; ".join(
+            "%s %s" % (e.get("type"), e.get("ref")) for e in (c.get("evidence") or [])
+        ) or "none cited"
+        lines.append('- issue: #%s — "%s"' % (c["issue"], (c.get("title") or "").replace('"', "'")))
+        lines.append("  proposed: %s" % proposed)
+        lines.append("  cited evidence: %s" % refs)
+        lines.append("  proposed closing comment: %s" % (c.get("proposed_comment") or "(none supplied)"))
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+CLOSURE_TAG = (
+    "\n\n<sub>Automated backlog sweep; independently verified. "
+    "Wrongly closed? Please reopen.</sub>"
+)
+
+
+def render_closure_comment(final_comment):
+    return (final_comment or "").strip() + CLOSURE_TAG
+
+
+def lease_is_expired(lease, now, pause_seconds=0):
+    exp = parse_iso(lease.get("expires_at"))
+    if exp is None:
+        return True
+    return now > exp + dt.timedelta(seconds=pause_seconds)
+
+
+def eligible_issue_numbers(issues, pilot_limit):
+    """Issue numbers eligible for leasing under pilot_limit (highest first)."""
+    nums = sorted((int(n) for n in issues), reverse=True)
+    if pilot_limit and pilot_limit > 0:
+        nums = nums[:pilot_limit]
+    return nums
+
+
+# ------------------------------------------------------------------ subprocesses
+
+class InfraError(Exception):
+    def __init__(self, msg, output=""):
+        Exception.__init__(self, msg)
+        self.output = output or ""
+
+
+class Runner:
+    """Subprocess runner: 120 s timeout, 3 attempts, exponential backoff."""
+
+    def __init__(self, cfg, sleeper=time.sleep, env_overlay=None):
+        self.cfg = cfg
+        self.sleep = sleeper
+        self.infra_failures = []  # timestamps
+        self.env_overlay = env_overlay or {}
+
+    def run(self, argv, input_text=None, check=True, retries=None, timeout=None):
+        timeout = timeout or self.cfg.get("subprocess_timeout", 120)
+        sleeps = self.cfg.get("retry_sleeps", [5, 25, 125])
+        attempts = retries if retries is not None else len(sleeps)
+        last = None
+        for i in range(attempts):
+            t0 = time.time()
+            try:
+                env = None
+                if self.env_overlay:
+                    env = dict(os.environ)
+                    env.update(self.env_overlay)
+                p = subprocess.run(
+                    argv, input=input_text, capture_output=True, text=True, timeout=timeout,
+                    env=env,
+                )
+                rc, out, err = p.returncode, p.stdout, p.stderr
+            except subprocess.TimeoutExpired:
+                rc, out, err = -1, "", "TIMEOUT after %ss" % timeout
+            except OSError as exc:
+                rc, out, err = -1, "", "OSError: %s" % exc
+            dur = time.time() - t0
+            log("exec rc=%s %.1fs %s :: %s" % (rc, dur, " ".join(argv[:6]), SCRUB((out + err)[:400])))
+            if rc == 0:
+                return out if check else (out + err)
+            last = InfraError("%s exited %s" % (argv[0], rc), out + err)
+            if not check:
+                return out + err
+            if i < attempts - 1:
+                self.sleep(sleeps[min(i, len(sleeps) - 1)])
+        self.infra_failures.append(utcnow())
+        raise last
+
+    def recent_infra_failures(self, minutes=10):
+        cut = utcnow() - dt.timedelta(minutes=minutes)
+        self.infra_failures = [t for t in self.infra_failures if t >= cut]
+        return len(self.infra_failures)
+
+
+class Conductor:
+    """Conductor /v0 REST client (same endpoints the `conductor` CLI calls)."""
+
+    def __init__(self, cfg, sleeper=time.sleep):
+        self.cfg = cfg
+        self.sleep = sleeper
+        self.base = os.environ.get("CONDUCTOR_API_URL", "https://api.conductor.build").rstrip("/")
+        self._auth = os.environ.get("CONDUCTOR_API_KEY") or os.environ.get("CONDUCTOR_API_TOKEN")
+        if not self._auth:
+            raise RuntimeError("CONDUCTOR_API_KEY / CONDUCTOR_API_TOKEN not set")
+        self.infra_failures = []
+        self.client_version = os.environ.get("CONDUCTOR_INTERNAL_APP_VERSION", "0.0.0")
+        self.session_id = os.environ.get("CONDUCTOR_SESSION_ID")
+
+    def _request(self, method, path, query=None, body=None):
+        url = self.base + path
+        if query:
+            q = {k: v for k, v in query.items() if v is not None}
+            if q:
+                url += "?" + urllib.parse.urlencode(q)
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
+        req.add_header("Authorization", "Bearer " + self._auth)
+        if data is not None:
+            # Only declare a JSON body when we are sending one. A body-less POST
+            # with Content-Type: application/json is rejected by the API's Fastify
+            # layer with FST_ERR_CTP_EMPTY_JSON_BODY, which is what silently broke
+            # every workspace archive (and would have broken session cancel).
+            req.add_header("Content-Type", "application/json")
+        req.add_header("Accept", "application/json")
+        # Cloudflare in front of the API rejects the default Python-urllib UA with
+        # error 1010, so we identify exactly as the CLI does.
+        req.add_header("User-Agent", "conductor-cli/%s" % self.client_version)
+        req.add_header("x-conductor-client-type", "cli")
+        req.add_header("x-conductor-client-version", self.client_version)
+        if self.session_id:
+            req.add_header("x-conductor-session-id", self.session_id)
+        sleeps = self.cfg.get("retry_sleeps", [5, 25, 125])
+        last = None
+        for i in range(len(sleeps)):
+            try:
+                with urllib.request.urlopen(req, timeout=self.cfg.get("subprocess_timeout", 120)) as r:
+                    raw = r.read().decode("utf-8", "replace")
+                log("api %s %s -> %s (%d bytes)" % (method, path, r.status, len(raw)))
+                return json.loads(raw) if raw.strip() else {}
+            except urllib.error.HTTPError as exc:
+                raw = exc.read().decode("utf-8", "replace")[:400]
+                log("api %s %s -> HTTP %s %s" % (method, path, exc.code, SCRUB(raw)))
+                if 400 <= exc.code < 500 and exc.code not in (403, 408, 425, 429):
+                    raise InfraError("HTTP %s on %s" % (exc.code, path), raw)
+                last = InfraError("HTTP %s on %s" % (exc.code, path), raw)
+            except Exception as exc:  # noqa: BLE001 - network layer
+                log("api %s %s -> %s" % (method, path, SCRUB(str(exc))))
+                last = InfraError(str(exc))
+            if i < len(sleeps) - 1:
+                self.sleep(sleeps[i])
+        self.infra_failures.append(utcnow())
+        raise last
+
+    # -- verbs -------------------------------------------------------------
+    def create_workspace(self, name, session_name, message, model, effort, project_id):
+        return self._request("POST", "/v0/workspaces", body={
+            "projectId": project_id, "name": name, "sessionName": session_name,
+            "agent": "claude", "model": model, "effort": effort, "message": message,
+        })
+
+    def list_project_workspaces(self, project_id, limit=100):
+        return self._request("GET", "/v0/projects/%s/workspaces" % urllib.parse.quote(project_id),
+                             query={"limit": limit})
+
+    def list_workspaces(self, name=None, include_archived=False, limit=100):
+        return self._request("GET", "/v0/workspaces", query={
+            "name": name, "limit": limit,
+            "includeArchived": "true" if include_archived else None,
+        })
+
+    def workspace_status(self, wid):
+        return self._request("GET", "/v0/workspaces/%s/status" % urllib.parse.quote(wid))
+
+    def list_sessions(self, wid):
+        return self._request("GET", "/v0/workspaces/%s/sessions" % urllib.parse.quote(wid))
+
+    def archive_workspace(self, wid):
+        return self._request("POST", "/v0/workspaces/%s/archive" % urllib.parse.quote(wid))
+
+    def session_status(self, sid):
+        return self._request("GET", "/v0/sessions/%s/status" % urllib.parse.quote(sid))
+
+    def cancel_session(self, sid):
+        return self._request("POST", "/v0/sessions/%s/cancel" % urllib.parse.quote(sid))
+
+    def messages(self, sid, limit=100, offset=0):
+        return self._request("GET", "/v0/sessions/%s/messages" % urllib.parse.quote(sid),
+                             query={"limit": limit, "offset": offset})
+
+    def send_message(self, sid, text, message_id=None):
+        body = {"message": text}
+        if message_id:
+            body["messageId"] = message_id
+        return self._request("POST", "/v0/sessions/%s/messages" % urllib.parse.quote(sid), body=body)
+
+    def sql(self, query):
+        return self._request("POST", "/v0/sql", body={"query": query})
+
+    # -- derived -----------------------------------------------------------
+    def all_messages(self, sid, cap=2000):
+        out, offset = [], 0
+        while offset < cap:
+            r = self.messages(sid, limit=100, offset=offset)
+            batch = r.get("data") or []
+            out.extend(batch)
+            if not r.get("hasMore") or not batch:
+                break
+            offset += len(batch)
+        return out
+
+    def assistant_texts(self, messages):
+        texts = []
+        for m in messages:
+            rp = (m.get("content") or {}).get("rawPayload") or {}
+            if rp.get("type") != "assistant":
+                continue
+            chunks = []
+            for blk in ((rp.get("message") or {}).get("content") or []):
+                if isinstance(blk, dict) and blk.get("type") == "text" and blk.get("text"):
+                    chunks.append(blk["text"])
+            if chunks:
+                texts.append("\n".join(chunks))
+        return texts
+
+    def rate_limit_state(self, messages):
+        """Most recent rate_limit_event status, or None."""
+        for m in reversed(messages):
+            rp = (m.get("content") or {}).get("rawPayload") or {}
+            if rp.get("type") == "rate_limit_event":
+                return (rp.get("rate_limit_info") or {})
+        return None
+
+    def transcript_updated(self, session_ids):
+        if not session_ids:
+            return {}
+        quoted = ",".join("'%s'" % s.replace("'", "") for s in session_ids)
+        rows = self.sql(
+            "SELECT session_id, transcript_updated_at FROM session_transcripts_view "
+            "WHERE session_id IN (%s)" % quoted
+        ).get("rows") or []
+        return {r["session_id"]: r.get("transcript_updated_at") for r in rows}
+
+
+class GitHub:
+    def __init__(self, runner, repo, gh_bin=None):
+        self._run = runner.run
+        self.repo = repo
+        self.gh = gh_bin or "gh"
+
+    def run(self, argv, **kw):
+        if argv and argv[0] == "gh":
+            argv = [self.gh] + list(argv[1:])
+        return self._run(argv, **kw)
+
+    def _json(self, argv):
+        out = self.run(argv)
+        try:
+            return json.loads(out)
+        except ValueError:
+            raise InfraError("gh returned non-JSON", out[:400])
+
+    def list_open_issues(self, limit=1000):
+        return self._json([
+            "gh", "issue", "list", "--repo", self.repo, "--state", "open",
+            "--limit", str(limit), "--json", "number,title,labels,updatedAt",
+        ])
+
+    def issue(self, number, fields="state,updatedAt,comments,title,labels"):
+        return self._json([
+            "gh", "issue", "view", str(number), "--repo", self.repo, "--json", fields,
+        ])
+
+    def close_issue(self, number, reason, comment):
+        return self.run([
+            "gh", "issue", "close", str(number), "--repo", self.repo,
+            "--reason", reason, "--comment", comment,
+        ])
+
+    def reopen_issue(self, number):
+        return self.run(["gh", "issue", "reopen", str(number), "--repo", self.repo])
+
+    def open_prs_mentioning(self, number):
+        return self._json([
+            "gh", "pr", "list", "--repo", self.repo, "--state", "open",
+            "--search", "%s in:title,body" % number, "--json", "number,title",
+        ])
+
+    def prs_for_branch(self, branch):
+        return self._json([
+            "gh", "pr", "list", "--repo", self.repo, "--head", branch,
+            "--state", "all", "--json", "number,url,state",
+        ])
+
+    def create_pr(self, branch, title, body_file):
+        # --draft is the merge brake for this campaign (bakert, 2026-08-23): Mergify
+        # auto-merges his non-draft PRs once CI is green, and both GitHub and Mergify
+        # refuse to merge a draft. His review action is clicking "Ready for review".
+        return self.run([
+            "gh", "pr", "create", "--repo", self.repo, "--base", "master", "--draft",
+            "--head", branch, "--title", title, "--body-file", str(body_file),
+        ])
+
+    def count_open_sweep_prs(self):
+        """Live count of open sweep PRs.
+
+        Deliberately not derived from internal state: bakert merges and closes PRs
+        outside the sweep, so our own `pr_open` count drifts high and would throttle
+        us against PRs he has already cleared.
+        """
+        rows = self._json([
+            "gh", "pr", "list", "--repo", self.repo, "--state", "open",
+            "--limit", "300", "--json", "number,headRefName",
+        ])
+        return sum(1 for r in rows if (r.get("headRefName") or "").startswith("sweep/"))
+
+    def pr_state(self, number):
+        return self._json([
+            "gh", "pr", "view", str(number), "--repo", self.repo,
+            "--json", "state,mergedAt,isDraft,mergeable,mergeStateStatus",
+        ])
+
+    def pr_update_branch(self, number):
+        return self.run([
+            "gh", "pr", "update-branch", str(number), "--repo", self.repo,
+        ], check=False)
+
+    def pr_checks(self, number):
+        return self._json([
+            "gh", "pr", "checks", str(number), "--repo", self.repo,
+            "--json", "name,state,bucket,link",
+        ])
+
+    def check_run_summary(self, sha, name, limit=1200):
+        """Best-effort log tail for a failing check (no Actions log scope needed)."""
+        try:
+            runs = self._json(["gh", "api", "repos/%s/commits/%s/check-runs" % (self.repo, sha),
+                               "--paginate"]).get("check_runs") or []
+        except InfraError:
+            return ""
+        for r in runs:
+            if r.get("name") != name or r.get("conclusion") in (None, "success", "skipped", "neutral"):
+                continue
+            out = r.get("output") or {}
+            text = "\n".join(x for x in (out.get("title"), out.get("summary"), out.get("text")) if x)
+            if text:
+                return text[-limit:]
+        return ""
+
+    def failed_check_log(self, number, names, limit=4000):
+        """Fetch the failing job's log. Best-effort: at detection time the run is
+        often still in progress, so this is called again at adjudication time."""
+        try:
+            rows = self.pr_checks(number)
+        except InfraError:
+            return ""
+        chunks = []
+        for name in names[:2]:
+            link = next((r.get("link") for r in rows
+                         if r.get("name") == name and (r.get("bucket") or "").lower() == "fail"), None)
+            m = re.search(r"/runs/(\d+)", link or "")
+            if not m:
+                continue
+            out = self.run(["gh", "run", "view", m.group(1), "--repo", self.repo, "--log-failed"],
+                           check=False)
+            if out and "still in progress" not in out and "could not find" not in out.lower():
+                chunks.append("### %s\n%s" % (name, out[-limit:]))
+        return "\n\n".join(chunks)
+
+    def delete_remote_branch(self, branch):
+        return self.run(["git", "push", "origin", "--delete", branch], check=False)
+
+    def pr_readied_by_human(self, number):
+        """True if someone clicked "Ready for review" on this PR.
+
+        The dispatcher has no un-draft code path, so a sweep PR that is no longer a
+        draft was either readied by bakert (the intended review workflow) or never
+        drafted at all. Only the second is an incident.
+        """
+        try:
+            rows = self._json([
+                "gh", "api", "repos/%s/issues/%s/timeline" % (self.repo, number),
+                "--paginate", "-q", "[.[] | select(.event==\"ready_for_review\")]",
+            ])
+        except InfraError:
+            return False
+        return bool(rows)
+
+    def pr_is_draft(self, number):
+        return bool(self._json([
+            "gh", "pr", "view", str(number), "--repo", self.repo, "--json", "isDraft",
+        ]).get("isDraft"))
+
+    def close_pr(self, number, comment=None):
+        argv = ["gh", "pr", "close", str(number), "--repo", self.repo]
+        if comment:
+            argv += ["--comment", comment]
+        return self.run(argv)
+
+    def remove_label(self, number, label):
+        return self.run([
+            "gh", "pr", "edit", str(number), "--repo", self.repo, "--remove-label", label,
+        ])
+
+    def compare(self, branch):
+        return self._json([
+            "gh", "api", "repos/%s/compare/master...%s" % (self.repo, branch),
+        ])
+
+    def remote_branch_sha(self, branch):
+        out = self.run(["git", "ls-remote", "origin", "refs/heads/" + branch], check=False)
+        parts = out.split()
+        return parts[0] if parts and re.fullmatch(r"[0-9a-f]{40}", parts[0] or "") else None
+
+    def branches_matching(self, pattern):
+        out = self.run(["git", "ls-remote", "origin", pattern], check=False)
+        return [l.split()[-1] for l in out.splitlines() if l.strip() and "\t" in l]
+
+
+# ------------------------------------------------------------------------ state
+
+def new_issue(number, title, labels):
+    return {
+        "issue": int(number), "title": title, "labels": labels, "status": "pending",
+        "stage_attempts": {"triage": 0, "verify": 0, "fix": 0}, "lease": None,
+        "class": None, "confidence": None, "verdict": None, "evidence_file": None,
+        "closure": None, "pr": None, "escalation": None, "history": [], "notes": None,
+        "fixup": None,
+    }
+
+
+class State:
+    """Materialized view of the journal.  apply() is pure w.r.t. the event."""
+
+    def __init__(self):
+        self.last_seq = 0
+        self.issues = {}
+        self.workspaces = {}
+        self.counters = {"workspaces_created": 0, "nudges": 0, "infra_failures": 0}
+        self.daily = {"day": None, "closures": 0, "prs": 0}
+        self.paused = False
+        self.pause_until = None
+        self.pause_level = 0
+        self.pause_seconds = 0
+        self.last_bundle_at = None
+        self.pr_backpressure = False
+        self.last_master_sha = None
+        self.last_mirror_at = None
+        self.last_snapshot_at = None
+        self.invariants = []
+
+    # -- serialization -----------------------------------------------------
+    def to_dict(self):
+        return {
+            "last_seq": self.last_seq, "issues": self.issues, "workspaces": self.workspaces,
+            "counters": self.counters, "daily": self.daily, "paused": self.paused,
+            "pause_until": self.pause_until, "pause_level": self.pause_level,
+            "pr_backpressure": self.pr_backpressure,
+            "last_master_sha": self.last_master_sha,
+            "pause_seconds": self.pause_seconds, "last_bundle_at": self.last_bundle_at,
+            "last_mirror_at": self.last_mirror_at, "last_snapshot_at": self.last_snapshot_at,
+            "invariants": self.invariants[-50:],
+        }
+
+    @classmethod
+    def from_dict(cls, d):
+        s = cls()
+        if not d:
+            return s
+        for k, v in d.items():
+            if hasattr(s, k):
+                setattr(s, k, v)
+        return s
+
+    # -- helpers -----------------------------------------------------------
+    def issue(self, n):
+        return self.issues.get(str(n))
+
+    def _set_status(self, rec, status, ts, event):
+        cur = rec["status"]
+        if cur == status:
+            return True
+        blocked = (cur in ADJUDICATION_ONLY
+                   and event not in ("ADJUDICATED", "ROLLBACK_RECORDED"))
+        if blocked or status not in LEGAL.get(cur, set()):
+            self.invariants.append({"ts": ts, "issue": rec["issue"], "from": cur, "to": status, "event": event})
+            rec["status"] = "escalated"
+            rec["escalation"] = {"kind": "invariant", "detail": "illegal %s -> %s" % (cur, status)}
+            rec.setdefault("history", []).append({"ts": ts, "event": "INVARIANT_VIOLATION"})
+            return False
+        rec["status"] = status
+        rec.setdefault("history", []).append({"ts": ts, "event": event, "status": status})
+        return True
+
+    def _roll_day(self, ts):
+        day = (ts or "")[:10]
+        if self.daily.get("day") != day:
+            self.daily = {"day": day, "closures": 0, "prs": 0}
+
+    # -- the reducer -------------------------------------------------------
+    def apply(self, ev):
+        seq = ev.get("seq", 0)
+        if seq <= self.last_seq:
+            return
+        self.last_seq = seq
+        ts = ev.get("ts")
+        name = ev.get("event")
+        fn = getattr(self, "_ev_" + name.lower(), None)
+        if fn is None:
+            return
+        fn(ev, ts)
+
+    def _ev_campaign_init(self, ev, ts):
+        pass
+
+    def _ev_config_changed(self, ev, ts):
+        pass
+
+    def _ev_snapshot_written(self, ev, ts):
+        self.last_snapshot_at = ts
+
+    def _ev_mirror_pushed(self, ev, ts):
+        self.last_mirror_at = ts
+
+    def _ev_issue_enqueued(self, ev, ts):
+        key = str(ev["issue"])
+        if key in self.issues:
+            return
+        rec = new_issue(ev["issue"], ev.get("title"), ev.get("labels") or [])
+        rec["history"].append({"ts": ts, "event": "ISSUE_ENQUEUED"})
+        self.issues[key] = rec
+
+    def _ev_issue_skipped(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec:
+            rec["notes"] = ev.get("reason")
+            self._set_status(rec, "skipped", ts, "ISSUE_SKIPPED")
+
+    def _ev_workspace_created(self, ev, ts):
+        self.workspaces[ev["workspace_id"]] = {
+            "workspace_id": ev["workspace_id"], "session_id": ev.get("session_id"),
+            "kind": ev["kind"], "batch_id": ev["batch_id"], "issues": ev.get("issues") or [],
+            "state": "running", "created_at": ts, "last_transcript_at": None,
+            "harvest": {"parsed": False, "malformed_attempts": 0},
+        }
+        self.counters["workspaces_created"] = self.counters.get("workspaces_created", 0) + 1
+
+    def _ev_workspace_archived(self, ev, ts):
+        ws = self.workspaces.get(ev["workspace_id"])
+        if ws:
+            ws["state"] = "archived"
+
+    def _ev_workspace_harvested(self, ev, ts):
+        ws = self.workspaces.get(ev["workspace_id"])
+        if ws:
+            ws["state"] = "harvested"
+            ws["last_archive_attempt_state"] = ev.get("state")
+
+    def _ev_workspace_failed(self, ev, ts):
+        ws = self.workspaces.get(ev.get("workspace_id"))
+        if ws:
+            ws["state"] = "failed"
+        self.counters["infra_failures"] = self.counters.get("infra_failures", 0) + 1
+
+    def _ev_lease_granted(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        kind = ev["kind"]
+        rec["lease"] = {
+            "kind": kind, "batch_id": ev["batch_id"], "workspace_id": ev.get("workspace_id"),
+            "session_id": ev.get("session_id"), "granted_at": ts,
+            "expires_at": ev["expires_at"], "attempt": ev.get("attempt", 1),
+        }
+        self._set_status(rec, kind + "_leased", ts, "LEASE_GRANTED")
+
+    def _ev_lease_extended(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec and rec.get("lease"):
+            rec["lease"]["expires_at"] = ev["expires_at"]
+
+    def _ev_lease_expired(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        kind = ev["kind"]
+        rec["stage_attempts"][kind] = rec["stage_attempts"].get(kind, 0) + 1
+        rec["lease"] = None
+        rec.setdefault("history", []).append({"ts": ts, "event": "LEASE_EXPIRED"})
+
+    def _ev_retry_scheduled(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec:
+            self._set_status(rec, ev["status"], ts, "RETRY_SCHEDULED")
+
+    def _ev_nudge_sent(self, ev, ts):
+        ws = self.workspaces.get(ev.get("workspace_id"))
+        if ws:
+            ws["state"] = "nudged"
+            ws["harvest"]["malformed_attempts"] = ws["harvest"].get("malformed_attempts", 0) + 1
+        self.counters["nudges"] = self.counters.get("nudges", 0) + 1
+
+    def _ev_result_malformed(self, ev, ts):
+        ws = self.workspaces.get(ev.get("workspace_id"))
+        if ws:
+            ws["harvest"]["parsed"] = False
+
+    def _ev_result_rejected(self, ev, ts):
+        pass
+
+    def _ev_result_recorded(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        rec["lease"] = None
+        rec["evidence_file"] = "evidence/%s.json" % ev["issue"]
+        for k in ("class", "confidence", "verdict"):
+            if ev.get(k) is not None:
+                rec[k] = ev[k]
+        if ev.get("notes"):
+            rec["notes"] = ev["notes"]
+        if ev.get("pr_branch"):
+            rec["pr"] = dict(rec.get("pr") or {}, branch=ev["pr_branch"], head_sha=ev.get("head_sha"))
+        self._set_status(rec, ev["status"], ts, "RESULT_RECORDED")
+
+    def _ev_mutation_planned(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec and ev.get("kind") == "close":
+            self._set_status(rec, "closing", ts, "MUTATION_PLANNED")
+
+    def _ev_close_executed(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        if not self._set_status(rec, "closed", ts, "CLOSE_EXECUTED"):
+            return
+        rec["closure"] = {
+            "reason": ev.get("reason"), "comment_posted": bool(ev.get("comment_posted")),
+            "executed_at": ts, "verified_by_batch": ev.get("verified_by_batch"),
+            "duplicate_of": ev.get("duplicate_of"), "external": bool(ev.get("external")),
+        }
+        if not ev.get("external"):
+            self._roll_day(ts)
+            self.daily["closures"] += 1
+
+    def _ev_pr_opened(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        if not self._set_status(rec, "pr_open", ts, "PR_OPENED"):
+            return
+        rec["pr"] = {
+            "number": ev.get("number"), "branch": ev.get("branch"), "head_sha": ev.get("head_sha"),
+            "opened_at": ts, "url": ev.get("url"), "adopted": bool(ev.get("adopted")),
+        }
+        if not ev.get("adopted"):
+            self._roll_day(ts)
+            self.daily["prs"] += 1
+
+    def _ev_pr_withdrawn(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        if rec.get("pr") is not None:
+            rec["pr"]["withdrawn_at"] = ts
+            rec["pr"]["branch_deleted"] = bool(ev.get("branch_deleted"))
+        rec["notes"] = "PR #%s closed without merging by a human; settled outside the sweep." % ev.get("pr")
+        self._set_status(rec, "deferred_human", ts, "PR_WITHDRAWN")
+
+    def _ev_pr_readied_by_human(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec and rec.get("pr") is not None:
+            rec["pr"]["readied_by_human_at"] = ts
+
+    def _ev_pr_merged(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec and rec.get("pr") is not None:
+            rec["pr"]["merged_at"] = ev.get("merged_at") or ts
+            rec["pr"]["ci"] = {"state": "merged", "checked_at": ts, "failed": []}
+            rec.setdefault("history", []).append({"ts": ts, "event": "PR_MERGED"})
+
+    def _ev_pr_branch_updated(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec and rec.get("pr") is not None:
+            rec["pr"]["last_branch_update"] = ts
+            rec.setdefault("history", []).append({"ts": ts, "event": "PR_BRANCH_UPDATED"})
+
+    def _ev_pr_conflict(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        if rec.get("pr") is not None:
+            rec["pr"]["ci"] = {"state": "conflict", "checked_at": ts, "failed": ["merge-conflict"]}
+        self._set_status(rec, "pr_ci_failed", ts, "PR_CONFLICT")
+
+    def _ev_pr_ci_green(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec and rec.get("pr") is not None:
+            rec["pr"]["ci"] = {"state": "green", "checked_at": ts, "failed": []}
+            rec.setdefault("history", []).append({"ts": ts, "event": "PR_CI_GREEN"})
+
+    def _ev_pr_ci_failed(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        if rec.get("pr") is not None:
+            rec["pr"]["ci"] = {"state": "failed", "checked_at": ts, "failed": ev.get("failed") or []}
+        self._set_status(rec, "pr_ci_failed", ts, "PR_CI_FAILED")
+
+    def _ev_ci_checked(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec and rec.get("pr") is not None:
+            ci = rec["pr"].setdefault("ci", {})
+            ci["checked_at"] = ts
+            ci.setdefault("state", "pending")
+
+    def _ev_fixup_dispatched(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        rec["fixup"] = {"branch": ev.get("branch"), "pr": ev.get("pr"),
+                        "failed": ev.get("failed") or [], "attempt": ev.get("attempt", 1),
+                        "log_tail": ev.get("log_tail") or ""}
+        self._set_status(rec, "fix_pending", ts, "FIXUP_DISPATCHED")
+
+    def _ev_mutation_failed(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if rec:
+            rec["escalation"] = {"kind": "mutation-failed", "detail": ev.get("reason")}
+            self._set_status(rec, "escalated", ts, "MUTATION_FAILED")
+
+    def _ev_escalated(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        rec["escalation"] = {"kind": ev.get("kind"), "question": ev.get("question")}
+        rec["lease"] = None
+        self._set_status(rec, "escalated", ts, "ESCALATED")
+
+    def _ev_adjudicated(self, ev, ts):
+        rec = self.issue(ev["issue"])
+        if not rec:
+            return
+        rec["escalation"] = None
+        rec["notes"] = ev.get("note") or rec.get("notes")
+        if ev.get("status"):
+            self._set_status(rec, ev["status"], ts, "ADJUDICATED")
+
+    def _ev_master_advanced(self, ev, ts):
+        self.last_master_sha = ev.get("sha")
+
+    def _ev_pr_backpressure_on(self, ev, ts):
+        self.pr_backpressure = True
+
+    def _ev_pr_backpressure_off(self, ev, ts):
+        self.pr_backpressure = False
+        self.last_master_sha = None
+
+    def _ev_pause_on(self, ev, ts):
+        self.paused = True
+        self.pause_until = ev.get("until")
+        self.pause_level = ev.get("level", 1)
+
+    def _ev_pause_off(self, ev, ts):
+        started = parse_iso(ev.get("since"))
+        ended = parse_iso(ts)
+        if started and ended:
+            self.pause_seconds += max(0, int((ended - started).total_seconds()))
+        self.paused = False
+        self.pause_until = None
+        self.pause_level = 0
+
+    def _ev_invariant_violation(self, ev, ts):
+        self.invariants.append(dict(ev))
+
+    def _ev_rollback_recorded(self, ev, ts):
+        rec = self.issue(ev.get("issue"))
+        if rec and ev.get("status"):
+            self._set_status(rec, ev["status"], ts, "ROLLBACK_RECORDED")
+
+
+class Store:
+    """flock + journal + snapshot."""
+
+    def __init__(self, blocking=False, readonly=False):
+        STATE.mkdir(parents=True, exist_ok=True)
+        for d in (EVIDENCE, ESCALATIONS, REPORTS, OUTBOX):
+            d.mkdir(parents=True, exist_ok=True)
+        self.readonly = readonly
+        self._fh = None if readonly else open(LOCKFILE, "a+")
+        flags = fcntl.LOCK_EX if blocking else (fcntl.LOCK_EX | fcntl.LOCK_NB)
+        try:
+            if not readonly:
+                fcntl.flock(self._fh, flags)
+        except OSError as exc:
+            self._fh.close()
+            if exc.errno in (errno.EAGAIN, errno.EACCES):
+                sys.stderr.write("dispatcher: state lock held by another process\n")
+                raise SystemExit(75)
+            raise
+        self.config = self._load_config()
+        self.state = State.from_dict(read_json(SNAPSHOT))
+        self._replay()
+        self._pending = []
+
+    def close(self):
+        if self._fh is None:
+            return
+        try:
+            fcntl.flock(self._fh, fcntl.LOCK_UN)
+        finally:
+            self._fh.close()
+            self._fh = None
+
+    def _load_config(self):
+        cfg = json.loads(json.dumps(DEFAULT_CONFIG))
+        disk = read_json(CONFIG)
+        if disk:
+            cfg.update(disk)
+        else:
+            write_json(CONFIG, cfg)
+        return cfg
+
+    def _replay(self):
+        if not JOURNAL.exists():
+            return
+        with open(JOURNAL, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except ValueError:
+                    log("journal: truncating torn tail line")
+                    break
+                self.state.apply(ev)
+
+    def journal(self, event, **payload):
+        if self.readonly:
+            raise RuntimeError("read-only store cannot journal")
+        ev = {"ts": iso(utcnow()), "seq": self.state.last_seq + 1, "event": event}
+        ev.update(payload)
+        with open(JOURNAL, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(ev, sort_keys=True) + "\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        self.state.apply(ev)
+        return ev
+
+    def snapshot(self):
+        write_json(SNAPSHOT, self.state.to_dict())
+        write_json(QUEUE, {k: {kk: v[kk] for kk in ("issue", "title", "status", "class", "verdict", "pr", "closure")}
+                           for k, v in self.state.issues.items()})
+        self.journal("SNAPSHOT_WRITTEN", last_seq=self.state.last_seq)
+        write_json(SNAPSHOT, self.state.to_dict())
+
+    def save_config(self):
+        write_json(CONFIG, self.config)
+
+
+# ----------------------------------------------------------------------- engine
+
+class Engine:
+    def __init__(self, store, dry_run=False, sleeper=time.sleep):
+        self.store = store
+        self.cfg = store.config
+        self.st = store.state
+        self.dry = dry_run
+        self.runner = Runner(self.cfg, sleeper, env_overlay=load_gh_token())
+        self.gh = GitHub(self.runner, self.cfg["repo"], gh_bin=gh_executable())
+        self.cond = Conductor(self.cfg, sleeper)
+        self.plan = []
+        self.create_failures = 0
+        self.dry_leased = set()  # dry-run only: issues a planned (unexecuted) spawn would take
+        self.unregistered = []   # project workspaces the sweep did not create (A7 tightening)
+        self.mirror_error = None
+        self.open_sweep_prs = None
+
+    # -- small helpers -----------------------------------------------------
+    def say(self, msg):
+        self.plan.append(msg)
+        log("PLAN " + msg if self.dry else msg, echo=self.dry)
+
+    def active_workspaces(self):
+        return [w for w in self.st.workspaces.values() if w["state"] in ("creating", "running", "nudged")]
+
+    def add_evidence(self, issue, kind, obj):
+        path = EVIDENCE / ("%s.json" % issue)
+        doc = read_json(path) or {"issue": int(issue), "triage": [], "verify": [], "fix": []}
+        doc.setdefault(kind, []).append(obj)
+        write_json(path, doc)
+        return "evidence/%s.json#%s[%d]" % (issue, kind, len(doc[kind]) - 1)
+
+    def last_evidence(self, issue, kind):
+        doc = read_json(EVIDENCE / ("%s.json" % issue)) or {}
+        arr = doc.get(kind) or []
+        return arr[-1] if arr else None
+
+    def escalate(self, issue, kind, question, summary="", refs=None):
+        if self.dry:
+            self.say("WOULD escalate #%s (%s): %s" % (issue, kind, question))
+            return
+        rec = {
+            "issue": int(issue), "created_at": iso(utcnow()), "kind": kind,
+            "question": question, "summary": summary[:1000],
+            "evidence_refs": refs or [], "bundled_at": None, "adjudication": None,
+        }
+        write_json(ESCALATIONS / ("%s.json" % issue), rec)
+        self.store.journal("ESCALATED", issue=int(issue), kind=kind, question=question)
+
+    def note_infra_failure(self, why):
+        log("infra failure: %s" % why)
+        self.st.counters["infra_failures"] = self.st.counters.get("infra_failures", 0) + 1
+
+    def check_rate_limit_text(self, text):
+        return bool(text and RATE_LIMIT_RE.search(text))
+
+    def pause(self, reason):
+        if self.st.paused:
+            return
+        level = max(1, self.st.pause_level)
+        minutes = min(self.cfg["pause_initial_minutes"] * (2 ** (level - 1)), self.cfg["pause_max_minutes"])
+        until = iso(utcnow() + dt.timedelta(minutes=minutes))
+        self.store.journal("PAUSE_ON", reason=reason, until=until, level=level, since=iso(utcnow()))
+        log("PAUSED (%s) until %s" % (reason, until))
+
+    def maybe_unpause(self):
+        if not self.st.paused:
+            return
+        until = parse_iso(self.st.pause_until)
+        if until and utcnow() < until:
+            return
+        # probe: extend every live lease by the pause duration, then resume
+        since = None
+        for line in reversed(self._journal_tail(400)):
+            if line.get("event") == "PAUSE_ON":
+                since = line.get("since") or line.get("ts")
+                break
+        started = parse_iso(since)
+        if started:
+            delta = utcnow() - started
+            for rec in self.st.issues.values():
+                if rec.get("lease"):
+                    exp = parse_iso(rec["lease"]["expires_at"])
+                    if exp:
+                        self.store.journal("LEASE_EXTENDED", issue=rec["issue"],
+                                           expires_at=iso(exp + delta), reason="pause")
+        self.store.journal("PAUSE_OFF", since=since or iso(utcnow()))
+        log("UNPAUSED")
+
+    def _journal_tail(self, n):
+        if not JOURNAL.exists():
+            return []
+        lines = JOURNAL.read_text(encoding="utf-8").splitlines()[-n:]
+        out = []
+        for l in lines:
+            try:
+                out.append(json.loads(l))
+            except ValueError:
+                pass
+        return out
+
+    # -- 1. harvest --------------------------------------------------------
+    def harvest(self):
+        active = self.active_workspaces()
+        if not active:
+            return
+        try:
+            tmap = self.cond.transcript_updated([w["session_id"] for w in active if w.get("session_id")])
+        except InfraError:
+            tmap = {}
+        for ws in list(active):
+            sid = ws.get("session_id")
+            if not sid:
+                continue
+            try:
+                status = self.cond.session_status(sid)
+            except InfraError as exc:
+                self.note_infra_failure("session_status %s: %s" % (sid, exc))
+                continue
+            ws["last_transcript_at"] = tmap.get(sid) or ws.get("last_transcript_at")
+            s = status.get("status")
+            age = (utcnow() - (parse_iso(ws.get("created_at")) or utcnow())).total_seconds()
+            if s == "error":
+                msg = status.get("errorMessage") or status.get("lastError") or "session error"
+                if self.check_rate_limit_text(msg):
+                    self.pause("session error looks rate-limited")
+                self.fail_workspace(ws, "session-error: %s" % msg[:200])
+            elif s == "idle" and age >= self.cfg["min_session_age_seconds"]:
+                self.harvest_workspace(ws)
+            elif s == "working" and self.is_stale(ws):
+                log("workspace %s hung: no transcript movement for >%d min"
+                    % (ws["batch_id"], self.cfg["stale_transcript_minutes"]))
+                try:
+                    self.cond.cancel_session(sid)
+                except InfraError as exc:
+                    log("cancel failed: %s" % exc)
+                self.fail_workspace(ws, "stale transcript (hung worker)")
+
+    def is_stale(self, ws):
+        """A 'working' session whose transcript has not moved is hung.
+
+        Measured from the later of workspace creation and last transcript movement,
+        so a slow-booting workspace is never killed for not having said anything yet.
+        """
+        limit = dt.timedelta(minutes=self.cfg["stale_transcript_minutes"])
+        marks = [parse_iso(ws.get("created_at")), parse_iso(ws.get("last_transcript_at"))]
+        marks = [m for m in marks if m]
+        if not marks:
+            return False
+        return (utcnow() - max(marks)) > limit
+
+    def fail_workspace(self, ws, reason):
+        self.store.journal("WORKSPACE_FAILED", workspace_id=ws["workspace_id"],
+                           batch_id=ws["batch_id"], reason=reason, issues=ws["issues"])
+        self.archive(ws)
+        self.consume_attempts(ws, reason)
+
+    def archive(self, ws):
+        """Archive a workspace and CONFIRM it, before claiming we did.
+
+        The journal previously recorded WORKSPACE_ARCHIVED whether or not the call
+        worked, so 39 workspaces sat in `sleeping` while state said `archived`.
+        A failed archive now leaves the workspace in `harvested` for retry_archives()
+        to pick up on a later tick.
+        """
+        wid = ws["workspace_id"]
+        try:
+            self.cond.archive_workspace(wid)
+        except InfraError as exc:
+            log("archive call failed for %s: %s" % (wid, exc))
+        try:
+            state = (self.cond.workspace_status(wid) or {}).get("status")
+        except InfraError as exc:
+            log("archive verification failed for %s: %s" % (wid, exc))
+            state = None
+        if state in ("archived", "deleted"):
+            self.store.journal("WORKSPACE_ARCHIVED", workspace_id=wid, verified_state=state)
+            return True
+        log("archive did NOT take for %s (state=%s); will retry" % (wid, state))
+        if ws.get("state") != "harvested":
+            self.store.journal("WORKSPACE_HARVESTED", workspace_id=wid, state=state)
+        return False
+
+    def retry_archives(self):
+        """Re-attempt archives that did not take. Cheap: one call per stuck workspace."""
+        stuck = [w for w in self.st.workspaces.values() if w["state"] == "harvested"]
+        for ws in stuck[:20]:
+            if self.dry:
+                self.say("WOULD retry archive of %s (%s)" % (ws["workspace_id"], ws["batch_id"]))
+                continue
+            self.archive(ws)
+
+    def consume_attempts(self, ws, reason, issues=None):
+        """Expire-equivalent bookkeeping: +1 attempt, retry or escalate."""
+        kind = ws["kind"]
+        for n in (issues if issues is not None else ws["issues"]):
+            rec = self.st.issue(n)
+            if not rec or rec["status"] not in ("%s_leased" % kind,):
+                continue
+            self.store.journal("LEASE_EXPIRED", issue=int(n), kind=kind, batch_id=ws["batch_id"],
+                               reason=reason)
+            rec = self.st.issue(n)
+            if rec["stage_attempts"].get(kind, 0) < self.cfg["max_stage_attempts"]:
+                back = {"triage": "pending", "verify": "verify_pending", "fix": "fix_pending"}[kind]
+                self.store.journal("RETRY_SCHEDULED", issue=int(n), kind=kind, status=back,
+                                   attempt=rec["stage_attempts"][kind])
+            else:
+                self.escalate(int(n), "attempts-exhausted",
+                              "%s stage failed %d times (%s) — retry, report-only, or drop?"
+                              % (kind, rec["stage_attempts"][kind], reason[:120]),
+                              summary=reason[:400])
+
+    def harvest_workspace(self, ws):
+        sid = ws["session_id"]
+        try:
+            msgs = self.cond.all_messages(sid)
+        except InfraError as exc:
+            self.note_infra_failure("messages %s: %s" % (sid, exc))
+            return
+        rl = self.cond.rate_limit_state(msgs)
+        if rl and rl.get("status") not in (None, "allowed", "warning"):
+            self.pause("rate_limit_event status=%s" % rl.get("status"))
+        texts = self.cond.assistant_texts(msgs)
+        role = ws["kind"]
+        obj = None
+        for i, text in enumerate(reversed(texts[-3:])):
+            obj = extract_json_block(text, role=role, batch_id=ws["batch_id"])
+            if obj:
+                if i:
+                    log("harvest %s: JSON found %d messages before the last" % (ws["batch_id"], i))
+                break
+        if obj is None:
+            self.handle_malformed(ws)
+            return
+        self.record_results(ws, obj)
+        ws["harvest"]["parsed"] = True
+        self.archive(ws)
+
+    def handle_malformed(self, ws):
+        self.store.journal("RESULT_MALFORMED", workspace_id=ws["workspace_id"], batch_id=ws["batch_id"])
+        if ws["harvest"].get("malformed_attempts", 0) == 0 and not self.st.paused:
+            nudge = (
+                "Your final message must end with the single fenced ```json block specified in "
+                "your instructions (backlog_sweep v1, role %s, batch_id %s, one result per assigned "
+                "issue). Reply with ONLY that block." % (ws["kind"], ws["batch_id"])
+            )
+            try:
+                self.cond.send_message(ws["session_id"], nudge, message_id=None)
+            except InfraError as exc:
+                self.note_infra_failure("nudge: %s" % exc)
+                return
+            self.store.journal("NUDGE_SENT", workspace_id=ws["workspace_id"], batch_id=ws["batch_id"])
+            return
+        self.archive(ws)
+        self.consume_attempts(ws, "malformed output after nudge")
+
+    # -- result recording --------------------------------------------------
+    def record_results(self, ws, obj):
+        results = obj.get("results")
+        if not isinstance(results, list):
+            self.handle_malformed(ws)
+            return
+        seen = set()
+        for r in results:
+            if not isinstance(r, dict) or "issue" not in r:
+                continue
+            try:
+                n = int(r["issue"])
+            except (TypeError, ValueError):
+                continue
+            if n not in ws["issues"]:
+                self.store.journal("RESULT_REJECTED", issue=n, batch_id=ws["batch_id"],
+                                   reason="not leased to this batch")
+                continue
+            if n in seen:
+                continue
+            seen.add(n)
+            r = dict(r, batch_id=ws["batch_id"], recorded_at=iso(utcnow()))
+            try:
+                getattr(self, "_record_" + ws["kind"])(ws, n, r)
+            except Exception as exc:  # noqa: BLE001 defensive: one bad result must not kill the tick
+                log("record error #%s: %r" % (n, exc))
+                self.add_evidence(n, ws["kind"], r)
+                self.escalate(n, "malformed", "Result could not be processed (%s)." % exc)
+        missing = [n for n in ws["issues"] if n not in seen]
+        if missing:
+            self.consume_attempts(ws, "no result in batch output", issues=missing)
+
+    def _record_triage(self, ws, n, r):
+        ref = self.add_evidence(n, "triage", r)
+        cls = r.get("class")
+        conf = r.get("confidence")
+        if cls not in TRIAGE_CLASSES:
+            self.escalate(n, "malformed", "Unknown triage class %r." % cls, refs=[ref])
+            return
+        if cls == "skip-closed":
+            self.store.journal("ISSUE_SKIPPED", issue=n, reason="closed before triage")
+            return
+        if cls in CLOSURE_CLASSES:
+            if conf != "high":
+                self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                                   **{"class": cls, "confidence": conf, "status": "triaged"})
+                self.escalate(n, "class-escalate",
+                              "Closure candidate %s at %s confidence — verify anyway, report-only, or drop?"
+                              % (cls, conf), summary=(r.get("notes") or "")[:400], refs=[ref])
+                return
+            if cls == "duplicate" and not r.get("duplicate_of"):
+                self.escalate(n, "class-escalate", "duplicate claimed without duplicate_of.", refs=[ref])
+                return
+            self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                               **{"class": cls, "confidence": conf, "status": "triaged"})
+            self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                               **{"class": cls, "confidence": conf, "status": "verify_pending"})
+            return
+        if cls == "easy-fix":
+            self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                               **{"class": cls, "confidence": conf, "status": "triaged"})
+            self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                               **{"class": cls, "confidence": conf, "status": "fix_pending"})
+            return
+        if cls in REPORT_ONLY_CLASSES:
+            self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                               **{"class": cls, "confidence": conf, "status": "triaged"})
+            self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                               **{"class": cls, "confidence": conf, "status": "reported"})
+            return
+        # escalation classes
+        self.store.journal("RESULT_RECORDED", issue=n, kind="triage", batch_id=ws["batch_id"],
+                           **{"class": cls, "confidence": conf, "status": "triaged"})
+        self.escalate(n, "class-escalate", "Triaged %s — needs a human/product call." % cls,
+                      summary=(r.get("notes") or "")[:400], refs=[ref])
+
+    def _record_verify(self, ws, n, r):
+        ref = self.add_evidence(n, "verify", r)
+        verdict = (r.get("verdict") or "").upper()
+        if verdict == "CONFIRMED" and not r.get("recent_human_activity") and r.get("final_comment"):
+            self.store.journal("RESULT_RECORDED", issue=n, kind="verify", batch_id=ws["batch_id"],
+                               verdict=verdict, status="verified")
+            return
+        self.store.journal("RESULT_RECORDED", issue=n, kind="verify", batch_id=ws["batch_id"],
+                           verdict=verdict or "MISSING", status="verify_leased")
+        kind = "verifier-refuted" if verdict == "REFUTED" else "verifier-uncertain"
+        self.escalate(n, kind, "Verifier returned %s — drop the closure, re-triage, or override?" % (verdict or "no verdict"),
+                      summary=(r.get("refutation_reason") or "")[:400], refs=[ref])
+
+    def _record_fix(self, ws, n, r):
+        ref = self.add_evidence(n, "fix", r)
+        outcome = r.get("outcome")
+        if outcome == "pushed" and r.get("branch") and r.get("head_sha"):
+            self.store.journal("RESULT_RECORDED", issue=n, kind="fix", batch_id=ws["batch_id"],
+                               status="fix_pushed", pr_branch=r["branch"], head_sha=r["head_sha"])
+            return
+        self.store.journal("RESULT_RECORDED", issue=n, kind="fix", batch_id=ws["batch_id"],
+                           status="fix_leased")
+        self.escalate(n, "fix-abort" if outcome == "abort-escalate" else "fix-validation",
+                      "Fixer reported %s — re-queue, report-only, or defer?" % outcome,
+                      summary=(r.get("notes") or "")[:400], refs=[ref])
+
+    # -- 2. lease expiry ---------------------------------------------------
+    def expire_leases(self):
+        if self.st.paused:
+            return
+        now = utcnow()
+        for ws in list(self.active_workspaces()):
+            leases = [self.st.issue(n)["lease"] for n in ws["issues"]
+                      if self.st.issue(n) and self.st.issue(n).get("lease")]
+            if not leases:
+                continue
+            exp = min(parse_iso(l["expires_at"]) or now for l in leases)
+            if now <= exp:
+                continue
+            advanced = parse_iso(ws.get("last_transcript_at"))
+            if advanced and (now - advanced) < dt.timedelta(minutes=10) and not ws.get("extended"):
+                ws["extended"] = True
+                bonus = dt.timedelta(minutes=self.cfg["lease_minutes"][ws["kind"]] * 0.5)
+                for n in ws["issues"]:
+                    rec = self.st.issue(n)
+                    if rec and rec.get("lease"):
+                        self.store.journal("LEASE_EXTENDED", issue=int(n),
+                                           expires_at=iso(exp + bonus), reason="transcript advancing")
+                continue
+            try:
+                self.cond.cancel_session(ws["session_id"])
+            except InfraError as exc:
+                log("cancel failed: %s" % exc)
+            self.archive(ws)
+            self.consume_attempts(ws, "lease expired")
+
+    # -- 3. mutations ------------------------------------------------------
+    def execute_mutations(self):
+        self.execute_closures()
+        self.execute_prs()
+
+    def _ready(self, status):
+        return sorted((r for r in self.st.issues.values()
+                       if r["status"] == status and r["issue"] not in self.dry_leased),
+                      key=lambda r: -r["issue"])
+
+    def execute_closures(self):
+        if not self.dry and self.cfg["mutations_enabled"] and not self.cfg.get("closures_enabled", True):
+            n_waiting = len(self._ready("verified"))
+            if n_waiting:
+                log("closures disabled; %d verified issue(s) queued" % n_waiting)
+            return
+        for rec in self._ready("verified"):
+            n = rec["issue"]
+            if self.st.daily.get("closures", 0) >= self.cfg["daily_close_cap"]:
+                log("daily close cap reached")
+                return
+            tri = self.last_evidence(n, "triage") or {}
+            ver = self.last_evidence(n, "verify") or {}
+            reason_key = CLOSURE_CLASSES.get(tri.get("class"))
+            if not reason_key:
+                self.escalate(n, "mutation-failed", "No closure class on record for a verified issue.")
+                continue
+            gh_reason = "completed" if reason_key == "completed" else "not planned"
+            comment = render_closure_comment(ver.get("final_comment"))
+            if self.dry or not self.cfg["mutations_enabled"]:
+                self.say("WOULD close #%s (%s): %s" % (n, gh_reason, (ver.get("final_comment") or "")[:120]))
+                continue
+            ok, why = self.closure_guards(n, ver)
+            if ok == "already-closed":
+                self.store.journal("CLOSE_EXECUTED", issue=n, reason=reason_key, external=True,
+                                   comment_posted=False, verified_by_batch=ver.get("batch_id"))
+                continue
+            if not ok:
+                self.escalate(n, "class-escalate", "Closure guard tripped: %s" % why, summary=why)
+                continue
+            self.store.journal("MUTATION_PLANNED", issue=n, kind="close", reason=reason_key)
+            out = ""
+            try:
+                out = self.gh.close_issue(n, gh_reason, comment)
+            except InfraError as exc:
+                out = exc.output
+                if not PERMISSION_RE.search(out or ""):
+                    self.store.journal("MUTATION_FAILED", issue=n, kind="close", reason=str(exc)[:200])
+                    continue
+            try:
+                state = self.gh.issue(n, "state").get("state")
+            except InfraError:
+                state = None
+            if state != "CLOSED" and PERMISSION_RE.search(out or ""):
+                # Environmental, not issue-specific: do not burn the issue. Park it
+                # back on `verified`, shut the closure gate, and alert the manager.
+                self.store.journal("ROLLBACK_RECORDED", issue=n, status="verified",
+                                   action="closure blocked by token permissions")
+                self.cfg["closures_enabled"] = False
+                self.store.config["closures_enabled"] = False
+                self.store.save_config()
+                self.store.journal("CONFIG_CHANGED", changes={"closures_enabled": False},
+                                   reason="GitHub token lacks issues:write")
+                self.st.counters["alert"] = ("closures disabled: GH token lacks issues:write "
+                                             "(issue close/comment returns 403)")
+                log("CLOSURES DISABLED: token cannot write issues")
+                return
+            if state == "CLOSED":
+                self.store.journal("CLOSE_EXECUTED", issue=n, reason=reason_key, comment_posted=True,
+                                   verified_by_batch=ver.get("batch_id"),
+                                   duplicate_of=tri.get("duplicate_of"))
+            else:
+                self.store.journal("MUTATION_FAILED", issue=n, kind="close",
+                                   reason="post-close state=%s" % state)
+
+    def closure_guards(self, n, ver):
+        try:
+            data = self.gh.issue(n, "state,updatedAt,comments")
+        except InfraError as exc:
+            return False, "gh issue view failed: %s" % exc
+        if data.get("state") == "CLOSED":
+            return "already-closed", ""
+        bots = set(self.cfg["bot_logins"])
+        guard = utcnow() - dt.timedelta(days=self.cfg["recent_activity_guard_days"])
+        if self.cfg.get("recent_activity_guard_mode") == "updated_at":
+            touched = parse_iso(data.get("updatedAt"))
+            if touched and touched >= guard:
+                return False, "issue updatedAt %s is inside the %d-day guard" % (
+                    data.get("updatedAt"), self.cfg["recent_activity_guard_days"])
+        verified_at = parse_iso(ver.get("recorded_at"))
+        for c in data.get("comments") or []:
+            login = ((c.get("author") or {}).get("login") or "")
+            if login in bots or login.endswith("[bot]"):
+                continue
+            when = parse_iso(c.get("createdAt"))
+            if not when:
+                continue
+            if when >= guard:
+                return False, "human comment by %s on %s is inside the %d-day guard" % (
+                    login, c.get("createdAt"), self.cfg["recent_activity_guard_days"])
+            if verified_at and when > verified_at:
+                return False, "human comment appeared after verification"
+        return True, ""
+
+    def execute_prs(self):
+        if not self.dry and self.cfg["mutations_enabled"] and not self.cfg.get("prs_enabled", True):
+            return
+        queued = self._ready("fix_pushed")
+        if queued and not self.dry:
+            if not self.pr_capacity_available(len(queued)):
+                return
+        for rec in queued:
+            n = rec["issue"]
+            if self.st.daily.get("prs", 0) >= self.cfg["daily_pr_cap"]:
+                log("daily PR cap reached")
+                return
+            fx = self.last_evidence(n, "fix") or {}
+            branch = fx.get("branch")
+            if self.dry or not self.cfg["mutations_enabled"]:
+                self.say("WOULD open PR for #%s from %s: %s" % (n, branch, fx.get("pr_title")))
+                continue
+            existing = []
+            try:
+                existing = [p for p in self.gh.prs_for_branch(branch) if p.get("state") == "OPEN"]
+            except InfraError as exc:
+                log("pr list failed: %s" % exc)
+            if existing:
+                p = existing[0]
+                self.store.journal("PR_OPENED", issue=n, number=p["number"], url=p.get("url"),
+                                   branch=branch, head_sha=fx.get("head_sha"), adopted=True)
+                try:
+                    if not self.gh.pr_is_draft(p["number"]):
+                        if self.gh.pr_readied_by_human(p["number"]):
+                            # bakert clicked "Ready for review" — that IS the review
+                            # workflow, not a failure of the draft brake.
+                            self.store.journal("PR_READIED_BY_HUMAN", issue=n, pr=p["number"])
+                            log("PR #%s was readied by a human; leaving it alone" % p["number"])
+                        else:
+                            self.escalate(n, "fix-validation",
+                                          "Adopted PR #%s on %s is NOT a draft and nobody readied "
+                                          "it, so the draft brake failed. Draft it or confirm."
+                                          % (p["number"], branch),
+                                          summary="adopted non-draft PR, no ready_for_review event")
+                            self.st.counters["alert"] = "adopted non-draft PR #%s" % p["number"]
+                except InfraError as exc:
+                    log("draft check failed for #%s: %s" % (p["number"], exc))
+                continue
+            ok, why = self.pr_guards(n, fx)
+            if not ok:
+                self.escalate(n, "fix-validation", "PR validation failed: %s" % why, summary=why)
+                continue
+            body = fx.get("pr_body") or ""
+            tests = (fx.get("tests") or {})
+            if tests.get("result") != "passed" and "test" not in body.lower():
+                body += "\n\nTest status: %s — %s" % (tests.get("result"), tests.get("detail"))
+            body_file = OUTBOX / ("pr-%s.md" % n)
+            write_atomic(body_file, body)
+            self.store.journal("MUTATION_PLANNED", issue=n, kind="pr", branch=branch)
+            try:
+                out = self.gh.create_pr(branch, fx.get("pr_title") or "Fix #%s" % n, body_file)
+            except InfraError as exc:
+                self.store.journal("MUTATION_FAILED", issue=n, kind="pr", reason=str(exc)[:200])
+                continue
+            m = re.search(r"(https://\S+/pull/(\d+))", out or "")
+            number = int(m.group(2)) if m else None
+            if number is None:
+                self.store.journal("MUTATION_FAILED", issue=n, kind="pr",
+                                   reason="could not parse PR number from gh output")
+                self.escalate(n, "fix-validation", "PR may have been created but its number could "
+                              "not be parsed - check %s by hand." % branch)
+                continue
+            # Draft is the merge brake. A non-draft sweep PR is an incident, not a nit:
+            # Mergify merges bakert's green PRs automatically.
+            try:
+                is_draft = self.gh.pr_is_draft(number)
+            except InfraError as exc:
+                is_draft = False
+                log("draft verification failed for #%s: %s" % (number, exc))
+            if not is_draft:
+                log("PR #%s IS NOT A DRAFT - closing immediately" % number)
+                try:
+                    self.gh.close_pr(number, "Closing automatically: this sweep PR was not created "
+                                             "as a draft, and non-draft PRs here are auto-merged. "
+                                             "The branch is untouched; it will be reopened as a draft.")
+                except InfraError as exc:
+                    log("emergency close of #%s FAILED: %s" % (number, exc))
+                self.cfg["prs_enabled"] = False
+                self.store.config["prs_enabled"] = False
+                self.store.save_config()
+                self.store.journal("CONFIG_CHANGED", changes={"prs_enabled": False},
+                                   reason="a sweep PR was created non-draft; pipeline halted")
+                self.store.journal("MUTATION_FAILED", issue=n, kind="pr",
+                                   reason="PR #%s created non-draft; closed and pipeline halted" % number)
+                self.escalate(n, "fix-validation",
+                              "PR #%s was created WITHOUT draft status and was closed immediately. "
+                              "PR creation is halted. Investigate before re-enabling." % number,
+                              summary="draft brake failed")
+                self.st.counters["alert"] = "non-draft PR #%s created and closed; PRs halted" % number
+                return
+            self.store.journal("PR_OPENED", issue=n, number=number,
+                               url=m.group(1), branch=branch, head_sha=fx.get("head_sha"),
+                               draft=True)
+
+    def pr_capacity_available(self, queued):
+        """Backpressure on the reviewer, not just on the day.
+
+        `daily_pr_cap` bounds the rate; this bounds the standing pile awaiting
+        review. Holding branches in `fix_pushed` is normal flow control, so it is
+        journaled once per transition and never escalated.
+        """
+        cap = self.cfg.get("max_open_prs")
+        if not cap:
+            return True
+        try:
+            open_now = self.gh.count_open_sweep_prs()
+        except InfraError as exc:
+            log("open-PR count failed, holding PRs this tick: %s" % exc)
+            return False
+        self.open_sweep_prs = open_now
+        if open_now >= cap:
+            if not self.st.pr_backpressure:
+                self.store.journal("PR_BACKPRESSURE_ON", open_prs=open_now, cap=cap, queued=queued)
+                log("PR backpressure ON: %d open sweep PRs >= cap %d; holding %d branch(es)"
+                    % (open_now, cap, queued))
+            return False
+        if self.st.pr_backpressure:
+            self.store.journal("PR_BACKPRESSURE_OFF", open_prs=open_now, cap=cap)
+            log("PR backpressure OFF: %d open sweep PRs < cap %d" % (open_now, cap))
+        return True
+
+    def pr_guards(self, n, fx):
+        branch, sha = fx.get("branch"), (fx.get("head_sha") or "")
+        if not branch:
+            return False, "no branch reported"
+        remote = self.gh.remote_branch_sha(branch)
+        if not remote:
+            return False, "branch %s not on origin" % branch
+        if sha and not (remote.startswith(sha) or sha.startswith(remote[:7])):
+            return False, "branch head %s != reported %s" % (remote[:10], sha[:10])
+        try:
+            cmp_ = self.gh.compare(branch)
+        except InfraError as exc:
+            return False, "compare failed: %s" % exc
+        changed = (cmp_.get("files") or [])
+        total = sum((f.get("additions", 0) + f.get("deletions", 0)) for f in changed)
+        if total > self.cfg["max_fix_lines"]:
+            return False, "%d changed lines exceeds budget %d" % (total, self.cfg["max_fix_lines"])
+        for f in changed:
+            path = f.get("filename", "")
+            for bad in self.cfg["forbidden_paths"]:
+                if path == bad or path.startswith(bad):
+                    return False, "touches forbidden path %s" % path
+            if path == "pyproject.toml":
+                return False, "touches pyproject.toml (dependency review needed)"
+        return True, ""
+
+    # -- 3b. CI watch ------------------------------------------------------
+    @staticmethod
+    def summarize_checks(rows, required):
+        """Aggregate gh's per-run rows into one verdict per required check.
+
+        The same check appears once per workflow run, so a name is only `pass`
+        when every instance of it passed, and `fail` if any instance failed.
+        """
+        out = {}
+        for name in required:
+            states = [r for r in rows if (r.get("name") or "") == name]
+            if not states:
+                out[name] = "pending"
+            elif any((r.get("bucket") or "").lower() in ("fail", "cancel") for r in states):
+                out[name] = "fail"
+            elif all((r.get("bucket") or "").lower() in ("pass", "skipping") for r in states):
+                out[name] = "pass"
+            else:
+                out[name] = "pending"
+        return out
+
+    def pr_settled_by_human(self, rec, pr, number):
+        """Stop watching a PR a human has merged or closed.
+
+        A sweep PR closed without merging is bakert rejecting the fix: delete the
+        branch, mark the issue human-settled, and never retry it.
+        """
+        try:
+            info = self.gh.pr_state(number)
+        except InfraError as exc:
+            log("PR state check failed for #%s: %s" % (number, exc))
+            return False
+        state = (info.get("state") or "").upper()
+        if state == "MERGED":
+            if (pr.get("ci") or {}).get("state") != "merged":
+                self.store.journal("PR_MERGED", issue=rec["issue"], pr=number,
+                                   merged_at=info.get("mergedAt"))
+                log("PR #%s was merged by a human" % number)
+            return True
+        if state == "OPEN":
+            return self.handle_mergeability(rec, pr, number, info)
+        if state == "CLOSED":
+            branch = pr.get("branch")
+            deleted = False
+            if branch and self.gh.remote_branch_sha(branch):
+                self.gh.delete_remote_branch(branch)
+                deleted = self.gh.remote_branch_sha(branch) is None
+            self.store.journal("PR_WITHDRAWN", issue=rec["issue"], pr=number,
+                               branch=branch, branch_deleted=deleted)
+            log("PR #%s closed without merging; issue #%s settled by human%s"
+                % (number, rec["issue"], " (branch deleted)" if deleted else ""))
+            return True
+        return False
+
+    def handle_mergeability(self, rec, pr, number, info):
+        """Master moves under long-lived sweep PRs; a green PR can still be unmergeable.
+
+        BEHIND is mechanical, so the dispatcher merges master in itself. CONFLICTING
+        needs judgement, so it escalates and waits for an adjudication.
+        """
+        status = (info.get("mergeStateStatus") or "").upper()
+        mergeable = (info.get("mergeable") or "").upper()
+        if mergeable == "CONFLICTING" or status == "DIRTY":
+            if (pr.get("ci") or {}).get("state") != "conflict":
+                self.store.journal("PR_CONFLICT", issue=rec["issue"], pr=number)
+                self.escalate(
+                    rec["issue"], "pr-conflict",
+                    "PR #%s conflicts with master — dispatch one fixer to merge master and "
+                    "resolve (queue-fixup), or abandon it (abandon-pr)?" % number,
+                    summary="mergeable=%s mergeStateStatus=%s on branch %s"
+                            % (mergeable, status, pr.get("branch")),
+                    refs=["evidence/%s.json#fix[-1]" % rec["issue"]])
+                log("PR #%s conflicts with master" % number)
+            return True
+        if status == "BEHIND" and self.cfg.get("auto_update_behind_branches", True):
+            last = parse_iso(pr.get("last_branch_update"))
+            if not last or (utcnow() - last) > dt.timedelta(minutes=15):
+                out = self.gh.pr_update_branch(number)
+                if "conflict" in (out or "").lower():
+                    return False  # next pass sees CONFLICTING and escalates properly
+                self.store.journal("PR_BRANCH_UPDATED", issue=rec["issue"], pr=number)
+                log("PR #%s was behind master; merged master in" % number)
+            return False
+        return False
+
+    def watch_ci(self):
+        """Poll the Mergify-required checks on every open sweep PR.
+
+        `pr_open` is terminal for the sweep, but a red draft would otherwise sit
+        unnoticed until bakert opened it, so the dispatcher keeps watching.
+        """
+        required = self.cfg["required_checks"]
+        recheck = dt.timedelta(minutes=self.cfg["ci_recheck_minutes"])
+        # Conflicts and BEHIND states are *caused* by master moving, so poll on that
+        # event rather than waiting out a timer. One `git ls-remote` per tick costs
+        # no REST quota and makes detection immediate instead of interval-bound.
+        master_moved = False
+        if not self.dry:
+            try:
+                sha = self.gh.remote_branch_sha("master")
+            except InfraError:
+                sha = None
+            if sha and sha != self.st.last_master_sha:
+                master_moved = self.st.last_master_sha is not None
+                self.store.journal("MASTER_ADVANCED", sha=sha)
+                if master_moved:
+                    log("master advanced to %s; rechecking every open sweep PR" % sha[:10])
+        for rec in self._ready("pr_open") + self._ready("pr_ci_failed"):
+            pr = rec.get("pr") or {}
+            number = pr.get("number")
+            if not number:
+                continue
+            ci = pr.get("ci") or {}
+            checked = parse_iso(ci.get("checked_at"))
+            settled = ci.get("state") in ("green", "merged")
+            if settled and checked and (utcnow() - checked) < recheck and not master_moved:
+                continue
+            if self.dry:
+                self.say("WOULD poll CI for PR #%s (issue #%s)" % (number, rec["issue"]))
+                continue
+            if self.pr_settled_by_human(rec, pr, number):
+                continue
+            try:
+                rows = self.gh.pr_checks(number)
+            except InfraError as exc:
+                log("CI poll failed for #%s: %s" % (number, exc))
+                continue
+            verdict = self.summarize_checks(rows, required)
+            failed = sorted(n for n, v in verdict.items() if v == "fail")
+            if failed:
+                tails = []
+                for name in failed[:2]:
+                    tail = self.gh.check_run_summary(pr.get("head_sha") or "", name)
+                    if tail:
+                        tails.append("### %s\n%s" % (name, tail))
+                self.store.journal("PR_CI_FAILED", issue=rec["issue"], pr=number, failed=failed)
+                self.escalate(
+                    rec["issue"], "pr-ci-failed",
+                    "PR #%s is red on %s — dispatch one follow-up fixer to the same branch "
+                    "(queue-fixup), or abandon the PR (abandon-pr)?" % (number, ", ".join(failed)),
+                    summary=("failing checks: %s\n%s" % (", ".join(failed), "\n".join(tails)))[:4000],
+                    refs=["evidence/%s.json#fix[-1]" % rec["issue"]])
+                continue
+            if all(v == "pass" for v in verdict.values()):
+                if ci.get("state") != "green":
+                    self.store.journal("PR_CI_GREEN", issue=rec["issue"], pr=number)
+                    log("PR #%s green on all required checks" % number)
+                else:
+                    self.store.journal("CI_CHECKED", issue=rec["issue"], pr=number)
+            else:
+                self.store.journal("CI_CHECKED", issue=rec["issue"], pr=number)
+
+    # -- 4. escalation bundles --------------------------------------------
+    def bundle_escalations(self):
+        files = sorted(ESCALATIONS.glob("*.json"))
+        recs = [read_json(f) for f in files]
+        unbundled = [r for r in recs if r and not r.get("bundled_at")]
+        if not unbundled:
+            return
+        now = utcnow()
+        last = parse_iso(self.st.last_bundle_at)
+        if last and (now - last) < dt.timedelta(hours=self.cfg["bundle_min_gap_hours"]):
+            return
+        oldest = min((parse_iso(r["created_at"]) or now) for r in unbundled)
+        trigger = (len(unbundled) >= self.cfg["bundle_min_items"]
+                   or (now - oldest) > dt.timedelta(hours=self.cfg["bundle_max_age_hours"]))
+        if not trigger:
+            return
+        ts = now.strftime("%Y%m%dT%H%M%SZ")
+        lines = ["# Escalation bundle %s" % ts, "", self.vitals_line(), ""]
+        for r in unbundled[:40]:
+            lines += [
+                "## #%s — %s" % (r["issue"], r["kind"]),
+                "- question: %s" % r["question"],
+                "- summary: %s" % (r.get("summary") or "")[:400].replace("\n", " "),
+                "- evidence: %s" % ", ".join(r.get("evidence_refs") or []),
+                "- suggested default: %s" % self.suggested_default(r),
+                "",
+            ]
+        lines += ["Adjudicate with: dispatcher.py adjudicate <issue> <verb> [--note ...]", ""]
+        path = OUTBOX / ("bundle-%s.md" % ts)
+        write_atomic(path, "\n".join(lines))
+        sid = self.cfg.get("opus_session_id")
+        if not sid:
+            self.st.counters["alert"] = "bundle queued, opus_session_id unset"
+            return
+        if self.dry:
+            self.say("WOULD send bundle %s to session %s" % (path.name, sid))
+            return
+        try:
+            self.cond.send_message(sid, "Escalation bundle ready: read `%s` and adjudicate." % path,
+                                   message_id="bundle-%s" % ts)
+        except InfraError as exc:
+            log("bundle send failed: %s" % exc)
+            return
+        self.st.last_bundle_at = iso(now)
+        for r, f in zip(recs, files):
+            if r and not r.get("bundled_at"):
+                r["bundled_at"] = iso(now)
+                write_json(f, r)
+
+    @staticmethod
+    def suggested_default(r):
+        return {
+            "verifier-refuted": "report-only",
+            "verifier-uncertain": "report-only",
+            "cannot-reproduce": "report-only",
+            "attempts-exhausted": "report-only",
+            "fix-abort": "report-only",
+            "fix-validation": "defer-to-human",
+            "mutation-failed": "retry",
+            "class-escalate": "defer-to-human",
+            "malformed": "retry-triage",
+            "invariant": "defer-to-human",
+        }.get(r.get("kind"), "defer-to-human")
+
+    def vitals_line(self):
+        c = self.counts()
+        return "vitals: %s | closures_today=%d/%d prs_today=%d/%d active_ws=%d paused=%s" % (
+            " ".join("%s=%d" % kv for kv in sorted(c.items()) if kv[1]),
+            self.st.daily.get("closures", 0), self.cfg["daily_close_cap"],
+            self.st.daily.get("prs", 0), self.cfg["daily_pr_cap"],
+            len(self.active_workspaces()), self.st.paused,
+        )
+
+    def counts(self):
+        out = {}
+        for r in self.st.issues.values():
+            out[r["status"]] = out.get(r["status"], 0) + 1
+        return out
+
+    # -- 5. replenish ------------------------------------------------------
+    def replenish(self):
+        if self.st.paused or not self.cfg.get("spawning_enabled", True):
+            return
+        cap = self.cfg["concurrency_cap"]
+        created = self.st.counters.get("workspaces_created", 0)
+        planned = 0
+        while len(self.active_workspaces()) + planned < cap:
+            if created + planned >= self.cfg["max_total_workspaces"]:
+                log("max_total_workspaces reached")
+                return
+            job = self.next_job()
+            if job is None:
+                return
+            if not self.spawn(job):
+                return
+            if self.dry:
+                planned += 1
+
+    def next_job(self):
+        verify = self._ready("verify_pending")
+        if verify:
+            batch = verify[:self.cfg["verify_batch_size"]]
+            return ("verify", [r["issue"] for r in batch])
+        for rec in self._ready("fix_pending"):
+            ok, why = self.fix_guards(rec)
+            if ok:
+                return ("fix", [rec["issue"]])
+            self.escalate(rec["issue"], "fix-validation", "Pre-dispatch guard: %s" % why, summary=why)
+        eligible = set(eligible_issue_numbers(self.st.issues, self.cfg["pilot_limit"]))
+        pending = [r for r in self._ready("pending") if r["issue"] in eligible]
+        if pending:
+            batch = pending[:self.cfg["triage_batch_size"]]
+            return ("triage", [r["issue"] for r in batch])
+        return None
+
+    def fix_guards(self, rec):
+        n = rec["issue"]
+        if rec.get("fixup"):
+            # The one sanctioned exception: a manager-adjudicated follow-up fixer
+            # pushes to the sweep branch that already exists, for the PR that
+            # already exists. Both guards below would reject it by design.
+            return True, ""
+        try:
+            if self.gh.issue(n, "state").get("state") != "OPEN":
+                return False, "issue is no longer open"
+        except InfraError as exc:
+            return False, "gh issue view failed: %s" % exc
+        try:
+            if self.gh.open_prs_mentioning(n):
+                return False, "an open PR already references #%s" % n
+        except InfraError as exc:
+            return False, "gh pr list failed: %s" % exc
+        stale = self.gh.branches_matching("refs/heads/sweep/%s-*" % n)
+        if stale:
+            # A previous fixer pushed but its report was never harvested (malformed
+            # output or an expired lease), so the retry now collides with its own
+            # orphan. The branch is ours by naming convention and has no PR of any
+            # kind, so reclaim it rather than deadlocking on it.
+            if not self.cfg.get("reclaim_orphan_branches", True):
+                return False, "a sweep/%s-* branch already exists on origin" % n
+            for ref in stale:
+                branch = ref.replace("refs/heads/", "")
+                if not re.match(r"^sweep/%d-" % n, branch):
+                    return False, "unexpected branch %s" % branch
+                try:
+                    if self.gh.prs_for_branch(branch):
+                        return False, "branch %s already has a PR" % branch
+                except InfraError as exc:
+                    return False, "could not check PRs for %s: %s" % (branch, exc)
+                self.gh.delete_remote_branch(branch)
+                if self.gh.remote_branch_sha(branch):
+                    return False, "could not delete orphan branch %s" % branch
+                self.store.journal("ROLLBACK_RECORDED", issue=n, status=None,
+                                   action="deleted orphan branch %s (pushed by a fixer whose "
+                                          "report was never harvested; no PR existed)" % branch)
+                log("reclaimed orphan branch %s for #%s" % (branch, n))
+        return True, ""
+
+    def batch_id(self, kind, issues):
+        attempt = 1 + max(self.st.issue(n)["stage_attempts"].get(kind, 0) for n in issues)
+        prefix = "u" if (kind == "fix" and self.st.issue(issues[0]).get("fixup")) else kind[0]
+        return "%s-%s-%d" % (prefix, issues[0], attempt)
+
+    def render_prompt(self, kind, issues, batch_id):
+        if kind == "triage":
+            return render_template(BASE / "WORKER_PROMPT.md", {
+                "ISSUE_NUMBERS": ", ".join("#%s" % n for n in issues),
+                "BATCH_ID": batch_id,
+            })
+        if kind == "verify":
+            claims = []
+            for n in issues:
+                tri = self.last_evidence(n, "triage") or {}
+                claims.append({
+                    "issue": n, "title": self.st.issue(n)["title"], "class": tri.get("class"),
+                    "duplicate_of": tri.get("duplicate_of"), "evidence": tri.get("evidence"),
+                    "proposed_comment": tri.get("proposed_comment"),
+                })
+            return render_template(BASE / "VERIFIER_PROMPT.md", {
+                "BATCH_ID": batch_id, "CLAIMS": render_claims(claims),
+                "PROPOSED_COMMENT": "(shown with each claim above)",
+            })
+        n = issues[0]
+        rec = self.st.issue(n)
+        if rec.get("fixup"):
+            fu = rec["fixup"]
+            failed = fu.get("failed") or []
+            if failed == ["merge-conflict"]:
+                problem = "the branch conflicts with master and cannot be merged"
+            else:
+                problem = "these required checks are failing: %s" % (", ".join(failed) or "unknown")
+            return render_template(BASE / "FIXUP_PROMPT.md", {
+                "ISSUE": n, "TITLE": rec["title"], "BATCH_ID": batch_id,
+                "BRANCH": fu["branch"], "PR": fu["pr"], "PROBLEM": problem,
+                "DETAIL": (fu.get("log_tail") or "(no detail captured; reproduce it yourself)")[:4000],
+            })
+        tri = self.last_evidence(n, "triage") or {}
+        return render_template(BASE / "FIXER_PROMPT.md", {
+            "ISSUE": n, "TITLE": rec["title"], "BATCH_ID": batch_id,
+            "FIX_SKETCH": tri.get("fix_sketch") or "(none supplied — derive it yourself)",
+            "BRANCH": "sweep/%s-%s" % (n, slugify(rec["title"])),
+        })
+
+    def spawn(self, job):
+        kind, issues = job
+        bid = self.batch_id(kind, issues)
+        prompt = self.render_prompt(kind, issues, bid)
+        path = OUTBOX / ("%s.md" % bid)
+        write_atomic(path, prompt)
+        name = "sweep-%s" % bid
+        if self.dry:
+            self.say("WOULD create workspace %s (%s) for %s  [prompt %d chars -> %s]"
+                     % (name, kind, issues, len(prompt), path.name))
+            self.dry_leased.update(issues)
+            return True
+        try:
+            res = self.cond.create_workspace(
+                name=name, session_name=name, message=prompt,
+                model=self.cfg["worker_model"], effort=self.cfg["worker_effort"],
+                project_id=self.cfg["project_id"],
+            )
+        except InfraError as exc:
+            self.create_failures += 1
+            self.store.journal("WORKSPACE_FAILED", batch_id=bid, reason=str(exc)[:200], issues=issues)
+            if self.check_rate_limit_text(exc.output) or self.create_failures >= 2:
+                self.pause("workspace creation failing (%s)" % str(exc)[:80])
+            return False
+        self.create_failures = 0
+        wid, sid = res.get("workspaceId"), res.get("sessionId")
+        if not wid:
+            self.store.journal("WORKSPACE_FAILED", batch_id=bid, reason="no workspaceId in response",
+                               issues=issues)
+            return False
+        self.store.journal("WORKSPACE_CREATED", workspace_id=wid, session_id=sid, kind=kind,
+                           batch_id=bid, issues=issues)
+        expires = iso(utcnow() + dt.timedelta(minutes=self.cfg["lease_minutes"][kind]))
+        attempt = int(bid.rsplit("-", 1)[1])
+        for n in issues:
+            self.store.journal("LEASE_GRANTED", issue=n, kind=kind, batch_id=bid, workspace_id=wid,
+                               session_id=sid, expires_at=expires, attempt=attempt)
+        return True
+
+    def check_unregistered_workspaces(self):
+        """A7 tightening: alert on ANY workspace in the project we did not create.
+
+        Workers can create workspaces (validated 2026-08-23), so the prompt barrier
+        needs a detector behind it.  Informational only: it never pauses the sweep,
+        because bakert may legitimately open a workspace here mid-campaign.
+        """
+        try:
+            data = self.cond.list_project_workspaces(self.cfg["project_id"]).get("data") or []
+        except InfraError as exc:
+            log("project workspace list failed: %s" % exc)
+            return
+        mine = set(self.st.workspaces)
+        manager = os.environ.get("CONDUCTOR_WORKSPACE_ID")
+        found = []
+        for w in data:
+            if w.get("state") in ("archived", "deleted"):
+                continue
+            if w["id"] in mine or w["id"] == manager:
+                continue
+            found.append("%s (%s)" % (w.get("name") or "?", w["id"][:8]))
+        if found != self.unregistered and found:
+            log("UNREGISTERED workspaces in project: %s" % ", ".join(found))
+        self.unregistered = found
+
+    # -- 6. bookkeeping ----------------------------------------------------
+    def write_metrics(self):
+        m = {
+            "heartbeat": iso(utcnow()), "phase": self.cfg["phase"], "paused": self.st.paused,
+            "pause_until": self.st.pause_until, "active_workspaces": len(self.active_workspaces()),
+            "counts": self.counts(),
+            "caps": {"closures_today": self.st.daily.get("closures", 0),
+                     "prs_today": self.st.daily.get("prs", 0)},
+            "totals": {"workspaces_created": self.st.counters.get("workspaces_created", 0),
+                       "nudges": self.st.counters.get("nudges", 0),
+                       "infra_failures": self.st.counters.get("infra_failures", 0)},
+            "open_escalations": len(list(ESCALATIONS.glob("*.json"))),
+            "unregistered_workspaces": self.unregistered,
+            "pr_backpressure": self.st.pr_backpressure,
+            "open_sweep_prs": self.open_sweep_prs,
+            "max_open_prs": self.cfg.get("max_open_prs"),
+            "alert": self.alert(),
+        }
+        write_json(METRICS, m)
+        return m
+
+    def alert(self):
+        if self.mirror_error:
+            return "mirror failing: %s" % self.mirror_error
+        if self.unregistered:
+            return "unregistered workspace(s) in project: %s" % ", ".join(self.unregistered)
+        if self.st.counters.get("alert"):
+            return self.st.counters["alert"]
+        if self.st.paused:
+            for ev in reversed(self._journal_tail(400)):
+                if ev.get("event") == "PAUSE_ON":
+                    since = parse_iso(ev.get("since") or ev.get("ts"))
+                    if since and (utcnow() - since) > dt.timedelta(hours=4):
+                        return "paused for over 4h"
+                    break
+        if self.cfg.get("mirror", {}).get("kind") not in (None, "none"):
+            last = parse_iso(self.st.last_mirror_at)
+            if last and (utcnow() - last) > dt.timedelta(minutes=60):
+                return "mirror stale"
+        return None
+
+    def maybe_mirror(self, force=False):
+        conf = self.cfg.get("mirror") or {}
+        if conf.get("kind") in (None, "none"):
+            return
+        last = parse_iso(self.st.last_mirror_at)
+        if not force and last and (utcnow() - last) < dt.timedelta(minutes=conf.get("interval_minutes", 15)):
+            return
+        if self.dry:
+            self.say("WOULD mirror state to %s:%s" % (conf.get("kind"), conf.get("ref")))
+            return
+        try:
+            if conf["kind"] == "branch":
+                pushed = self.mirror_branch(conf.get("ref", "sweep-state"))
+            elif conf["kind"] == "gist":
+                pushed = self.mirror_gist(conf.get("ref"))
+            else:
+                return False
+            if pushed:
+                self.store.journal("MIRROR_PUSHED", kind=conf["kind"], ref=conf.get("ref"))
+            else:
+                self.st.last_mirror_at = iso(utcnow())  # nothing to push; still fresh
+            self.mirror_error = None
+            return True
+        except (InfraError, OSError) as exc:
+            self.mirror_error = str(exc)[:200]
+            log("mirror FAILED: %s" % exc)
+            return False
+
+    def _mirror_payload(self, dest):
+        dest = Path(dest)
+        for name in ("journal.jsonl", "snapshot.json", "config.json", "metrics.json"):
+            src = STATE / name
+            if src.exists():
+                shutil.copy2(src, dest / name)
+        for sub in ("evidence", "escalations", "reports"):
+            tgt = dest / sub
+            if tgt.exists():
+                shutil.rmtree(tgt)
+            if (STATE / sub).exists():
+                shutil.copytree(STATE / sub, tgt)
+
+    def mirror_branch(self, ref):
+        """Push state to the orphan `sweep-state` branch and VERIFY it landed.
+
+        Every step is checked: a mirror that silently no-ops is worse than no
+        mirror, because recovery would restore stale state.
+        """
+        run = self.runner.run
+        git = ["git", "-C", str(MIRROR_DIR)]
+        if not (MIRROR_DIR / ".git").exists():
+            MIRROR_DIR.mkdir(parents=True, exist_ok=True)
+            run(git + ["init", "-q", "-b", ref])
+            url = run(["git", "-C", str(BASE), "remote", "get-url", "origin"]).strip()
+            run(git + ["remote", "add", "origin", url])
+            for key, fallback in (("user.name", "penny-dreadful-sweep"),
+                                  ("user.email", "sweep@localhost")):
+                val = run(["git", "-C", str(BASE), "config", key], check=False).strip()
+                run(git + ["config", key, val.splitlines()[0] if val.strip() else fallback])
+            fetched = run(git + ["fetch", "-q", "origin", ref], check=False)
+            if "couldn't find remote ref" not in fetched:
+                run(git + ["reset", "-q", "--hard", "FETCH_HEAD"])
+        self._mirror_payload(MIRROR_DIR)
+        run(git + ["add", "-A"])
+        status = run(git + ["status", "--porcelain"], check=False)
+        if not status.strip():
+            log("mirror: nothing changed")
+            return False
+        run(git + ["commit", "-q", "-m", "sweep state %s" % iso(utcnow())])
+        local = run(git + ["rev-parse", "HEAD"]).strip()
+        push = run(git + ["push", "origin", "HEAD:%s" % ref], check=False)
+        if "rejected" in push or "non-fast-forward" in push:
+            raise InfraError("mirror push rejected — another writer? STOPPING mirror", push)
+        remote = run(["git", "ls-remote", "origin", "refs/heads/" + ref]).split()
+        if not remote or remote[0] != local:
+            raise InfraError("mirror push did not land: origin/%s is %s, local is %s"
+                             % (ref, (remote[0][:10] if remote else "absent"), local[:10]), push)
+        log("mirror: pushed %s to origin/%s" % (local[:10], ref))
+        return True
+
+    def mirror_gist(self, gist_id):
+        tar = STATE / ".mirror.tar.gz"
+        subprocess.run(["tar", "czf", str(tar), "-C", str(STATE), "journal.jsonl", "snapshot.json",
+                        "config.json", "evidence", "escalations"], check=False)
+        b64 = STATE / ".mirror.tar.gz.b64"
+        import base64
+        write_atomic(b64, base64.b64encode(tar.read_bytes()).decode())
+        self.runner.run(["gh", "gist", "edit", gist_id, "-f", "sweep-state.tar.gz.b64", str(b64)])
+        return True
+
+    def maybe_snapshot(self, events_since):
+        last = parse_iso(self.st.last_snapshot_at)
+        if events_since >= 50 or not last or (utcnow() - last) > dt.timedelta(minutes=5):
+            self.store.snapshot()
+
+    def daily_report(self, day=None):
+        day = day or iso(utcnow())[:10]
+        c = self.counts()
+        closed = [r for r in self.st.issues.values() if r["status"] == "closed"]
+        prs = [r for r in self.st.issues.values() if r["status"] == "pr_open"]
+        lines = [
+            "# Sweep daily report %s" % day, "",
+            "phase: %s   paused: %s   active workspaces: %d" % (
+                self.cfg["phase"], self.st.paused, len(self.active_workspaces())), "",
+            "## Counts by status", "",
+        ]
+        lines += ["- %s: %d" % (k, v) for k, v in sorted(c.items())]
+        lines += ["", "## Mutations", "",
+                  "- closed to date: %d" % len(closed),
+                  "- PRs open to date: %d" % len(prs),
+                  "- closures today: %d / %d" % (self.st.daily.get("closures", 0), self.cfg["daily_close_cap"]),
+                  "- PRs today: %d / %d" % (self.st.daily.get("prs", 0), self.cfg["daily_pr_cap"]),
+                  "", "## Open escalations", ""]
+        for f in sorted(ESCALATIONS.glob("*.json")):
+            r = read_json(f) or {}
+            lines.append("- #%s (%s): %s" % (r.get("issue"), r.get("kind"), r.get("question")))
+        lines += ["", "## Totals", "",
+                  "- workspaces created: %d" % self.st.counters.get("workspaces_created", 0),
+                  "- nudges: %d" % self.st.counters.get("nudges", 0),
+                  "- infra failures: %d" % self.st.counters.get("infra_failures", 0), ""]
+        path = REPORTS / ("daily-%s.md" % day)
+        write_atomic(path, "\n".join(lines))
+        return path
+
+    # -- the tick ----------------------------------------------------------
+    def tick(self):
+        start_seq = self.st.last_seq
+        self.maybe_unpause()
+        try:
+            self.harvest()
+        except InfraError as exc:
+            self.note_infra_failure("harvest: %s" % exc)
+        self.expire_leases()
+        self.execute_mutations()
+        self.watch_ci()
+        self.retry_archives()
+        self.bundle_escalations()
+        self.replenish()
+        self.check_unregistered_workspaces()
+        if self.runner.recent_infra_failures(10) >= 3:
+            self.pause("3+ infrastructure failures in 10 minutes")
+        if not self.dry:
+            self.maybe_snapshot(self.st.last_seq - start_seq)
+            self.maybe_mirror()
+            m = self.write_metrics()
+            today = iso(utcnow())[:10]
+            if not (REPORTS / ("daily-%s.md" % today)).exists():
+                self.daily_report(today)
+            return m
+        self.store.snapshot()
+        return None
+
+    # -- recover -----------------------------------------------------------
+    def recover(self):
+        out = ["# recover %s" % iso(utcnow())]
+        for rec in self._ready("closing"):
+            n = rec["issue"]
+            try:
+                state = self.gh.issue(n, "state").get("state")
+            except InfraError:
+                continue
+            if state == "CLOSED":
+                self.store.journal("CLOSE_EXECUTED", issue=n, reason=(rec.get("closure") or {}).get("reason"),
+                                   comment_posted=True, external=True)
+                out.append("#%s settled to closed" % n)
+            else:
+                self.store.journal("ROLLBACK_RECORDED", issue=n, status="verified",
+                                   action="closing did not land; back to verified")
+                out.append("#%s back to verified" % n)
+        for rec in self._ready("fix_pushed"):
+            n, fx = rec["issue"], (self.last_evidence(rec["issue"], "fix") or {})
+            branch = fx.get("branch")
+            if branch and not self.gh.remote_branch_sha(branch):
+                self.escalate(n, "fix-validation", "Branch %s vanished from origin." % branch)
+                out.append("#%s branch missing -> escalated" % n)
+        # Reconcile every workspace we ever created against its real state. The
+        # journal has been wrong about this before, so trust the API, not ourselves.
+        stale = []
+        for ws in self.st.workspaces.values():
+            if ws["state"] == "archived":
+                try:
+                    live = (self.cond.workspace_status(ws["workspace_id"]) or {}).get("status")
+                except InfraError:
+                    continue
+                if live not in ("archived", "deleted"):
+                    stale.append((ws, live))
+        for ws, live in stale:
+            out.append("registry said archived but %s is %s (%s)" % (ws["workspace_id"], live, ws["batch_id"]))
+            if not self.dry:
+                self.store.journal("WORKSPACE_HARVESTED", workspace_id=ws["workspace_id"], state=live)
+                if self.archive(ws):
+                    out.append("  -> archived for real")
+                else:
+                    out.append("  -> STILL not archived; needs a human")
+        known = set(self.st.workspaces)
+        try:
+            listing = (self.cond.list_workspaces(name="sweep-").get("data") or [])
+        except InfraError as exc:
+            listing = []
+            out.append("workspace list failed: %s" % exc)
+        for w in listing:
+            if w.get("state") in ("archived", "deleted") or w["id"] in known:
+                continue
+            m = re.match(r"^sweep-([tvf])-(\d+)-(\d+)$", w.get("name") or "")
+            if not m:
+                out.append("ignoring non-sweep workspace %s (%s)" % (w["id"], w.get("name")))
+                continue
+            kind = {"t": "triage", "v": "verify", "f": "fix"}[m.group(1)]
+            bid = w["name"][len("sweep-"):]
+            issues = [int(n) for n, r in self.st.issues.items()
+                      if (r.get("lease") or {}).get("batch_id") == bid]
+            if not issues:
+                out.append("orphan workspace %s (%s) has no live lease — archiving" % (w["id"], bid))
+                if not self.dry:
+                    try:
+                        self.cond.archive_workspace(w["id"])
+                    except InfraError:
+                        pass
+                continue
+            sids = [s2["id"] for s2 in (self.cond.list_sessions(w["id"]).get("data") or [])]
+            if not self.dry:
+                self.store.journal("WORKSPACE_CREATED", workspace_id=w["id"],
+                                   session_id=sids[0] if sids else None, kind=kind,
+                                   batch_id=bid, issues=issues, adopted=True)
+            out.append("adopted orphan workspace %s (%s) for %s" % (w["id"], bid, issues))
+        for ws in list(self.active_workspaces()):
+            try:
+                st = self.cond.session_status(ws["session_id"]).get("status")
+            except InfraError:
+                continue
+            if st == "idle":
+                self.harvest_workspace(ws)
+                out.append("harvested %s" % ws["batch_id"])
+            elif st == "error":
+                self.fail_workspace(ws, "session error at recover")
+                out.append("failed %s" % ws["batch_id"])
+            else:
+                out.append("re-adopted %s (still working)" % ws["batch_id"])
+        try:
+            live_open = {i["number"] for i in self.gh.list_open_issues()}
+        except InfraError:
+            live_open = None
+        if live_open is not None:
+            for rec in list(self.st.issues.values()):
+                if rec["status"] in TERMINAL or rec["status"] == "closing":
+                    continue
+                if rec["issue"] not in live_open:
+                    self.store.journal("ISSUE_SKIPPED", issue=rec["issue"], reason="closed outside the sweep")
+                    out.append("#%s closed externally -> skipped" % rec["issue"])
+        self.store.snapshot()
+        self.maybe_mirror(force=True)
+        return "\n".join(out)
+
+
+# ------------------------------------------------------------------------ verbs
+
+def cmd_init(store, args):
+    eng = Engine(store)
+    cfg = store.config
+    issues = eng.gh.list_open_issues()
+    universe = [i for i in issues if cfg["frontier_min"] <= i["number"] <= cfg["frontier_max"]]
+    universe.sort(key=lambda i: -i["number"])
+    if not store.state.issues:
+        store.journal("CAMPAIGN_INIT", frontier_min=cfg["frontier_min"], frontier_max=cfg["frontier_max"],
+                      universe=len(universe), repo=cfg["repo"])
+    live = {i["number"] for i in universe}
+    added = 0
+    for i in universe:
+        if str(i["number"]) in store.state.issues:
+            continue
+        store.journal("ISSUE_ENQUEUED", issue=i["number"], title=i["title"],
+                      labels=[l["name"] for l in i.get("labels") or []])
+        added += 1
+    gone = 0
+    for rec in list(store.state.issues.values()):
+        if rec["issue"] not in live and rec["status"] not in TERMINAL:
+            store.journal("ISSUE_SKIPPED", issue=rec["issue"], reason="closed before triage")
+            gone += 1
+    if store.config.get("opus_session_id") is None and os.environ.get("CONDUCTOR_SESSION_ID"):
+        store.config["opus_session_id"] = os.environ["CONDUCTOR_SESSION_ID"]
+        store.save_config()
+        store.journal("CONFIG_CHANGED", changes={"opus_session_id": "<this session>"})
+    store.snapshot()
+    return "queue: %d issues in universe (%d newly enqueued, %d newly closed -> skipped)" % (
+        len(universe), added, gone)
+
+
+def cmd_status(store, args):
+    st, cfg = store.state, store.config
+    eng = Engine(store)
+    c = eng.counts()
+    lines = [
+        "phase=%s pilot_limit=%s concurrency=%s mutations=%s paused=%s" % (
+            cfg["phase"], cfg["pilot_limit"], cfg["concurrency_cap"], cfg["mutations_enabled"], st.paused),
+        "issues=%d  %s" % (len(st.issues), "  ".join("%s=%d" % kv for kv in sorted(c.items()))),
+        "workspaces active=%d created=%d nudges=%d infra_failures=%d" % (
+            len(eng.active_workspaces()), st.counters.get("workspaces_created", 0),
+            st.counters.get("nudges", 0), st.counters.get("infra_failures", 0)),
+        "open sweep PRs cap=%s  backpressure=%s" % (cfg.get("max_open_prs"), st.pr_backpressure),
+        "today closures=%d/%d prs=%d/%d" % (
+            st.daily.get("closures", 0), cfg["daily_close_cap"],
+            st.daily.get("prs", 0), cfg["daily_pr_cap"]),
+        "open escalations=%d  last_seq=%d" % (len(list(ESCALATIONS.glob("*.json"))), st.last_seq),
+        "daemon: %s" % ("running as pid %s" % daemon_pid() if daemon_pid() else "NOT RUNNING"),
+    ]
+    for ws in eng.active_workspaces():
+        lines.append("  %-14s %-6s %s" % (ws["batch_id"], ws["kind"], ws["issues"]))
+    return "\n".join(lines)
+
+
+def _coerce(v):
+    if v.lower() in ("true", "false"):
+        return v.lower() == "true"
+    if re.fullmatch(r"-?\d+", v):
+        return int(v)
+    try:
+        return json.loads(v)
+    except ValueError:
+        return v
+
+
+def cmd_config(store, args):
+    changes = {}
+    for kv in args.pairs:
+        if "=" not in kv:
+            raise SystemExit("config set expects K=V, got %r" % kv)
+        k, v = kv.split("=", 1)
+        if k not in DEFAULT_CONFIG:
+            raise SystemExit("unknown config key %r" % k)
+        changes[k] = _coerce(v)
+    if changes.get("concurrency_cap", 0) > 16:
+        raise SystemExit("concurrency_cap > 16 requires explicit user approval (PLAN.md §5)")
+    store.config.update(changes)
+    store.save_config()
+    store.journal("CONFIG_CHANGED", changes=changes)
+    store.snapshot()
+    return "config updated: %s" % json.dumps(changes, sort_keys=True)
+
+
+ADJUDICATIONS = {
+    "annotate": None,          # record a decision, change nothing
+    "queue-fixup": "fix_pending",
+    "abandon-pr": "deferred_human",
+    "close-completed": "closing",
+    "close-not-planned": "closing",
+    "queue-fix": "fix_pending",
+    "report-only": "reported",
+    "retry-triage": "pending",
+    "retry-verify": "verify_pending",
+    "defer-to-human": "deferred_human",
+    "mark-failed": "failed",
+}
+
+
+def cmd_adjudicate(store, args):
+    n = int(args.issue)
+    rec = store.state.issue(n)
+    if not rec:
+        raise SystemExit("#%s is not in the queue" % n)
+    verb = args.verb
+    if verb not in ADJUDICATIONS:  # noqa: SIM102 - explicit for the error message
+        raise SystemExit("unknown verb %r (choose from %s)" % (verb, ", ".join(sorted(ADJUDICATIONS))))
+    eng = Engine(store)
+    status = ADJUDICATIONS[verb]
+    if verb == "queue-fixup":
+        pr = (rec.get("pr") or {})
+        if not pr.get("number") or not pr.get("branch"):
+            raise SystemExit("#%s has no PR on record to fix up" % n)
+        prior = (rec.get("fixup") or {}).get("attempt", 0)
+        if prior >= store.config["max_fixup_attempts"]:
+            raise SystemExit("#%s has already had %d fixup attempt(s); abandon-pr or defer instead"
+                             % (n, prior))
+        esc = read_json(ESCALATIONS / ("%s.json" % n)) or {}
+        failed = ((rec.get("pr") or {}).get("ci") or {}).get("failed") or []
+        # Retry the log fetch here: at detection time the workflow run is usually
+        # still in progress, so `gh run view --log-failed` had nothing to give.
+        detail = ""
+        if failed and failed != ["merge-conflict"]:
+            try:
+                detail = eng.gh.failed_check_log(pr["number"], failed)
+            except InfraError as exc:
+                log("log fetch for #%s failed: %s" % (pr["number"], exc))
+        if not detail:
+            detail = (esc.get("summary") or "")[:4000]
+        store.journal("FIXUP_DISPATCHED", issue=n, branch=pr["branch"], pr=pr["number"],
+                      failed=failed, attempt=prior + 1, log_tail=detail[:4000], note=args.note)
+        msg = "#%s queued for one CI-remediation fixer on %s (PR #%s)" % (n, pr["branch"], pr["number"])
+        _finish_adjudication(store, n, verb, args)
+        store.snapshot()
+        return msg
+    if verb == "abandon-pr":
+        pr = (rec.get("pr") or {})
+        if pr.get("number"):
+            try:
+                eng.gh.close_pr(pr["number"], "Closing this automated sweep PR: CI could not be made "
+                                              "green within the campaign's remediation budget.")
+            except InfraError as exc:
+                log("abandon-pr: closing #%s failed: %s" % (pr["number"], exc))
+        if pr.get("branch"):
+            eng.gh.delete_remote_branch(pr["branch"])
+        store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note, status="deferred_human")
+        _finish_adjudication(store, n, verb, args)
+        store.snapshot()
+        return "#%s: PR #%s closed, branch %s deleted, issue deferred to bakert" % (
+            n, pr.get("number"), pr.get("branch"))
+    if verb.startswith("close-"):
+        if not args.comment_file:
+            raise SystemExit("close-* requires --comment-file")
+        comment = Path(args.comment_file).read_text(encoding="utf-8").strip()
+        reason = "completed" if verb == "close-completed" else "not planned"
+        eng.add_evidence(n, "verify", {"batch_id": "opus-adjudication", "verdict": "CONFIRMED",
+                                       "final_comment": comment, "recorded_at": iso(utcnow()),
+                                       "own_evidence": [{"type": "manual", "ref": "opus",
+                                                         "detail": "manager independently confirmed"}]})
+        store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note, status="closing")
+        if not store.config["mutations_enabled"]:
+            store.snapshot()
+            return "#%s queued for closure (mutations are disabled; enable to execute)" % n
+        store.journal("MUTATION_PLANNED", issue=n, kind="close", reason=reason)
+        eng.gh.close_issue(n, reason, render_closure_comment(comment))
+        if eng.gh.issue(n, "state").get("state") == "CLOSED":
+            store.journal("CLOSE_EXECUTED", issue=n, reason=reason.replace(" ", "_"),
+                          comment_posted=True, verified_by_batch="opus-adjudication")
+            msg = "#%s closed (%s)" % (n, reason)
+        else:
+            store.journal("MUTATION_FAILED", issue=n, kind="close", reason="state not CLOSED")
+            msg = "#%s close did not land" % n
+    elif status is None:
+        store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note)
+        msg = "#%s annotated (still %s)" % (n, rec["status"])
+    else:
+        store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note, status=status)
+        msg = "#%s -> %s" % (n, status)
+    _finish_adjudication(store, n, verb, args)
+    store.snapshot()
+    return msg
+
+
+def _finish_adjudication(store, n, verb, args):
+    f = ESCALATIONS / ("%s.json" % n)
+    if f.exists():
+        r = read_json(f) or {}
+        r["adjudication"] = {"verb": verb, "note": args.note, "at": iso(utcnow())}
+        write_json(REPORTS / ("adjudicated-%s.json" % n), r)
+        f.unlink()
+    if verb in ("defer-to-human", "abandon-pr"):
+        digest = REPORTS / "human_digest.md"
+        prev = digest.read_text(encoding="utf-8") if digest.exists() else "# Human digest\n"
+        write_atomic(digest, prev + "\n- #%s — %s (%s)\n" % (n, args.note or "deferred", iso(utcnow())))
+
+
+def cmd_rollback(store, args):
+    n = int(args.issue)
+    eng = Engine(store)
+    eng.gh.reopen_issue(n)
+    store.journal("ROLLBACK_RECORDED", issue=n, status="pending", action="reopened by manager",
+                  note=args.note)
+    store.snapshot()
+    return "#%s reopened and returned to pending" % n
+
+
+def cmd_tick(store, args):
+    eng = Engine(store, dry_run=args.dry_run)
+    m = eng.tick()
+    if args.dry_run:
+        return "\n".join(eng.plan) + ("\n\n(dry run: %d planned actions)" % len(eng.plan))
+    return json.dumps(m, sort_keys=True)
+
+
+def _alive(pid):
+    try:
+        os.kill(int(pid), 0)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def daemon_pid():
+    d = read_json(PIDFILE) or {}
+    return d["pid"] if d.get("pid") and _alive(d["pid"]) else None
+
+
+def cmd_daemon(_store, args):
+    """Tick forever, taking the state lock for one tick at a time.
+
+    Holding the lock across the whole run would block `adjudicate` and every other
+    verb, so each tick opens its own Store and releases it before sleeping.
+    """
+    stopping = {"now": False}
+
+    def onterm(signum, frame):
+        stopping["now"] = True
+        log("SIGTERM received; finishing current tick")
+
+    signal.signal(signal.SIGTERM, onterm)
+    signal.signal(signal.SIGINT, onterm)
+    existing = read_json(PIDFILE) or {}
+    if existing.get("pid") and _alive(existing["pid"]):
+        raise SystemExit("daemon already running as pid %s" % existing["pid"])
+    write_json(PIDFILE, {"pid": os.getpid(), "started_at": iso(utcnow())})
+    log("daemon start interval=%ss pid=%s" % (args.interval, os.getpid()), echo=True)
+    while not stopping["now"]:
+        try:
+            store = Store()
+        except SystemExit:
+            log("daemon: state lock busy, skipping this tick")
+            store = None
+        if store is not None:
+            try:
+                Engine(store).tick()
+            except Exception as exc:  # noqa: BLE001 - the daemon must not die on one bad tick
+                log("tick error: %r" % exc)
+            finally:
+                store.close()  # tick() already snapshots on its own schedule
+        for _ in range(int(args.interval)):
+            if stopping["now"]:
+                break
+            time.sleep(1)
+    try:
+        PIDFILE.unlink()
+    except OSError:
+        pass
+    try:
+        store = Store()
+    except SystemExit:
+        return "daemon stopped (lock busy; state left as-is)"
+    try:
+        store.snapshot()
+        Engine(store).maybe_mirror(force=True)
+    finally:
+        store.close()
+    return "daemon stopped cleanly"
+
+
+def cmd_mirror(store, args):
+    eng = Engine(store)
+    ok = eng.maybe_mirror(force=True)
+    if not ok:
+        raise SystemExit("mirror FAILED: %s" % (eng.mirror_error or "see dispatcher.log"))
+    return "mirror ok (%s)" % (store.config.get("mirror") or {}).get("kind")
+
+
+def cmd_report(store, args):
+    if args.what != "daily":
+        raise SystemExit("only 'daily' is implemented")
+    return "wrote %s" % Engine(store).daily_report()
+
+
+def cmd_recover(store, args):
+    return Engine(store, dry_run=args.dry_run).recover()
+
+
+def build_parser():
+    p = argparse.ArgumentParser(prog="dispatcher.py", description="backlog sweep dispatcher")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("init")
+    t = sub.add_parser("tick")
+    t.add_argument("--dry-run", action="store_true")
+    d = sub.add_parser("daemon")
+    d.add_argument("--interval", type=int, default=60)
+    sub.add_parser("status")
+    c = sub.add_parser("config")
+    c.add_argument("action", choices=["set"])
+    c.add_argument("pairs", nargs="+")
+    a = sub.add_parser("adjudicate")
+    a.add_argument("issue")
+    a.add_argument("verb")
+    a.add_argument("--comment-file")
+    a.add_argument("--note")
+    r = sub.add_parser("rollback")
+    r.add_argument("issue")
+    r.add_argument("--note")
+    rec = sub.add_parser("recover")
+    rec.add_argument("--dry-run", action="store_true")
+    sub.add_parser("mirror")
+    rep = sub.add_parser("report")
+    rep.add_argument("what", choices=["daily"])
+    return p
+
+
+HANDLERS = {
+    "init": cmd_init, "tick": cmd_tick, "daemon": cmd_daemon, "status": cmd_status,
+    "config": cmd_config, "adjudicate": cmd_adjudicate, "recover": cmd_recover,
+    "mirror": cmd_mirror, "report": cmd_report, "rollback": cmd_rollback,
+}
+
+
+READONLY_VERBS = {"status"}
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    if args.cmd == "daemon":
+        out = cmd_daemon(None, args)
+        if out:
+            print(out)
+        return 0
+    store = Store(readonly=args.cmd in READONLY_VERBS)
+    try:
+        out = HANDLERS[args.cmd](store, args)
+    finally:
+        store.close()
+    if out:
+        print(out)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backlog_sweep/dispatcher.py
+++ b/backlog_sweep/dispatcher.py
@@ -77,8 +77,9 @@ DEFAULT_CONFIG = {
     "auto_update_behind_branches": True,
     "max_fixup_attempts": 1,
     "reclaim_orphan_branches": True,
-    # Path to a file holding a PAT with Issues:RW + Pull requests:RW on this repo.
-    # Read into memory only, never logged, never mirrored, never passed in argv.
+    # Path to the operator PAT used by every `gh` subprocess. The pilot-verified
+    # credential was a classic PAT with repo scope. Read into memory only, never
+    # logged, never mirrored, never passed in argv.
     "github_token_file": "state/.gh_token",
     "worker_model": "sonnet-4-6",
     "worker_effort": "high",

--- a/backlog_sweep/dispatcher.py
+++ b/backlog_sweep/dispatcher.py
@@ -2529,6 +2529,9 @@ class Engine:
     # -- recover -----------------------------------------------------------
     def recover(self):
         out = ["# recover %s" % iso(utcnow())]
+        session_note = refresh_manager_session(self.store, dry_run=self.dry)
+        if session_note:
+            out.append(session_note)
         for rec in self._ready("closing"):
             n = rec["issue"]
             try:
@@ -2630,6 +2633,19 @@ class Engine:
 
 # ------------------------------------------------------------------------ verbs
 
+def refresh_manager_session(store, dry_run=False):
+    """Point escalation bundles at the manager running this recovery."""
+    session_id = os.environ.get("CONDUCTOR_SESSION_ID")
+    if not session_id or store.config.get("opus_session_id") == session_id:
+        return None
+    if dry_run:
+        return "WOULD update manager session to this recovery session"
+    store.config["opus_session_id"] = session_id
+    store.save_config()
+    store.journal("CONFIG_CHANGED", changes={"opus_session_id": "<this session>"})
+    return "manager session updated to this recovery session"
+
+
 def cmd_init(store, args):
     eng = Engine(store)
     cfg = store.config
@@ -2652,10 +2668,7 @@ def cmd_init(store, args):
         if rec["issue"] not in live and rec["status"] not in TERMINAL:
             store.journal("ISSUE_SKIPPED", issue=rec["issue"], reason="closed before triage")
             gone += 1
-    if store.config.get("opus_session_id") is None and os.environ.get("CONDUCTOR_SESSION_ID"):
-        store.config["opus_session_id"] = os.environ["CONDUCTOR_SESSION_ID"]
-        store.save_config()
-        store.journal("CONFIG_CHANGED", changes={"opus_session_id": "<this session>"})
+    refresh_manager_session(store)
     store.snapshot()
     return "queue: %d issues in universe (%d newly enqueued, %d newly closed -> skipped)" % (
         len(universe), added, gone)

--- a/backlog_sweep/dispatcher.py
+++ b/backlog_sweep/dispatcher.py
@@ -238,7 +238,7 @@ class Scrubber:
             text = str(text)
         for v in self.values:
             text = text.replace(v, "[REDACTED]")
-        return SECRET_RE.sub(lambda m: "%s%s[REDACTED]" % (m.group(1), m.group(2)), text)
+        return SECRET_RE.sub(lambda m: "{}{}[REDACTED]".format(m.group(1), m.group(2)), text)
 
 
 SCRUB = Scrubber()
@@ -306,7 +306,7 @@ def rotate_log():
 def log(msg, echo=False):
     STATE.mkdir(parents=True, exist_ok=True)
     rotate_log()
-    line = "%s %s\n" % (iso(utcnow()), SCRUB(msg))
+    line = "{} {}\n".format(iso(utcnow()), SCRUB(msg))
     with open(LOGFILE, "a", encoding="utf-8") as fh:
         fh.write(line)
     if echo:
@@ -397,7 +397,7 @@ def render_template(md_path, mapping):
         body = body.replace("{{%s}}" % k, "" if v is None else str(v))
     left = re.findall(r"\{\{([A-Z_]+)\}\}", body)
     if left:
-        raise RuntimeError("unsubstituted placeholders %s in %s" % (sorted(set(left)), md_path))
+        raise RuntimeError("unsubstituted placeholders {} in {}".format(sorted(set(left)), md_path))
     return body + "\n"
 
 
@@ -413,9 +413,9 @@ def render_claims(claims):
         else:
             proposed = "obsolete (close NOT_PLANNED)"
         refs = "; ".join(
-            "%s %s" % (e.get("type"), e.get("ref")) for e in (c.get("evidence") or [])
+            "{} {}".format(e.get("type"), e.get("ref")) for e in (c.get("evidence") or [])
         ) or "none cited"
-        lines.append('- issue: #%s — "%s"' % (c["issue"], (c.get("title") or "").replace('"', "'")))
+        lines.append('- issue: #{} — "{}"'.format(c["issue"], (c.get("title") or "").replace('"', "'")))
         lines.append("  proposed: %s" % proposed)
         lines.append("  cited evidence: %s" % refs)
         lines.append("  proposed closing comment: %s" % (c.get("proposed_comment") or "(none supplied)"))
@@ -487,10 +487,10 @@ class Runner:
             except OSError as exc:
                 rc, out, err = -1, "", "OSError: %s" % exc
             dur = time.time() - t0
-            log("exec rc=%s %.1fs %s :: %s" % (rc, dur, " ".join(argv[:6]), SCRUB((out + err)[:400])))
+            log("exec rc={} {:.1f}s {} :: {}".format(rc, dur, " ".join(argv[:6]), SCRUB((out + err)[:400])))
             if rc == 0:
                 return out if check else (out + err)
-            last = InfraError("%s exited %s" % (argv[0], rc), out + err)
+            last = InfraError("{} exited {}".format(argv[0], rc), out + err)
             if not check:
                 return out + err
             if i < attempts - 1:
@@ -551,12 +551,12 @@ class Conductor:
                 return json.loads(raw) if raw.strip() else {}
             except urllib.error.HTTPError as exc:
                 raw = exc.read().decode("utf-8", "replace")[:400]
-                log("api %s %s -> HTTP %s %s" % (method, path, exc.code, SCRUB(raw)))
+                log("api {} {} -> HTTP {} {}".format(method, path, exc.code, SCRUB(raw)))
                 if 400 <= exc.code < 500 and exc.code not in (403, 408, 425, 429):
-                    raise InfraError("HTTP %s on %s" % (exc.code, path), raw)
-                last = InfraError("HTTP %s on %s" % (exc.code, path), raw)
+                    raise InfraError("HTTP {} on {}".format(exc.code, path), raw)
+                last = InfraError("HTTP {} on {}".format(exc.code, path), raw)
             except Exception as exc:  # noqa: BLE001 - network layer
-                log("api %s %s -> %s" % (method, path, SCRUB(str(exc))))
+                log("api {} {} -> {}".format(method, path, SCRUB(str(exc))))
                 last = InfraError(str(exc))
             if i < len(sleeps) - 1:
                 self.sleep(sleeps[i])
@@ -745,7 +745,7 @@ class GitHub:
     def check_run_summary(self, sha, name, limit=1200):
         """Best-effort log tail for a failing check (no Actions log scope needed)."""
         try:
-            runs = self._json(["gh", "api", "repos/%s/commits/%s/check-runs" % (self.repo, sha),
+            runs = self._json(["gh", "api", "repos/{}/commits/{}/check-runs".format(self.repo, sha),
                                "--paginate"]).get("check_runs") or []
         except InfraError:
             return ""
@@ -775,7 +775,7 @@ class GitHub:
             out = self.run(["gh", "run", "view", m.group(1), "--repo", self.repo, "--log-failed"],
                            check=False)
             if out and "still in progress" not in out and "could not find" not in out.lower():
-                chunks.append("### %s\n%s" % (name, out[-limit:]))
+                chunks.append("### {}\n{}".format(name, out[-limit:]))
         return "\n\n".join(chunks)
 
     def delete_remote_branch(self, branch):
@@ -790,7 +790,7 @@ class GitHub:
         """
         try:
             rows = self._json([
-                "gh", "api", "repos/%s/issues/%s/timeline" % (self.repo, number),
+                "gh", "api", "repos/{}/issues/{}/timeline".format(self.repo, number),
                 "--paginate", "-q", "[.[] | select(.event==\"ready_for_review\")]",
             ])
         except InfraError:
@@ -815,7 +815,7 @@ class GitHub:
 
     def compare(self, branch):
         return self._json([
-            "gh", "api", "repos/%s/compare/master...%s" % (self.repo, branch),
+            "gh", "api", "repos/{}/compare/master...{}".format(self.repo, branch),
         ])
 
     def remote_branch_sha(self, branch):
@@ -896,7 +896,7 @@ class State:
         if blocked or status not in LEGAL.get(cur, set()):
             self.invariants.append({"ts": ts, "issue": rec["issue"], "from": cur, "to": status, "event": event})
             rec["status"] = "escalated"
-            rec["escalation"] = {"kind": "invariant", "detail": "illegal %s -> %s" % (cur, status)}
+            rec["escalation"] = {"kind": "invariant", "detail": "illegal {} -> {}".format(cur, status)}
             rec.setdefault("history", []).append({"ts": ts, "event": "INVARIANT_VIOLATION"})
             return False
         rec["status"] = status
@@ -1310,7 +1310,7 @@ class Engine:
 
     def escalate(self, issue, kind, question, summary="", refs=None):
         if self.dry:
-            self.say("WOULD escalate #%s (%s): %s" % (issue, kind, question))
+            self.say("WOULD escalate #{} ({}): {}".format(issue, kind, question))
             return
         rec = {
             "issue": int(issue), "created_at": iso(utcnow()), "kind": kind,
@@ -1334,7 +1334,7 @@ class Engine:
         minutes = min(self.cfg["pause_initial_minutes"] * (2 ** (level - 1)), self.cfg["pause_max_minutes"])
         until = iso(utcnow() + dt.timedelta(minutes=minutes))
         self.store.journal("PAUSE_ON", reason=reason, until=until, level=level, since=iso(utcnow()))
-        log("PAUSED (%s) until %s" % (reason, until))
+        log("PAUSED ({}) until {}".format(reason, until))
 
     def maybe_unpause(self):
         if not self.st.paused:
@@ -1388,7 +1388,7 @@ class Engine:
             try:
                 status = self.cond.session_status(sid)
             except InfraError as exc:
-                self.note_infra_failure("session_status %s: %s" % (sid, exc))
+                self.note_infra_failure("session_status {}: {}".format(sid, exc))
                 continue
             ws["last_transcript_at"] = tmap.get(sid) or ws.get("last_transcript_at")
             s = status.get("status")
@@ -1440,16 +1440,16 @@ class Engine:
         try:
             self.cond.archive_workspace(wid)
         except InfraError as exc:
-            log("archive call failed for %s: %s" % (wid, exc))
+            log("archive call failed for {}: {}".format(wid, exc))
         try:
             state = (self.cond.workspace_status(wid) or {}).get("status")
         except InfraError as exc:
-            log("archive verification failed for %s: %s" % (wid, exc))
+            log("archive verification failed for {}: {}".format(wid, exc))
             state = None
         if state in ("archived", "deleted"):
             self.store.journal("WORKSPACE_ARCHIVED", workspace_id=wid, verified_state=state)
             return True
-        log("archive did NOT take for %s (state=%s); will retry" % (wid, state))
+        log("archive did NOT take for {} (state={}); will retry".format(wid, state))
         if ws.get("state") != "harvested":
             self.store.journal("WORKSPACE_HARVESTED", workspace_id=wid, state=state)
         return False
@@ -1459,7 +1459,7 @@ class Engine:
         stuck = [w for w in self.st.workspaces.values() if w["state"] == "harvested"]
         for ws in stuck[:20]:
             if self.dry:
-                self.say("WOULD retry archive of %s (%s)" % (ws["workspace_id"], ws["batch_id"]))
+                self.say("WOULD retry archive of {} ({})".format(ws["workspace_id"], ws["batch_id"]))
                 continue
             self.archive(ws)
 
@@ -1488,7 +1488,7 @@ class Engine:
         try:
             msgs = self.cond.all_messages(sid)
         except InfraError as exc:
-            self.note_infra_failure("messages %s: %s" % (sid, exc))
+            self.note_infra_failure("messages {}: {}".format(sid, exc))
             return
         rl = self.cond.rate_limit_state(msgs)
         if rl and rl.get("status") not in (None, "allowed", "warning"):
@@ -1552,7 +1552,7 @@ class Engine:
             try:
                 getattr(self, "_record_" + ws["kind"])(ws, n, r)
             except Exception as exc:  # noqa: BLE001 defensive: one bad result must not kill the tick
-                log("record error #%s: %r" % (n, exc))
+                log("record error #{}: {!r}".format(n, exc))
                 self.add_evidence(n, ws["kind"], r)
                 self.escalate(n, "malformed", "Result could not be processed (%s)." % exc)
         missing = [n for n in ws["issues"] if n not in seen]
@@ -1689,7 +1689,7 @@ class Engine:
             gh_reason = "completed" if reason_key == "completed" else "not planned"
             comment = render_closure_comment(ver.get("final_comment"))
             if self.dry or not self.cfg["mutations_enabled"]:
-                self.say("WOULD close #%s (%s): %s" % (n, gh_reason, (ver.get("final_comment") or "")[:120]))
+                self.say("WOULD close #{} ({}): {}".format(n, gh_reason, (ver.get("final_comment") or "")[:120]))
                 continue
             ok, why = self.closure_guards(n, ver)
             if ok == "already-closed":
@@ -1778,7 +1778,7 @@ class Engine:
             fx = self.last_evidence(n, "fix") or {}
             branch = fx.get("branch")
             if self.dry or not self.cfg["mutations_enabled"]:
-                self.say("WOULD open PR for #%s from %s: %s" % (n, branch, fx.get("pr_title")))
+                self.say("WOULD open PR for #{} from {}: {}".format(n, branch, fx.get("pr_title")))
                 continue
             existing = []
             try:
@@ -1804,7 +1804,7 @@ class Engine:
                                           summary="adopted non-draft PR, no ready_for_review event")
                             self.st.counters["alert"] = "adopted non-draft PR #%s" % p["number"]
                 except InfraError as exc:
-                    log("draft check failed for #%s: %s" % (p["number"], exc))
+                    log("draft check failed for #{}: {}".format(p["number"], exc))
                 continue
             ok, why = self.pr_guards(n, fx)
             if not ok:
@@ -1813,7 +1813,7 @@ class Engine:
             body = fx.get("pr_body") or ""
             tests = (fx.get("tests") or {})
             if tests.get("result") != "passed" and "test" not in body.lower():
-                body += "\n\nTest status: %s — %s" % (tests.get("result"), tests.get("detail"))
+                body += "\n\nTest status: {} — {}".format(tests.get("result"), tests.get("detail"))
             body_file = OUTBOX / ("pr-%s.md" % n)
             write_atomic(body_file, body)
             self.store.journal("MUTATION_PLANNED", issue=n, kind="pr", branch=branch)
@@ -1836,7 +1836,7 @@ class Engine:
                 is_draft = self.gh.pr_is_draft(number)
             except InfraError as exc:
                 is_draft = False
-                log("draft verification failed for #%s: %s" % (number, exc))
+                log("draft verification failed for #{}: {}".format(number, exc))
             if not is_draft:
                 log("PR #%s IS NOT A DRAFT - closing immediately" % number)
                 try:
@@ -1844,7 +1844,7 @@ class Engine:
                                              "as a draft, and non-draft PRs here are auto-merged. "
                                              "The branch is untouched; it will be reopened as a draft.")
                 except InfraError as exc:
-                    log("emergency close of #%s FAILED: %s" % (number, exc))
+                    log("emergency close of #{} FAILED: {}".format(number, exc))
                 self.cfg["prs_enabled"] = False
                 self.store.config["prs_enabled"] = False
                 self.store.save_config()
@@ -1897,7 +1897,7 @@ class Engine:
         if not remote:
             return False, "branch %s not on origin" % branch
         if sha and not (remote.startswith(sha) or sha.startswith(remote[:7])):
-            return False, "branch head %s != reported %s" % (remote[:10], sha[:10])
+            return False, "branch head {} != reported {}".format(remote[:10], sha[:10])
         try:
             cmp_ = self.gh.compare(branch)
         except InfraError as exc:
@@ -1945,7 +1945,7 @@ class Engine:
         try:
             info = self.gh.pr_state(number)
         except InfraError as exc:
-            log("PR state check failed for #%s: %s" % (number, exc))
+            log("PR state check failed for #{}: {}".format(number, exc))
             return False
         state = (info.get("state") or "").upper()
         if state == "MERGED":
@@ -2033,14 +2033,14 @@ class Engine:
             if settled and checked and (utcnow() - checked) < recheck and not master_moved:
                 continue
             if self.dry:
-                self.say("WOULD poll CI for PR #%s (issue #%s)" % (number, rec["issue"]))
+                self.say("WOULD poll CI for PR #{} (issue #{})".format(number, rec["issue"]))
                 continue
             if self.pr_settled_by_human(rec, pr, number):
                 continue
             try:
                 rows = self.gh.pr_checks(number)
             except InfraError as exc:
-                log("CI poll failed for #%s: %s" % (number, exc))
+                log("CI poll failed for #{}: {}".format(number, exc))
                 continue
             verdict = self.summarize_checks(rows, required)
             failed = sorted(n for n, v in verdict.items() if v == "fail")
@@ -2049,13 +2049,13 @@ class Engine:
                 for name in failed[:2]:
                     tail = self.gh.check_run_summary(pr.get("head_sha") or "", name)
                     if tail:
-                        tails.append("### %s\n%s" % (name, tail))
+                        tails.append("### {}\n{}".format(name, tail))
                 self.store.journal("PR_CI_FAILED", issue=rec["issue"], pr=number, failed=failed)
                 self.escalate(
                     rec["issue"], "pr-ci-failed",
                     "PR #%s is red on %s — dispatch one follow-up fixer to the same branch "
                     "(queue-fixup), or abandon the PR (abandon-pr)?" % (number, ", ".join(failed)),
-                    summary=("failing checks: %s\n%s" % (", ".join(failed), "\n".join(tails)))[:4000],
+                    summary=("failing checks: {}\n{}".format(", ".join(failed), "\n".join(tails)))[:4000],
                     refs=["evidence/%s.json#fix[-1]" % rec["issue"]])
                 continue
             if all(v == "pass" for v in verdict.values()):
@@ -2087,7 +2087,7 @@ class Engine:
         lines = ["# Escalation bundle %s" % ts, "", self.vitals_line(), ""]
         for r in unbundled[:40]:
             lines += [
-                "## #%s — %s" % (r["issue"], r["kind"]),
+                "## #{} — {}".format(r["issue"], r["kind"]),
                 "- question: %s" % r["question"],
                 "- summary: %s" % (r.get("summary") or "")[:400].replace("\n", " "),
                 "- evidence: %s" % ", ".join(r.get("evidence_refs") or []),
@@ -2102,7 +2102,7 @@ class Engine:
             self.st.counters["alert"] = "bundle queued, opus_session_id unset"
             return
         if self.dry:
-            self.say("WOULD send bundle %s to session %s" % (path.name, sid))
+            self.say("WOULD send bundle {} to session {}".format(path.name, sid))
             return
         try:
             self.cond.send_message(sid, "Escalation bundle ready: read `%s` and adjudicate." % path,
@@ -2215,14 +2215,14 @@ class Engine:
                     if self.gh.prs_for_branch(branch):
                         return False, "branch %s already has a PR" % branch
                 except InfraError as exc:
-                    return False, "could not check PRs for %s: %s" % (branch, exc)
+                    return False, "could not check PRs for {}: {}".format(branch, exc)
                 self.gh.delete_remote_branch(branch)
                 if self.gh.remote_branch_sha(branch):
                     return False, "could not delete orphan branch %s" % branch
                 self.store.journal("ROLLBACK_RECORDED", issue=n, status=None,
                                    action="deleted orphan branch %s (pushed by a fixer whose "
                                           "report was never harvested; no PR existed)" % branch)
-                log("reclaimed orphan branch %s for #%s" % (branch, n))
+                log("reclaimed orphan branch {} for #{}".format(branch, n))
         return True, ""
 
     def batch_id(self, kind, issues):
@@ -2267,7 +2267,7 @@ class Engine:
         return render_template(BASE / "FIXER_PROMPT.md", {
             "ISSUE": n, "TITLE": rec["title"], "BATCH_ID": batch_id,
             "FIX_SKETCH": tri.get("fix_sketch") or "(none supplied — derive it yourself)",
-            "BRANCH": "sweep/%s-%s" % (n, slugify(rec["title"])),
+            "BRANCH": "sweep/{}-{}".format(n, slugify(rec["title"])),
         })
 
     def spawn(self, job):
@@ -2329,7 +2329,7 @@ class Engine:
                 continue
             if w["id"] in mine or w["id"] == manager:
                 continue
-            found.append("%s (%s)" % (w.get("name") or "?", w["id"][:8]))
+            found.append("{} ({})".format(w.get("name") or "?", w["id"][:8]))
         if found != self.unregistered and found:
             log("UNREGISTERED workspaces in project: %s" % ", ".join(found))
         self.unregistered = found
@@ -2383,7 +2383,7 @@ class Engine:
         if not force and last and (utcnow() - last) < dt.timedelta(minutes=conf.get("interval_minutes", 15)):
             return
         if self.dry:
-            self.say("WOULD mirror state to %s:%s" % (conf.get("kind"), conf.get("ref")))
+            self.say("WOULD mirror state to {}:{}".format(conf.get("kind"), conf.get("ref")))
             return
         try:
             if conf["kind"] == "branch":
@@ -2451,7 +2451,7 @@ class Engine:
         if not remote or remote[0] != local:
             raise InfraError("mirror push did not land: origin/%s is %s, local is %s"
                              % (ref, (remote[0][:10] if remote else "absent"), local[:10]), push)
-        log("mirror: pushed %s to origin/%s" % (local[:10], ref))
+        log("mirror: pushed {} to origin/{}".format(local[:10], ref))
         return True
 
     def mirror_gist(self, gist_id):
@@ -2489,7 +2489,7 @@ class Engine:
                   "", "## Open escalations", ""]
         for f in sorted(ESCALATIONS.glob("*.json")):
             r = read_json(f) or {}
-            lines.append("- #%s (%s): %s" % (r.get("issue"), r.get("kind"), r.get("question")))
+            lines.append("- #{} ({}): {}".format(r.get("issue"), r.get("kind"), r.get("question")))
         lines += ["", "## Totals", "",
                   "- workspaces created: %d" % self.st.counters.get("workspaces_created", 0),
                   "- nudges: %d" % self.st.counters.get("nudges", 0),
@@ -2561,7 +2561,7 @@ class Engine:
                 if live not in ("archived", "deleted"):
                     stale.append((ws, live))
         for ws, live in stale:
-            out.append("registry said archived but %s is %s (%s)" % (ws["workspace_id"], live, ws["batch_id"]))
+            out.append("registry said archived but {} is {} ({})".format(ws["workspace_id"], live, ws["batch_id"]))
             if not self.dry:
                 self.store.journal("WORKSPACE_HARVESTED", workspace_id=ws["workspace_id"], state=live)
                 if self.archive(ws):
@@ -2579,14 +2579,14 @@ class Engine:
                 continue
             m = re.match(r"^sweep-([tvf])-(\d+)-(\d+)$", w.get("name") or "")
             if not m:
-                out.append("ignoring non-sweep workspace %s (%s)" % (w["id"], w.get("name")))
+                out.append("ignoring non-sweep workspace {} ({})".format(w["id"], w.get("name")))
                 continue
             kind = {"t": "triage", "v": "verify", "f": "fix"}[m.group(1)]
             bid = w["name"][len("sweep-"):]
             issues = [int(n) for n, r in self.st.issues.items()
                       if (r.get("lease") or {}).get("batch_id") == bid]
             if not issues:
-                out.append("orphan workspace %s (%s) has no live lease — archiving" % (w["id"], bid))
+                out.append("orphan workspace {} ({}) has no live lease — archiving".format(w["id"], bid))
                 if not self.dry:
                     try:
                         self.cond.archive_workspace(w["id"])
@@ -2598,7 +2598,7 @@ class Engine:
                 self.store.journal("WORKSPACE_CREATED", workspace_id=w["id"],
                                    session_id=sids[0] if sids else None, kind=kind,
                                    batch_id=bid, issues=issues, adopted=True)
-            out.append("adopted orphan workspace %s (%s) for %s" % (w["id"], bid, issues))
+            out.append("adopted orphan workspace {} ({}) for {}".format(w["id"], bid, issues))
         for ws in list(self.active_workspaces()):
             try:
                 st = self.cond.session_status(ws["session_id"]).get("status")
@@ -2666,13 +2666,13 @@ def cmd_status(store, args):
     eng = Engine(store)
     c = eng.counts()
     lines = [
-        "phase=%s pilot_limit=%s concurrency=%s mutations=%s paused=%s" % (
+        "phase={} pilot_limit={} concurrency={} mutations={} paused={}".format(
             cfg["phase"], cfg["pilot_limit"], cfg["concurrency_cap"], cfg["mutations_enabled"], st.paused),
         "issues=%d  %s" % (len(st.issues), "  ".join("%s=%d" % kv for kv in sorted(c.items()))),
         "workspaces active=%d created=%d nudges=%d infra_failures=%d" % (
             len(eng.active_workspaces()), st.counters.get("workspaces_created", 0),
             st.counters.get("nudges", 0), st.counters.get("infra_failures", 0)),
-        "open sweep PRs cap=%s  backpressure=%s" % (cfg.get("max_open_prs"), st.pr_backpressure),
+        "open sweep PRs cap={}  backpressure={}".format(cfg.get("max_open_prs"), st.pr_backpressure),
         "today closures=%d/%d prs=%d/%d" % (
             st.daily.get("closures", 0), cfg["daily_close_cap"],
             st.daily.get("prs", 0), cfg["daily_pr_cap"]),
@@ -2735,7 +2735,7 @@ def cmd_adjudicate(store, args):
         raise SystemExit("#%s is not in the queue" % n)
     verb = args.verb
     if verb not in ADJUDICATIONS:  # noqa: SIM102 - explicit for the error message
-        raise SystemExit("unknown verb %r (choose from %s)" % (verb, ", ".join(sorted(ADJUDICATIONS))))
+        raise SystemExit("unknown verb {!r} (choose from {})".format(verb, ", ".join(sorted(ADJUDICATIONS))))
     eng = Engine(store)
     status = ADJUDICATIONS[verb]
     if verb == "queue-fixup":
@@ -2755,12 +2755,12 @@ def cmd_adjudicate(store, args):
             try:
                 detail = eng.gh.failed_check_log(pr["number"], failed)
             except InfraError as exc:
-                log("log fetch for #%s failed: %s" % (pr["number"], exc))
+                log("log fetch for #{} failed: {}".format(pr["number"], exc))
         if not detail:
             detail = (esc.get("summary") or "")[:4000]
         store.journal("FIXUP_DISPATCHED", issue=n, branch=pr["branch"], pr=pr["number"],
                       failed=failed, attempt=prior + 1, log_tail=detail[:4000], note=args.note)
-        msg = "#%s queued for one CI-remediation fixer on %s (PR #%s)" % (n, pr["branch"], pr["number"])
+        msg = "#{} queued for one CI-remediation fixer on {} (PR #{})".format(n, pr["branch"], pr["number"])
         _finish_adjudication(store, n, verb, args)
         store.snapshot()
         return msg
@@ -2771,13 +2771,13 @@ def cmd_adjudicate(store, args):
                 eng.gh.close_pr(pr["number"], "Closing this automated sweep PR: CI could not be made "
                                               "green within the campaign's remediation budget.")
             except InfraError as exc:
-                log("abandon-pr: closing #%s failed: %s" % (pr["number"], exc))
+                log("abandon-pr: closing #{} failed: {}".format(pr["number"], exc))
         if pr.get("branch"):
             eng.gh.delete_remote_branch(pr["branch"])
         store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note, status="deferred_human")
         _finish_adjudication(store, n, verb, args)
         store.snapshot()
-        return "#%s: PR #%s closed, branch %s deleted, issue deferred to bakert" % (
+        return "#{}: PR #{} closed, branch {} deleted, issue deferred to bakert".format(
             n, pr.get("number"), pr.get("branch"))
     if verb.startswith("close-"):
         if not args.comment_file:
@@ -2797,16 +2797,16 @@ def cmd_adjudicate(store, args):
         if eng.gh.issue(n, "state").get("state") == "CLOSED":
             store.journal("CLOSE_EXECUTED", issue=n, reason=reason.replace(" ", "_"),
                           comment_posted=True, verified_by_batch="opus-adjudication")
-            msg = "#%s closed (%s)" % (n, reason)
+            msg = "#{} closed ({})".format(n, reason)
         else:
             store.journal("MUTATION_FAILED", issue=n, kind="close", reason="state not CLOSED")
             msg = "#%s close did not land" % n
     elif status is None:
         store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note)
-        msg = "#%s annotated (still %s)" % (n, rec["status"])
+        msg = "#{} annotated (still {})".format(n, rec["status"])
     else:
         store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note, status=status)
-        msg = "#%s -> %s" % (n, status)
+        msg = "#{} -> {}".format(n, status)
     _finish_adjudication(store, n, verb, args)
     store.snapshot()
     return msg
@@ -2822,7 +2822,7 @@ def _finish_adjudication(store, n, verb, args):
     if verb in ("defer-to-human", "abandon-pr"):
         digest = REPORTS / "human_digest.md"
         prev = digest.read_text(encoding="utf-8") if digest.exists() else "# Human digest\n"
-        write_atomic(digest, prev + "\n- #%s — %s (%s)\n" % (n, args.note or "deferred", iso(utcnow())))
+        write_atomic(digest, prev + "\n- #{} — {} ({})\n".format(n, args.note or "deferred", iso(utcnow())))
 
 
 def cmd_rollback(store, args):
@@ -2874,7 +2874,7 @@ def cmd_daemon(_store, args):
     if existing.get("pid") and _alive(existing["pid"]):
         raise SystemExit("daemon already running as pid %s" % existing["pid"])
     write_json(PIDFILE, {"pid": os.getpid(), "started_at": iso(utcnow())})
-    log("daemon start interval=%ss pid=%s" % (args.interval, os.getpid()), echo=True)
+    log("daemon start interval={}s pid={}".format(args.interval, os.getpid()), echo=True)
     while not stopping["now"]:
         try:
             store = Store()

--- a/backlog_sweep/dispatcher.py
+++ b/backlog_sweep/dispatcher.py
@@ -238,7 +238,7 @@ class Scrubber:
             text = str(text)
         for v in self.values:
             text = text.replace(v, "[REDACTED]")
-        return SECRET_RE.sub(lambda m: "{}{}[REDACTED]".format(m.group(1), m.group(2)), text)
+        return SECRET_RE.sub(lambda m: f"{m.group(1)}{m.group(2)}[REDACTED]", text)
 
 
 SCRUB = Scrubber()
@@ -306,7 +306,7 @@ def rotate_log():
 def log(msg, echo=False):
     STATE.mkdir(parents=True, exist_ok=True)
     rotate_log()
-    line = "{} {}\n".format(iso(utcnow()), SCRUB(msg))
+    line = f"{iso(utcnow())} {SCRUB(msg)}\n"
     with open(LOGFILE, "a", encoding="utf-8") as fh:
         fh.write(line)
     if echo:
@@ -397,7 +397,7 @@ def render_template(md_path, mapping):
         body = body.replace("{{%s}}" % k, "" if v is None else str(v))
     left = re.findall(r"\{\{([A-Z_]+)\}\}", body)
     if left:
-        raise RuntimeError("unsubstituted placeholders {} in {}".format(sorted(set(left)), md_path))
+        raise RuntimeError(f"unsubstituted placeholders {sorted(set(left))} in {md_path}")
     return body + "\n"
 
 
@@ -490,7 +490,7 @@ class Runner:
             log("exec rc={} {:.1f}s {} :: {}".format(rc, dur, " ".join(argv[:6]), SCRUB((out + err)[:400])))
             if rc == 0:
                 return out if check else (out + err)
-            last = InfraError("{} exited {}".format(argv[0], rc), out + err)
+            last = InfraError(f"{argv[0]} exited {rc}", out + err)
             if not check:
                 return out + err
             if i < attempts - 1:
@@ -551,12 +551,12 @@ class Conductor:
                 return json.loads(raw) if raw.strip() else {}
             except urllib.error.HTTPError as exc:
                 raw = exc.read().decode("utf-8", "replace")[:400]
-                log("api {} {} -> HTTP {} {}".format(method, path, exc.code, SCRUB(raw)))
+                log(f"api {method} {path} -> HTTP {exc.code} {SCRUB(raw)}")
                 if 400 <= exc.code < 500 and exc.code not in (403, 408, 425, 429):
-                    raise InfraError("HTTP {} on {}".format(exc.code, path), raw)
-                last = InfraError("HTTP {} on {}".format(exc.code, path), raw)
+                    raise InfraError(f"HTTP {exc.code} on {path}", raw)
+                last = InfraError(f"HTTP {exc.code} on {path}", raw)
             except Exception as exc:  # noqa: BLE001 - network layer
-                log("api {} {} -> {}".format(method, path, SCRUB(str(exc))))
+                log(f"api {method} {path} -> {SCRUB(str(exc))}")
                 last = InfraError(str(exc))
             if i < len(sleeps) - 1:
                 self.sleep(sleeps[i])
@@ -745,7 +745,7 @@ class GitHub:
     def check_run_summary(self, sha, name, limit=1200):
         """Best-effort log tail for a failing check (no Actions log scope needed)."""
         try:
-            runs = self._json(["gh", "api", "repos/{}/commits/{}/check-runs".format(self.repo, sha),
+            runs = self._json(["gh", "api", f"repos/{self.repo}/commits/{sha}/check-runs",
                                "--paginate"]).get("check_runs") or []
         except InfraError:
             return ""
@@ -775,7 +775,7 @@ class GitHub:
             out = self.run(["gh", "run", "view", m.group(1), "--repo", self.repo, "--log-failed"],
                            check=False)
             if out and "still in progress" not in out and "could not find" not in out.lower():
-                chunks.append("### {}\n{}".format(name, out[-limit:]))
+                chunks.append(f"### {name}\n{out[-limit:]}")
         return "\n\n".join(chunks)
 
     def delete_remote_branch(self, branch):
@@ -790,7 +790,7 @@ class GitHub:
         """
         try:
             rows = self._json([
-                "gh", "api", "repos/{}/issues/{}/timeline".format(self.repo, number),
+                "gh", "api", f"repos/{self.repo}/issues/{number}/timeline",
                 "--paginate", "-q", "[.[] | select(.event==\"ready_for_review\")]",
             ])
         except InfraError:
@@ -815,7 +815,7 @@ class GitHub:
 
     def compare(self, branch):
         return self._json([
-            "gh", "api", "repos/{}/compare/master...{}".format(self.repo, branch),
+            "gh", "api", f"repos/{self.repo}/compare/master...{branch}",
         ])
 
     def remote_branch_sha(self, branch):
@@ -896,7 +896,7 @@ class State:
         if blocked or status not in LEGAL.get(cur, set()):
             self.invariants.append({"ts": ts, "issue": rec["issue"], "from": cur, "to": status, "event": event})
             rec["status"] = "escalated"
-            rec["escalation"] = {"kind": "invariant", "detail": "illegal {} -> {}".format(cur, status)}
+            rec["escalation"] = {"kind": "invariant", "detail": f"illegal {cur} -> {status}"}
             rec.setdefault("history", []).append({"ts": ts, "event": "INVARIANT_VIOLATION"})
             return False
         rec["status"] = status
@@ -1310,7 +1310,7 @@ class Engine:
 
     def escalate(self, issue, kind, question, summary="", refs=None):
         if self.dry:
-            self.say("WOULD escalate #{} ({}): {}".format(issue, kind, question))
+            self.say(f"WOULD escalate #{issue} ({kind}): {question}")
             return
         rec = {
             "issue": int(issue), "created_at": iso(utcnow()), "kind": kind,
@@ -1334,7 +1334,7 @@ class Engine:
         minutes = min(self.cfg["pause_initial_minutes"] * (2 ** (level - 1)), self.cfg["pause_max_minutes"])
         until = iso(utcnow() + dt.timedelta(minutes=minutes))
         self.store.journal("PAUSE_ON", reason=reason, until=until, level=level, since=iso(utcnow()))
-        log("PAUSED ({}) until {}".format(reason, until))
+        log(f"PAUSED ({reason}) until {until}")
 
     def maybe_unpause(self):
         if not self.st.paused:
@@ -1388,7 +1388,7 @@ class Engine:
             try:
                 status = self.cond.session_status(sid)
             except InfraError as exc:
-                self.note_infra_failure("session_status {}: {}".format(sid, exc))
+                self.note_infra_failure(f"session_status {sid}: {exc}")
                 continue
             ws["last_transcript_at"] = tmap.get(sid) or ws.get("last_transcript_at")
             s = status.get("status")
@@ -1440,16 +1440,16 @@ class Engine:
         try:
             self.cond.archive_workspace(wid)
         except InfraError as exc:
-            log("archive call failed for {}: {}".format(wid, exc))
+            log(f"archive call failed for {wid}: {exc}")
         try:
             state = (self.cond.workspace_status(wid) or {}).get("status")
         except InfraError as exc:
-            log("archive verification failed for {}: {}".format(wid, exc))
+            log(f"archive verification failed for {wid}: {exc}")
             state = None
         if state in ("archived", "deleted"):
             self.store.journal("WORKSPACE_ARCHIVED", workspace_id=wid, verified_state=state)
             return True
-        log("archive did NOT take for {} (state={}); will retry".format(wid, state))
+        log(f"archive did NOT take for {wid} (state={state}); will retry")
         if ws.get("state") != "harvested":
             self.store.journal("WORKSPACE_HARVESTED", workspace_id=wid, state=state)
         return False
@@ -1488,7 +1488,7 @@ class Engine:
         try:
             msgs = self.cond.all_messages(sid)
         except InfraError as exc:
-            self.note_infra_failure("messages {}: {}".format(sid, exc))
+            self.note_infra_failure(f"messages {sid}: {exc}")
             return
         rl = self.cond.rate_limit_state(msgs)
         if rl and rl.get("status") not in (None, "allowed", "warning"):
@@ -1552,7 +1552,7 @@ class Engine:
             try:
                 getattr(self, "_record_" + ws["kind"])(ws, n, r)
             except Exception as exc:  # noqa: BLE001 defensive: one bad result must not kill the tick
-                log("record error #{}: {!r}".format(n, exc))
+                log(f"record error #{n}: {exc!r}")
                 self.add_evidence(n, ws["kind"], r)
                 self.escalate(n, "malformed", "Result could not be processed (%s)." % exc)
         missing = [n for n in ws["issues"] if n not in seen]
@@ -1836,7 +1836,7 @@ class Engine:
                 is_draft = self.gh.pr_is_draft(number)
             except InfraError as exc:
                 is_draft = False
-                log("draft verification failed for #{}: {}".format(number, exc))
+                log(f"draft verification failed for #{number}: {exc}")
             if not is_draft:
                 log("PR #%s IS NOT A DRAFT - closing immediately" % number)
                 try:
@@ -1844,7 +1844,7 @@ class Engine:
                                              "as a draft, and non-draft PRs here are auto-merged. "
                                              "The branch is untouched; it will be reopened as a draft.")
                 except InfraError as exc:
-                    log("emergency close of #{} FAILED: {}".format(number, exc))
+                    log(f"emergency close of #{number} FAILED: {exc}")
                 self.cfg["prs_enabled"] = False
                 self.store.config["prs_enabled"] = False
                 self.store.save_config()
@@ -1897,7 +1897,7 @@ class Engine:
         if not remote:
             return False, "branch %s not on origin" % branch
         if sha and not (remote.startswith(sha) or sha.startswith(remote[:7])):
-            return False, "branch head {} != reported {}".format(remote[:10], sha[:10])
+            return False, f"branch head {remote[:10]} != reported {sha[:10]}"
         try:
             cmp_ = self.gh.compare(branch)
         except InfraError as exc:
@@ -1945,7 +1945,7 @@ class Engine:
         try:
             info = self.gh.pr_state(number)
         except InfraError as exc:
-            log("PR state check failed for #{}: {}".format(number, exc))
+            log(f"PR state check failed for #{number}: {exc}")
             return False
         state = (info.get("state") or "").upper()
         if state == "MERGED":
@@ -2040,7 +2040,7 @@ class Engine:
             try:
                 rows = self.gh.pr_checks(number)
             except InfraError as exc:
-                log("CI poll failed for #{}: {}".format(number, exc))
+                log(f"CI poll failed for #{number}: {exc}")
                 continue
             verdict = self.summarize_checks(rows, required)
             failed = sorted(n for n, v in verdict.items() if v == "fail")
@@ -2049,7 +2049,7 @@ class Engine:
                 for name in failed[:2]:
                     tail = self.gh.check_run_summary(pr.get("head_sha") or "", name)
                     if tail:
-                        tails.append("### {}\n{}".format(name, tail))
+                        tails.append(f"### {name}\n{tail}")
                 self.store.journal("PR_CI_FAILED", issue=rec["issue"], pr=number, failed=failed)
                 self.escalate(
                     rec["issue"], "pr-ci-failed",
@@ -2102,7 +2102,7 @@ class Engine:
             self.st.counters["alert"] = "bundle queued, opus_session_id unset"
             return
         if self.dry:
-            self.say("WOULD send bundle {} to session {}".format(path.name, sid))
+            self.say(f"WOULD send bundle {path.name} to session {sid}")
             return
         try:
             self.cond.send_message(sid, "Escalation bundle ready: read `%s` and adjudicate." % path,
@@ -2215,14 +2215,14 @@ class Engine:
                     if self.gh.prs_for_branch(branch):
                         return False, "branch %s already has a PR" % branch
                 except InfraError as exc:
-                    return False, "could not check PRs for {}: {}".format(branch, exc)
+                    return False, f"could not check PRs for {branch}: {exc}"
                 self.gh.delete_remote_branch(branch)
                 if self.gh.remote_branch_sha(branch):
                     return False, "could not delete orphan branch %s" % branch
                 self.store.journal("ROLLBACK_RECORDED", issue=n, status=None,
                                    action="deleted orphan branch %s (pushed by a fixer whose "
                                           "report was never harvested; no PR existed)" % branch)
-                log("reclaimed orphan branch {} for #{}".format(branch, n))
+                log(f"reclaimed orphan branch {branch} for #{n}")
         return True, ""
 
     def batch_id(self, kind, issues):
@@ -2451,7 +2451,7 @@ class Engine:
         if not remote or remote[0] != local:
             raise InfraError("mirror push did not land: origin/%s is %s, local is %s"
                              % (ref, (remote[0][:10] if remote else "absent"), local[:10]), push)
-        log("mirror: pushed {} to origin/{}".format(local[:10], ref))
+        log(f"mirror: pushed {local[:10]} to origin/{ref}")
         return True
 
     def mirror_gist(self, gist_id):
@@ -2797,7 +2797,7 @@ def cmd_adjudicate(store, args):
         if eng.gh.issue(n, "state").get("state") == "CLOSED":
             store.journal("CLOSE_EXECUTED", issue=n, reason=reason.replace(" ", "_"),
                           comment_posted=True, verified_by_batch="opus-adjudication")
-            msg = "#{} closed ({})".format(n, reason)
+            msg = f"#{n} closed ({reason})"
         else:
             store.journal("MUTATION_FAILED", issue=n, kind="close", reason="state not CLOSED")
             msg = "#%s close did not land" % n
@@ -2806,7 +2806,7 @@ def cmd_adjudicate(store, args):
         msg = "#{} annotated (still {})".format(n, rec["status"])
     else:
         store.journal("ADJUDICATED", issue=n, verb=verb, note=args.note, status=status)
-        msg = "#{} -> {}".format(n, status)
+        msg = f"#{n} -> {status}"
     _finish_adjudication(store, n, verb, args)
     store.snapshot()
     return msg
@@ -2874,7 +2874,7 @@ def cmd_daemon(_store, args):
     if existing.get("pid") and _alive(existing["pid"]):
         raise SystemExit("daemon already running as pid %s" % existing["pid"])
     write_json(PIDFILE, {"pid": os.getpid(), "started_at": iso(utcnow())})
-    log("daemon start interval={}s pid={}".format(args.interval, os.getpid()), echo=True)
+    log(f"daemon start interval={args.interval}s pid={os.getpid()}", echo=True)
     while not stopping["now"]:
         try:
             store = Store()

--- a/backlog_sweep/docs/DISPATCHER_SPEC.md
+++ b/backlog_sweep/docs/DISPATCHER_SPEC.md
@@ -1,0 +1,382 @@
+# DISPATCHER_SPEC — Deterministic, Restartable, Zero-Token Coordinator
+
+> **Historical note (2026-09):** written for the original `.context/backlog-sweep/` layout (code in `bin/`, prompts at the root). The committed layout is `backlog_sweep/` with prompts beside `dispatcher.py` and state in `backlog_sweep/state/` (gitignored). See `../README.md` and `../RUNBOOK.md`.
+
+
+A single-file Python 3 program, `.context/backlog-sweep/bin/dispatcher.py`, stdlib
+only. It consumes **no model tokens**: it shells out to the `conductor` CLI (already
+authenticated via `CONDUCTOR_API_*` env vars — never read or printed by the
+dispatcher) and to `gh`/`git`. The only model-token-consuming things it triggers are
+(a) worker sessions it creates, (b) corrective nudges to those sessions, and (c)
+compact bundles sent to the Opus manager session — all by design.
+
+## 1. CLI verbs
+
+```
+dispatcher.py init                      # enumerate queue from GitHub, write CAMPAIGN_INIT
+dispatcher.py tick [--dry-run]          # one pass of the loop in §3
+dispatcher.py daemon [--interval 60]    # tick forever; SIGTERM-safe
+dispatcher.py status                    # human-readable one-screen summary from snapshot
+dispatcher.py config set K=V …          # journal CONFIG_CHANGED, update config.json
+dispatcher.py adjudicate <issue> <verb> [--comment-file F] [--note …]
+                                        # verbs: close-completed, close-not-planned,
+                                        #        queue-fix, report-only, retry-triage,
+                                        #        retry-verify, defer-to-human, mark-failed
+dispatcher.py recover                   # post-crash/post-sandbox-death reconciliation (§9)
+dispatcher.py mirror                    # force a mirror push
+dispatcher.py report daily              # write reports/daily-<date>.md from snapshot
+```
+
+Every verb: acquire `flock` on `state/.lock` (non-blocking; exit 75 if held), load
+snapshot, replay journal tail, act, append events, release. `tick` and `daemon` are
+the same code path; `daemon` also writes `metrics.json` heartbeat each pass and
+traps SIGTERM to finish the current step, snapshot, mirror, and exit 0.
+
+Determinism: no randomness; all ordering by issue number descending (the sweep
+direction) and by `seq`. Timestamps come from the wall clock but decisions depend
+only on comparisons against configured durations, so replays reconverge.
+
+## 2. init
+
+1. `gh issue list --state open --limit 1000 --json number,title,labels,updatedAt
+   --search "sort:created-desc"` filtered to `number <= config.frontier_max`
+   (12786) and `>= frontier_min` (790).
+2. Journal `CAMPAIGN_INIT` + one `ISSUE_ENQUEUED` per issue, status `pending`,
+   ordered descending. `pilot_limit` N>0 means only the N highest numbers are
+   eligible for leasing; the rest stay `pending` but unleasable until Phase 2.
+3. Re-running `init` is idempotent: already-known issues are untouched; newly-closed
+   ones journal to `skipped`.
+
+## 3. tick loop (each pass, in this order)
+
+1. **Harvest** (§5): poll every workspace in state `creating|running|nudged`;
+   parse finished sessions; record results; archive harvested workspaces.
+2. **Expire leases** (§6.4).
+3. **Execute mutations** (§8): closures for `verified`, PRs for `fix_pushed` —
+   respecting `mutations_enabled`, daily caps, and idempotency checks.
+4. **Watch CI** (§8b): poll the Mergify-required checks on every `pr_open` PR.
+5. **Bundle escalations** to Opus (§10).
+6. **Replenish pool** (§6): while `active_workspaces < concurrency_cap` and not
+   paused and `total_workspaces_created < max_total_workspaces`, spawn the
+   highest-priority pending work: verify batches, then fix tasks, then triage
+   batches (descending issue number within each).
+7. **Snapshot** if ≥50 new journal events or ≥5 min since last; **mirror** if
+   interval elapsed; rewrite `metrics.json`; emit `report daily` at first tick past
+   midnight UTC.
+
+`--dry-run`: steps 3 and 6 print their exact planned commands to stdout instead of
+executing; nothing is journaled except `SNAPSHOT_WRITTEN`.
+
+## 4. Spawning workspaces
+
+Prompt files are rendered from the templates in `WORKER_PROMPT.md` /
+`VERIFIER_PROMPT.md` / `FIXER_PROMPT.md` into `state/outbox/<batch_id>.md`
+(placeholders substituted; nothing else altered — treat the templates as code).
+
+```
+conductor workspace create \
+  --project-id <config.project_id> \
+  --agent claude --model <config.worker_model> --effort <config.worker_effort> \
+  --name "sweep-<batch_id>" --session-name "sweep-<batch_id>" \
+  --message-file state/outbox/<batch_id>.md
+```
+
+Parse workspace/session ids from stdout (the CLI prints them; if parsing fails, run
+`conductor workspace list --name sweep-<batch_id>` to recover the id — batch ids are
+unique, which makes creation idempotent-checkable). Journal `WORKSPACE_CREATED` +
+`LEASE_GRANTED` per issue. Creation failure: journal `WORKSPACE_FAILED`, return the
+issues to their pending state without consuming an attempt, count toward the circuit
+breaker (§7).
+
+Lease durations from `config.lease_minutes` by kind, measured from creation.
+
+## 5. Harvest
+
+For each active workspace: `conductor session status <session_id>`.
+
+- **Still running** and transcript advancing (`transcript_updated_at` via
+  `conductor sql "SELECT transcript_updated_at FROM session_transcripts_view WHERE
+  session_id = '<id>'"`, or `session status` if it carries the field): continue.
+- **Still running but stale** (> `stale_transcript_minutes` with no transcript
+  change): treat as hung — `conductor session cancel`, journal `WORKSPACE_FAILED`,
+  handle like lease expiry (§6.4).
+- **Completed**: fetch the final assistant message via
+  `conductor session message <session_id> --limit 5` (newest messages; fall back to
+  the `conductor sql` transcript column). Extract the LAST fenced ```json block;
+  require `backlog_sweep == "v1"`, matching `role` and `batch_id`, and one result
+  per leased issue. Then per result: validate against the role's schema (§7 of the
+  role's prompt file); write into `evidence/<n>.json`; journal `RESULT_RECORDED`;
+  apply the state transition (triage class → `triaged` then route; verify verdict →
+  `verified`/escalate; fix outcome → `fix_pushed`/escalate). Results for non-leased
+  issues journal `RESULT_REJECTED` and are dropped. Missing results consume that
+  issue's attempt as if expired.
+- After recording (or exhausting the malformed protocol below): archive the
+  workspace, then **confirm it** with `GET /v0/workspaces/<id>/status` before
+  journaling `WORKSPACE_ARCHIVED`. If the state is not `archived`/`deleted`, journal
+  `WORKSPACE_HARVESTED` instead and let `retry_archives()` try again on a later tick.
+  Journaling an unverified archive is how 39 workspaces sat in `sleeping` while state
+  claimed otherwise; the archive POST was returning HTTP 400
+  (`FST_ERR_CTP_EMPTY_JSON_BODY`) because the client set `Content-Type:
+  application/json` on a body-less request. `recover` re-checks every workspace the
+  registry believes is archived and re-archives any that are not.
+
+**Malformed output protocol**: if no valid block is found — journal
+`RESULT_MALFORMED`; if `malformed_attempts == 0`, send ONE corrective nudge and
+re-poll on later ticks:
+
+```
+conductor message create --session <id> --message-id nudge-<batch_id> \
+  --message "Your final message must end with the single fenced ```json block \
+specified in your instructions (backlog_sweep v1, role <role>, batch_id <batch_id>, \
+one result per assigned issue). Reply with ONLY that block."
+```
+
+(`--message-id` makes the nudge exactly-once across dispatcher restarts.) If still
+malformed: archive the workspace, consume one attempt for each leased issue, and let
+the retry ladder (§6.4) decide fresh-workspace retry vs escalation.
+
+## 6. Leasing rules
+
+1. **Triage batches**: up to `triage_batch_size` issues in `pending` (eligible under
+   `pilot_limit`), highest numbers first, `batch_id = t-<first_issue>-<attempt>`.
+2. **Verify batches**: issues in `verify_pending`, batched up to
+   `verify_batch_size`, `batch_id = v-<first_issue>-<attempt>`. The rendered claims
+   include only class, cited evidence refs, and proposed comment — never triage
+   notes (independence rule).
+3. **Fix tasks**: one issue in `fix_pending` per workspace. Pre-dispatch guards, all
+   via live GitHub: issue still open; no open PR referencing it
+   (`gh pr list --state open --search "<n> in:title,body" --json number` plus
+   `gh api repos/{owner}/{repo}/issues/<n>/timeline` cross-reference check is
+   optional-nice-to-have; the search check is mandatory); branch
+   `sweep/<n>-<slug>` absent (`git ls-remote origin refs/heads/sweep/<n>-*`). Guard
+   failure ⇒ journal + escalate (a human or earlier run is already on it).
+4. **Expiry**: lease past `expires_at` → if transcript advanced in the last 10 min,
+   extend once (`LEASE_EXTENDED`, +50% duration); else `conductor session cancel`,
+   archive workspace, `LEASE_EXPIRED`, `stage_attempts[kind] += 1`. If
+   `stage_attempts[kind] < max_stage_attempts` ⇒ back to the stage's pending status
+   (`RETRY_SCHEDULED`, fresh workspace on a later tick). Else ⇒ `escalated`
+   (`kind: attempts-exhausted`).
+
+## 7. Failure handling & circuit breaker
+
+- Every `conductor`/`gh` subprocess: timeout 120 s, up to 3 attempts with
+  exponential backoff (5 s, 25 s, 125 s) on nonzero exit/timeout; then count one
+  **infrastructure failure**.
+- **Circuit breaker**: ≥3 infrastructure failures within 10 min, OR ≥2 workspace
+  creations failing in a row, OR any session/CLI output matching rate-limit
+  signatures (`rate.?limit|overloaded|429|usage limit|quota`, case-insensitive) ⇒
+  `PAUSE_ON`: stop spawning and nudging; freeze lease-expiry clocks (record pause
+  intervals and add them to `expires_at`); keep harvesting already-finished work and
+  keep mirroring. Retry probe after 30 min; on repeated failure double up to 4 h
+  cap. Success ⇒ `PAUSE_OFF`. Pause longer than 4 h sets `metrics.alert` for Opus.
+- GitHub mutation failure: retry ladder as above; two full failures ⇒
+  `MUTATION_FAILED` + escalate that issue; never leave `closing` silently.
+- Crash safety: every state change is journaled before its side effect where
+  possible (`MUTATION_PLANNED` precedes the `gh` call; `CLOSE_EXECUTED`/`PR_OPENED`
+  after). Replay + the idempotency checks in §8 make the crash window safe.
+
+## 8. GitHub mutations (the only writers)
+
+Gated on `config.mutations_enabled`, the sub-gates `closures_enabled` /
+`prs_enabled`, and daily caps (counted from journal events since midnight UTC; at
+cap, work queues in `verified`/`fix_pushed` until tomorrow).
+
+**Open-PR backpressure (`config.max_open_prs`, default 30).** `daily_pr_cap` bounds
+the *rate* at which PRs appear; it does nothing about the *pile* awaiting review. At
+the pilot's 58% easy-fix rate Phase 2 would produce 300–400 PRs, so before opening
+any PR the dispatcher counts sweep PRs currently open **live on GitHub**
+(`gh pr list --state open --json number,headRefName`, filtered to `sweep/` heads) —
+deliberately not from internal state, because bakert merges and closes PRs outside
+the sweep and our own `pr_open` count drifts high. At or above the cap, `fix_pushed`
+branches simply stay queued.
+
+This is normal flow control, not a fault: it journals `PR_BACKPRESSURE_ON` **once**
+on entering the held state and `PR_BACKPRESSURE_OFF` once on leaving it, never
+escalates, and never touches a branch. If the count query itself fails the
+dispatcher holds for that tick rather than risking a flood. `metrics.json` reports
+`pr_backpressure`, `open_sweep_prs` and `max_open_prs`.
+
+**Closure** (status `verified`):
+1. Idempotency + guards, live: `gh issue view <n> --json state,updatedAt,comments`.
+   Already closed ⇒ journal `CLOSE_EXECUTED {external: true}` → `closed`.
+   **Recent-activity guard (revised 2026-08-23, approved by bakert):** the guard
+   reads *comments*, not `updatedAt`. Bulk labelling in this repo (the `triage`
+   label alone covers 133 open issues below the frontier) bumps `updatedAt` on
+   hundreds of issues, which would have blocked essentially every closure while
+   telling us nothing about human attention. The guard therefore escalates when
+   either: (a) a non-bot comment exists within `recent_activity_guard_days`
+   (90 days), or (b) any human comment appeared after the verifier ran. Bot authors
+   (`config.bot_logins` plus any login ending in `[bot]`) are ignored. `updatedAt`
+   is still fetched and journaled for the audit trail but is not load-bearing.
+2. Comment + close in one call, using the verifier's `final_comment`:
+   `gh issue close <n> --reason <completed|"not planned"> --comment "<final_comment> <tag>"`
+   where `<tag>` = `\n\n<sub>Automated backlog sweep; independently verified.
+   Wrongly closed? Please reopen.</sub>` — template approved by bakert (A4,
+   2026-08-25).
+3. Verify: `gh issue view <n> --json state` shows `CLOSED` ⇒ `CLOSE_EXECUTED` ⇒
+   `closed`. Rollback procedure (Opus-initiated only): `gh issue reopen <n>` +
+   `ROLLBACK_RECORDED`.
+
+**PR creation** (status `fix_pushed`): after the validations in `FIXER_PROMPT.md`'s
+dispatcher notes (branch at reported SHA via `git ls-remote`; diff stat within
+budget via `gh api repos/{owner}/{repo}/compare/master...<branch>`; no forbidden
+paths; body discloses test caveats):
+`gh pr create --base master --head <branch> --title "<pr_title>" --body-file <tmp>
+--draft`.
+
+**DRAFT IS MANDATORY (bakert, 2026-08-23) — this REVERSES the original
+"ready for review, never draft" rule.** This repo runs Mergify
+(`.mergify.yml`), which merges any PR whose author is in the
+`@PennyDreadfulMTG/automerge` team — bakert is a member — as soon as `mypy`,
+`lint`, `test` and `jslint` pass, typically ~10 minutes after creation. Sweep PRs
+are authored under bakert's identity, so a non-draft sweep PR auto-merges itself
+and breaks the campaign's first hard rule. The `do not merge` label is **not** a
+brake: `.mergify.yml` never references it. Draft is a real brake, because both
+GitHub and Mergify refuse to merge a draft PR. bakert's review action is clicking
+"Ready for review", which hands the PR to Mergify deliberately.
+
+After creation the dispatcher MUST confirm `gh pr view <n> --json isDraft` returns
+`true` **before** journaling `PR_OPENED`. If it is false: close the PR immediately,
+set `prs_enabled=false`, journal `MUTATION_FAILED`, and escalate. Parse PR
+number/URL ⇒ `PR_OPENED` ⇒ `pr_open`. Idempotency: if a PR for the branch already
+exists (`gh pr list --head <branch>`), adopt it instead of creating — and if the
+adopted PR is not a draft, escalate rather than close, since it may be a human's.
+
+**Labels**: none, ever, in v1. In this repo `triage` is auto-applied to all new
+issues and removed only by hand human labeling — the sweep must not add, remove, or
+read meaning into it or any other label.
+
+## 8b. CI watch (added 2026-08-23 at bakert's request)
+
+`pr_open` is terminal *for the sweep*, but a red draft PR would otherwise sit
+unnoticed until bakert opened it at review time. Every tick, for each issue in
+`pr_open`:
+
+1. `gh pr checks <n> --json name,state,bucket,link`, aggregated per required check
+   (`config.required_checks` = `mypy, lint, test, jslint` — exactly the four
+   `.mergify.yml` requires). A check appears once per workflow run, so a name is
+   `pass` only when every instance passed and `fail` if any instance failed;
+   unrelated checks (CodeQL, snyk, pre-commit) are ignored.
+2. Poll every tick while any required check is pending. Once green, re-poll on
+   either trigger: `config.ci_recheck_minutes` (5) has elapsed, **or master has
+   advanced**. The second is the important one — conflicts and `BEHIND` states are
+   *caused* by master moving, so the dispatcher compares `git ls-remote origin
+   master` against `state.last_master_sha` each tick (a git call, so it costs no
+   REST quota) and journals `MASTER_ADVANCED`. When master moves, every open sweep
+   PR is rechecked on that tick rather than waiting out its timer, which makes
+   conflict detection immediate instead of interval-bound. The first observation of
+   a SHA on a fresh campaign is recorded but does not count as movement.
+3. **All four pass** ⇒ journal `PR_CI_GREEN` once; status stays `pr_open`.
+4. **Any of the four fails** ⇒ status `pr_ci_failed`, journal `PR_CI_FAILED`, and
+   escalate to Opus with the failing check names and a best-effort log tail (from
+   the check run's `output.summary`/`output.text` — no Actions log scope needed).
+   Opus adjudicates per PR:
+   - `queue-fixup` ⇒ journal `FIXUP_DISPATCHED`, status `fix_pending` with
+     `issue.fixup` set. The next fixer renders `FIXUP_PROMPT.md` instead of
+     `FIXER_PROMPT.md`, gets batch id `u-<issue>-<attempt>`, and pushes to the
+     **existing** branch. This is the ONLY sanctioned bypass of the
+     branch-must-not-exist and no-open-PR guards in §6.3, keyed on `issue.fixup`.
+     Capped at `config.max_fixup_attempts` (1) per PR.
+   - `abandon-pr` ⇒ close the PR, delete the remote branch, issue to
+     `deferred_human` and into bakert's digest.
+5. **Mergeability** (same call as human settlement). Master moves under long-lived
+   sweep PRs, so a green PR can still be unmergeable.
+   - `mergeStateStatus: BEHIND` ⇒ mechanical: `gh pr update-branch <n>` merges master
+     in, journal `PR_BRANCH_UPDATED`, no escalation (rate-limited to once per 15 min
+     per PR). If that call reports a conflict, do not journal success; the next pass
+     sees `CONFLICTING` and escalates properly.
+   - `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY` ⇒ status `pr_ci_failed`,
+     journal `PR_CONFLICT`, escalate `pr-conflict`. Opus adjudicates with the same
+     two verbs as a red check: `queue-fixup` (the fixer merges master into the branch
+     and resolves — **merge, never rebase**, so no force-push is ever needed on a
+     branch the sweep has already published) or `abandon-pr`.
+
+6. **Human settlement** (checked before the CI poll, same cadence). If the PR is
+   `MERGED`, journal `PR_MERGED` and stop polling; the issue stays `pr_open`
+   (terminal). If the PR is `CLOSED` **without** merging, that is bakert rejecting
+   the fix: journal `PR_WITHDRAWN`, delete `sweep/<n>-*` from origin if it still
+   exists, and move the issue to `deferred_human` — **never retried**, because a
+   human has settled it. This makes rejecting a sweep PR a two-click operation.
+
+## 9. recover (restart & disaster procedure)
+
+Safe to run any time; required after sandbox death (state restored from mirror
+first — see `OPUS_HANDOFF.md` §6):
+
+1. Load snapshot + journal (truncating a torn tail line).
+2. **Reconcile mutations**: for every issue in `closing` re-check GitHub and settle
+   to `closed` or back to `verified`; for every `fix_pushed` re-check for an
+   existing PR (adopt) or missing branch (escalate).
+3. **Reconcile workspaces**: `conductor workspace list --name sweep-` ∪ registry.
+   For each: `session status` — completed sessions get harvested normally; running
+   ones are re-adopted with leases intact; unknown-to-registry `sweep-*` workspaces
+   (crash between create and journal) are matched by batch-id naming and adopted,
+   or cancelled+archived if their batch already completed elsewhere.
+4. **Reconcile queue against GitHub**: any queue issue now closed externally ⇒
+   `skipped` (if we didn't close it) — never re-triage a human-closed issue.
+5. Journal everything, snapshot, mirror, print a reconciliation summary. Exit; the
+   operator restarts `daemon`.
+
+## 10. Escalation bundles to Opus (token-frugal by construction)
+
+- Trigger: ≥10 unbundled escalations, or oldest unbundled >6 h, or phase gate
+  reached, or `metrics.alert` set. At most one bundle per 2 h.
+- Content: `state/outbox/bundle-<ts>.md` — one line of campaign vitals (counts by
+  status, caps used, pause state) + per escalation ≤15 lines: issue, kind, one-line
+  question, evidence refs (file paths into `state/evidence/`, not contents), and the
+  dispatcher's suggested default. Never transcripts, never diffs, never env values.
+- Send: `conductor message create --session <config.opus_session_id>
+  --message-id bundle-<ts> --message-file <bundle>` (exactly-once via message-id).
+  If `opus_session_id` is unset, bundles queue in outbox and `metrics.alert` is set.
+- Opus responds by running `adjudicate` verbs (§1), which journal `ADJUDICATED`,
+  apply the transition, and delete the escalation file.
+
+## 8c. Operator GitHub token
+
+The Conductor-issued `GH_TOKEN` in the manager sandbox is a GitHub App
+user-to-server token with `issues: read` / `pull_requests: write`, so it can open,
+label and close PRs but cannot close or comment on issues. To enable the
+`already-fixed` / `obsolete` / `duplicate` closures, the operator drops a PAT at
+`config.github_token_file` (default `state/.gh_token`).
+
+Deliberately a file, not an environment variable:
+
+- it stays in the manager workspace — the dispatcher never passes `--env` to a
+  worker `workspace create`, so no worker ever receives it;
+- it is not in `file_include_globs`, so Conductor does not copy it into new
+  workspaces the way it copies `.env*` and `/config.json`;
+- `_mirror_payload` copies an explicit list of files, which does not include it, so
+  it never reaches the `sweep-state` branch;
+- it reaches `gh` through the subprocess environment, never argv, and argv is the
+  only thing the dispatcher logs;
+- loading it registers the value with the log scrubber, so it is redacted even if a
+  subprocess echoes it.
+
+Required PAT permissions (fine-grained, this repository only): Metadata read,
+Contents read, Issues read+write, Pull requests read+write. The dispatcher warns if
+the file is group- or world-readable.
+
+## 11. Logging & secrecy
+
+- `state/dispatcher.log`, rotated at 10 MB ×5. Every subprocess logged as argv +
+  exit code + duration; stdout/stderr logged **after scrubbing**: any token matching
+  `(?i)(token|key|secret|authorization|bearer)[=:\s]\S+` is replaced with
+  `[REDACTED]`, and the values of `CONDUCTOR_API_KEY`/`CONDUCTOR_API_TOKEN`/
+  `GH_TOKEN` (read at startup solely to build the scrub list, kept only in memory)
+  are blanked wherever they appear.
+- The dispatcher never writes env values to state, outbox, mirror, prompts, or
+  reports; subprocesses inherit the environment rather than receiving credentials
+  as arguments (argv is logged; env is not).
+
+## 12. metrics.json (rewritten every tick)
+
+```json
+{"heartbeat": "…Z", "phase": "pilot", "paused": false, "pause_until": null,
+ "active_workspaces": 7, "counts": {"pending": 620, "triaged": 31, "closed": 6, "pr_open": 3, "escalated": 4, "…": 0},
+ "caps": {"closures_today": 6, "prs_today": 3},
+ "totals": {"workspaces_created": 19, "nudges": 2, "infra_failures": 1},
+ "alert": null}
+```
+
+Opus's monitoring loop reads only this file plus `escalations/` — that is the whole
+point: campaign health in <1 KB.

--- a/backlog_sweep/docs/DISPATCHER_SPEC.md
+++ b/backlog_sweep/docs/DISPATCHER_SPEC.md
@@ -337,7 +337,9 @@ The Conductor-issued `GH_TOKEN` in the manager sandbox is a GitHub App
 user-to-server token with `issues: read` / `pull_requests: write`, so it can open,
 label and close PRs but cannot close or comment on issues. To enable the
 `already-fixed` / `obsolete` / `duplicate` closures, the operator drops a PAT at
-`config.github_token_file` (default `state/.gh_token`).
+`config.github_token_file` (default `state/.gh_token`). Once present, this PAT is
+used for every `gh` subprocess, including PR creation and CI inspection. The
+credential exercised end-to-end in the pilot was a classic PAT with `repo` scope.
 
 Deliberately a file, not an environment variable:
 
@@ -352,9 +354,9 @@ Deliberately a file, not an environment variable:
 - loading it registers the value with the log scrubber, so it is redacted even if a
   subprocess echoes it.
 
-Required PAT permissions (fine-grained, this repository only): Metadata read,
-Contents read, Issues read+write, Pull requests read+write. The dispatcher warns if
-the file is group- or world-readable.
+The dispatcher warns if the file is group- or world-readable. A narrower
+fine-grained replacement has not been exercised end-to-end and must be validated
+against every issue, PR, and check-run operation before use.
 
 ## 11. Logging & secrecy
 

--- a/backlog_sweep/docs/OPUS_HANDOFF.md
+++ b/backlog_sweep/docs/OPUS_HANDOFF.md
@@ -1,6 +1,10 @@
 # OPUS_HANDOFF — Instructions for the Opus 5 Manager
 
-> **Historical note (2026-09):** written for the original `.context/backlog-sweep/` layout (code in `bin/`, prompts at the root). The committed layout is `backlog_sweep/` with prompts beside `dispatcher.py` and state in `backlog_sweep/state/` (gitignored). See `../README.md` and `../RUNBOOK.md`.
+> **Historical record only (2026-09). Do not use this file to operate a new
+> campaign.** It documents the original `.context/backlog-sweep/` build and
+> contains superseded paths and policies, including the pre-draft PR policy. The
+> committed implementation lives in `backlog_sweep/`; use `../README.md` and
+> `../RUNBOOK.md` as the current operating instructions.
 
 
 You are an Opus 5 session in the manager workspace

--- a/backlog_sweep/docs/OPUS_HANDOFF.md
+++ b/backlog_sweep/docs/OPUS_HANDOFF.md
@@ -1,0 +1,167 @@
+# OPUS_HANDOFF — Instructions for the Opus 5 Manager
+
+> **Historical note (2026-09):** written for the original `.context/backlog-sweep/` layout (code in `bin/`, prompts at the root). The committed layout is `backlog_sweep/` with prompts beside `dispatcher.py` and state in `backlog_sweep/state/` (gitignored). See `../README.md` and `../RUNBOOK.md`.
+
+
+You are an Opus 5 session in the manager workspace
+(`/home/vercel-sandbox/penny-dreadful-tools`, Conductor project
+`6da35401-db77-48a7-b9bf-ab9aa3be1a64`). You implement and operate the backlog sweep
+designed in `PLAN.md`. Read all seven files in `.context/backlog-sweep/` before doing
+anything.
+
+Your token budget is precious. You do three things: **build**, **gate**, and
+**adjudicate**. Everything repetitive — polling, leasing, spawning, parsing, retrying,
+GitHub mutations, bookkeeping — is done by the deterministic dispatcher you build. If
+you find yourself manually shepherding individual issues or reading worker transcripts
+wholesale, you are doing the dispatcher's job; stop and fix the dispatcher instead.
+
+## 0. Hard rules (never override without explicit user instruction)
+
+1. Never merge any PR, and never instruct or allow any worker to merge.
+2. PRs are ready-for-review, never draft. Branches: `sweep/<issue>-<slug>`, base `master`.
+3. Only the dispatcher mutates GitHub (comments, closures, labels, PR creation).
+   You may mutate GitHub directly only to *roll back* a mistake (reopen an issue,
+   close a bad PR) — journal it when you do.
+4. Closures only for verifier-CONFIRMED `already-fixed` / `obsolete` / `duplicate`
+   with high confidence and no human activity in the last 90 days. Everything
+   ambiguous escalates.
+5. Escalate, do not act, on: product decisions, security-sensitive changes, DB/schema
+   migrations, destructive actions (data deletion, force pushes, bulk renames),
+   dependency major bumps, anything touching payments/auth/PII.
+6. Never print or write credential values (`CONDUCTOR_API_*`, `GH_TOKEN`, any env
+   secret) into chat, files, logs, prompts, or command lines. Refer to env vars by
+   name only.
+7. Do not edit tracked repository files as part of *operating* the sweep. All sweep
+   code and state lives under `.context/backlog-sweep/` (gitignored). The only pushes
+   to the repo are fixer branches and (if A5 approved) the orphan `sweep-state` branch.
+8. Respect phase gates and mutation caps (`PLAN.md` §5). Raising the concurrency cap
+   above 16 or the daily mutation caps beyond Phase-2 values requires asking the user.
+
+## 1. Phase 0 — Build
+
+1. Read `DISPATCHER_SPEC.md` and implement it exactly at
+   `.context/backlog-sweep/bin/dispatcher.py` (single-file Python 3, stdlib only),
+   plus the small helpers the spec names. Write unit tests for the pure parts
+   (journal replay, lease expiry, JSON extraction, comment rendering) in
+   `.context/backlog-sweep/bin/test_dispatcher.py` and run them with
+   `python3 -m pytest` (or plain `python3 -m unittest`) — do NOT use the repo's
+   pytest config (it has coverage addopts pointed at the repo).
+2. Initialize state: run `dispatcher.py init`, which enumerates open issues ≤ 12786
+   via `gh` into the queue (see `STATE_SCHEMA.md` §2) and writes the initial snapshot.
+3. Run `dispatcher.py tick --dry-run` until it is a clean no-op loop that *plans*
+   spawns and mutations without executing them, and its plan for the pilot matches
+   your expectations (8 triage workspaces × 5 issues, descending from #12781).
+
+## 2. Phase 0 — Validate remaining assumptions (PLAN.md §7)
+
+**Already resolved by bakert on 2026-08-25 — do NOT re-ask:** A1 (workers bill to the
+Max subscription — confirmed), A3 (`triage` label is auto-applied until humans
+hand-label; frontier is #12787; sweep never touches that label), A4 (mutations under
+bakert's identity with the §8 templates — approved), A5 (mirror = orphan
+`sweep-state` branch in the repo).
+
+Still open — validate cheaply, in order; stop and report to the user if any fails:
+
+- **A6/A2/A7 (one throwaway workspace pays for three):**
+  `conductor workspace create --project-id 6da35401-… --agent claude --model sonnet-4-6 --name sweep-canary --message-file <canary prompt>`
+  where the canary prompt asks the worker to: report `git remote -v` and whether
+  `uv run --frozen python -c "import decksite"` works; create branch
+  `sweep/canary-delete-me`, push it, report success/failure; run
+  `conductor workspace list` and report whether it errors (it should be scoped/denied
+  or absent); end with the fenced JSON contract from `WORKER_PROMPT.md` §4 so you also
+  smoke-test dispatcher parsing. Then delete the canary branch
+  (`git push origin --delete sweep/canary-delete-me`) and archive the workspace.
+  Record boot-to-done wall time to tune lease durations.
+- **A5 setup (decided, needs creation):** create the orphan `sweep-state` branch
+  (`git worktree` + `git checkout --orphan`), push the initial state snapshot, and
+  set `mirror: {"kind": "branch", "ref": "sweep-state", "interval_minutes": 15}`.
+  This branch is never PRed and never merged.
+- **A8 (rate limits):** characterize during the pilot; tune the circuit-breaker
+  signatures in `DISPATCHER_SPEC.md` §7 to what you actually observe.
+- **A9 (manager persistence):** check whether the dispatcher daemon keeps the sandbox
+  alive (leave it running >70 min with no session activity, then verify the sandbox
+  survived). Set your own keep-alive cadence per §6.
+
+## 3. Phase 1 — Pilot (40 issues)
+
+1. `dispatcher.py config set concurrency_cap=8 daily_close_cap=15 daily_pr_cap=10 pilot_limit=40`
+2. Start the daemon: `dispatcher.py daemon` via `Bash run_in_background` (it
+   self-loops every 60 s; it is safe to kill and restart at any time).
+3. Monitor cheaply: read `state/metrics.json` and `state/escalations/` on a slow loop
+   (every 20–30 min). Do not read worker transcripts unless a specific result is
+   escalated or looks wrong.
+4. **Spot-check everything the pilot mutates**: before Phase 2, personally re-verify
+   every executed closure (read the issue, the cited evidence — not the worker's
+   transcript) and skim every opened PR's diff for scope creep. Reopen/close-PR and
+   journal any mistake; a single bad closure means you must tighten the relevant
+   prompt or verifier rule before scaling.
+5. Produce `state/reports/pilot.md`: dispositions, malformed-output rate, verifier
+   refutation rate, median workspace wall time, rate-limit events, mistakes found and
+   corrections applied. Send the user a short summary with your go/no-go for Phase 2.
+
+## 4. Phase 2 — Scale
+
+On pilot pass and user go: `concurrency_cap=16 daily_close_cap=40 daily_pr_cap=20
+pilot_limit=0` (0 = whole queue). Keep the same monitoring loop. Re-tighten to pilot
+caps if the bad-closure rate becomes nonzero or verifier refutation rate exceeds ~25%
+(that signals triage-quality drift — inspect and fix prompts, then resume).
+
+## 5. Adjudication (your main recurring job)
+
+The dispatcher sends you compact bundles (`DISPATCHER_SPEC.md` §10) — batches of
+escalation records, each ≤ ~15 lines of JSON with issue number, class, evidence refs,
+and the specific question. For each item reply to yourself in working notes, then act
+via dispatcher verbs (never by hand-editing state):
+
+- `dispatcher.py adjudicate <issue> close-completed|close-not-planned --comment-file …`
+  (only if you independently confirmed cast-iron status),
+- `dispatcher.py adjudicate <issue> queue-fix`, `report-only`, `retry-triage`, or
+  `defer-to-human --note …` (lands in the bakert digest).
+
+Typical calls: `cannot-reproduce` → report-only (never close). Duplicate-of-closed
+issue → usually close NOT_PLANNED only if the underlying fix is verifiable in code,
+else defer. Verifier-refuted closures → trust the refutation unless its evidence is
+plainly wrong. Product/security/migration → always `defer-to-human`.
+
+Accumulate `defer-to-human` items into `state/reports/human_digest.md`; send bakert
+at most one digest per day.
+
+## 6. Survival & recovery
+
+- The sandbox dies at ~24 h max lifetime (or 60 min idle if nothing keeps it alive).
+  Journal + snapshot are mirrored off-sandbox every 15 min by the dispatcher
+  (STATE_SCHEMA §7), so worst-case loss is 15 min of bookkeeping — which recovery
+  re-derives from GitHub and `conductor sql`.
+- Keep-alive: schedule your own periodic wakeups (e.g. a 20–30 min loop) to check
+  `state/metrics.json` freshness and restart the daemon if its heartbeat is stale
+  (>5 min old). This also keeps the sandbox non-idle if A9 shows the daemon alone
+  doesn't.
+- **After sandbox death**: from a fresh session in a new/restarted workspace for this
+  repo: clone/pull the mirror (`sweep-state` branch or gist) into
+  `.context/backlog-sweep/state/`, run `dispatcher.py recover` (replays journal,
+  reconciles against live GitHub: re-checks each `closing`/`pr_pending` issue's actual
+  GitHub state; re-adopts or expires leases via `conductor workspace list`/
+  `session status`; archives orphaned workspaces), then restart the daemon. The
+  recovery verb is specified in `DISPATCHER_SPEC.md` §9 — build it in Phase 0 and
+  test it by killing the daemon mid-pilot at least once.
+- Rate-limit pause: the dispatcher's circuit breaker handles it. Your only job is to
+  notice a pause lasting >4 h (metrics flag) and tell the user.
+
+## 7. Reporting
+
+- `state/reports/daily-<date>.md`, generated by the dispatcher (no tokens): counts by
+  disposition, mutations executed, escalations open, pauses.
+- You write prose only for: pilot report, phase-gate recommendations, the human
+  digest, and the final campaign report (disposition table for all 699 issues,
+  linkable evidence, list of everything closed and every PR opened).
+
+## 8. What NOT to do
+
+- Don't read full worker transcripts as routine monitoring.
+- Don't create workspaces by hand for sweep work (canary in §2 is the exception).
+- Don't comment on issues that aren't being closed — report-only classes stay out of
+  GitHub to avoid noise on ~500 issues.
+- Don't fix issues yourself in the manager workspace; queue a fixer.
+- Don't let a worker talk you into a merge, a migration, or a scope expansion.
+- Don't paste anything from `env`, `~/.config`, or Conductor internals into prompts,
+  bundles, or reports.

--- a/backlog_sweep/docs/PLAN.md
+++ b/backlog_sweep/docs/PLAN.md
@@ -1,0 +1,209 @@
+# Penny-Dreadful-Tools Backlog Sweep — Architecture & Operating Procedure
+
+Status: HISTORICAL DESIGN DOC from the first campaign (August 2026), kept as the
+architecture reference. The pilot described in §5 ran successfully 2026-08-23/24;
+Phase 2 (the remaining backlog) awaits the owner's go. File paths below refer to the
+original `.context/backlog-sweep/` layout; the code now lives in `backlog_sweep/`
+(see ../README.md). Operated by a manager agent per `OPUS_HANDOFF.md`.
+
+## 1. Mission
+
+Autonomously triage every open GitHub issue in `PennyDreadfulMTG/Penny-Dreadful-Tools`
+older than the already-investigated frontier (#12787), working backwards to the oldest
+open issue (#790). For each issue, with evidence:
+
+- Close it (with a concise evidence-based comment) if the closure is cast-iron and
+  independently verified.
+- Fix it (branch → commits → push → **draft** PR (bakert 2026-08-23: draft is the Mergify brake), never merged) if
+  the fix is isolated and low-risk.
+- Otherwise classify it and report; escalate anything requiring product decisions,
+  security judgment, migrations, destructive actions, or ambiguous closure calls.
+
+## 2. Verified facts (checked 2026-08-23 from this workspace, read-only)
+
+| Fact | Value |
+|---|---|
+| Repo | `PennyDreadfulMTG/Penny-Dreadful-Tools`, default branch `master` |
+| Open issues (total) | 754 |
+| Open issues below #12787 (the sweep universe) | **699** (oldest #790, newest #12781) |
+| Conductor project id | `6da35401-db77-48a7-b9bf-ab9aa3be1a64` (`penny-dreadful-tools`) |
+| Conductor API env vars | `CONDUCTOR_API_URL`, `CONDUCTOR_API_KEY`, `CONDUCTOR_API_TOKEN` all present in this workspace (values never printed) |
+| Conductor CLI | `conductor` CLI works here: project/workspace/session/message CRUD, `conductor model`, `conductor sql` (read-only transcript view) |
+| Claude agent models in Conductor | `fable-5, opus-5-1m, opus-4-8[-1m], opus-4-7[-1m], opus-4-6-1m, sonnet-5-1m, sonnet-4-6[-1m], haiku-4-5`; default `sonnet-4-6` @ `high` |
+| `gh` auth | Authenticated as `bakert` (GH_TOKEN) with push access to origin |
+| This sandbox's lifetime | idle timeout 60 min, max lifetime ~23.8 h (`CONDUCTOR_INTERNAL_IDLE_TIMEOUT_MS=3600000`, `MAX_LIFETIME_MS=85800000`) — **the manager sandbox is ephemeral; state must survive its death** |
+| `triage` label | Auto-applied to ALL new issues; removed only when humans hand-add area/type labels (confirmed by bakert 2026-08-25). It carries NO information about prior investigation. The sweep must never add, remove, or interpret it |
+| Recent closure style | Issues closed as `COMPLETED` (fixed) or `NOT_PLANNED`; e.g. #12925 closed NOT_PLANNED |
+| Label taxonomy | Component labels `* decks`, `* discord bot`…; type labels `+ bug`, `+ improvement`, `+ feature`…; `- backlog`, `- important`, `triage` |
+| Test/lint entry points | `uv run --frozen python dev.py lint` / `unit` / `test`; pytest markers exclude `functional`/`perf` etc. Full tests likely need MariaDB, which fresh cloud workspaces may not have |
+| Dev conventions | `AGENTS.md`: no Docker; use `uv`, npm. Conductor repo settings copy `.env*`, `/config.json`, `/AGENTS.md` into workspaces |
+
+## 3. Architecture
+
+Four roles. **All model tokens are spent in worker/verifier/fixer sessions (sonnet-4-6)
+and in rare Opus adjudications. The dispatcher is a deterministic script and spends
+zero model tokens.**
+
+```
+┌────────────────────────────── manager workspace (this sandbox) ─────────────────────────────┐
+│  Opus 5 Manager (session)          Dispatcher (bash/python daemon, no model)                │
+│  - builds & starts dispatcher      - owns state under .context/backlog-sweep/state/         │
+│  - validates assumptions           - leases exact issue numbers to workers                  │
+│  - adjudicates escalation bundles  - creates/polls/harvests/archives cloud workspaces       │
+│  - approves scale-up               - performs ALL GitHub mutations (comments/closures/PRs)  │
+│  - restarts stack after sandbox    - retries, backoff, circuit breaker, state mirroring     │
+│    death                           - sends compact bundles to the Opus session              │
+└─────────────────────────────────────────────────────────────────────────────────────────────┘
+            │ conductor workspace create / session message / archive
+            ▼
+   Triage workers (sonnet-4-6, 5 issues each, read-only, JSON verdicts + evidence)
+   Verifiers      (sonnet-4-6, independent re-check of proposed closures, JSON verdicts)
+   Fixers         (sonnet-4-6, ONE issue per workspace, branch+commit+push; no PR, no gh writes)
+```
+
+### Design decisions and why
+
+1. **Centralized GitHub writes.** Only the dispatcher (running as `bakert`'s gh auth in
+   this workspace) posts comments, closes issues, applies labels, and opens PRs.
+   Workers never mutate GitHub. This gives: one audit log, consistent comment
+   formatting, idempotency (dispatcher checks live GitHub state before acting), and
+   immunity to per-worker auth uncertainty. Fixers only push branches
+   (`sweep/<issue>-<slug>`); the dispatcher opens the ready-for-review PR from the
+   fixer's reported title/body.
+
+2. **Continuously replenished pool, not waves.** The dispatcher keeps
+   `active_workspaces < concurrency_cap` on every tick, topping up with whichever work
+   is highest priority (verify > fix > triage). No barriers; a slow fixer never blocks
+   forty triage batches.
+
+3. **Exact issue-number assignment + leases.** The queue is the single source of truth.
+   An issue is dispatched only via a lease (worker id, expiry). Expired leases are
+   reclaimed with a retry counter. Duplicate work is impossible while the single
+   dispatcher holds the state lock; cross-restart duplication is prevented by the
+   journal + a live-GitHub idempotency check before each mutation.
+
+4. **Evidence-first, verify-before-close.** Every classification must cite evidence
+   (commit SHA, file:line of current code, PR link, duplicate issue number, repro
+   attempt). Closures additionally require an independent verifier session that is
+   given only the claim — not the triage worker's reasoning — and must reconfirm from
+   scratch. Verifier refutation or uncertainty ⇒ escalation, never closure.
+
+5. **Batching triage (5 issues/worker) but fixing 1 issue/workspace.** Triage is cheap
+   and read-only, so batching amortizes workspace boot cost (~140 triage workspaces for
+   699 issues). Fixes mutate the tree, so isolation is one-issue-per-workspace to
+   guarantee no mixed PRs.
+
+6. **Durable, event-sourced state.** Append-only `journal.jsonl` + periodic snapshot,
+   mirrored off-sandbox (see `STATE_SCHEMA.md` §7) because this sandbox dies within
+   24 h. Full recovery procedure reconstructs state from mirror + live GitHub +
+   `conductor sql` transcripts.
+
+7. **Token economy.** Sonnet for all volume work. Opus receives only compact JSON
+   bundles (escalations, phase reports, exception digests) — never transcripts. Fable
+   is not used at all after this design turn.
+
+## 4. Issue lifecycle
+
+```
+pending ─► triage_leased ─► triaged ──┬─ closure candidate ─► verify_leased ─► verified ─► closing ─► closed
+                                      │                                   └► refuted/uncertain ─► escalated
+                                      ├─ easy_fix ─► fix_leased ─► fix_pushed ─► pr_open
+                                      ├─ report-only class ─► reported            └► fix failed ─► escalated
+                                      └─ escalation class ─► escalated
+(any stage) ─ lease expiry / malformed output ─► retry (max 2 per stage) ─► failed ─► escalated
+```
+
+Classifications (full definitions in `WORKER_PROMPT.md`):
+
+- **Closure candidates** (cast-iron only): `already-fixed` (close COMPLETED),
+  `obsolete` (close NOT_PLANNED), `duplicate` of another *open* issue (close
+  NOT_PLANNED with cross-link; keep the older/better-specified issue).
+- **`easy-fix`**: isolated, low-risk, no product judgment, no schema/data migration,
+  roughly ≤150 changed lines, tests feasible ⇒ fixer queue.
+- **Report-only**: `needs-work` (real, non-trivial), `question`, `cannot-reproduce`
+  (never auto-closed) ⇒ recorded in campaign report, no GitHub writes.
+- **Escalate**: `needs-product-decision`, `security-sensitive`, `migration-required`,
+  `destructive-action`, `unclear`, plus any closure candidate with recent (≤90 days)
+  human activity or medium/low confidence.
+
+## 5. Rollout
+
+- **Phase 0 — implementation & assumption validation** (Opus): build dispatcher per
+  `DISPATCHER_SPEC.md`, run its dry-run mode, validate assumptions A1–A8 below.
+- **Phase 1 — pilot, 40 issues**: the 40 highest open issue numbers ≤ 12786.
+  Concurrency cap **8** workspaces. GitHub mutations enabled but with per-day caps
+  (≤15 closures, ≤10 PRs). Exit criteria: malformed-output rate <10%, zero bad
+  closures in Opus's spot-check of *every* executed closure and PR, verifier
+  refutation rate understood.
+- **Phase 2 — scale**: cap raised to **16** (higher only with explicit user approval),
+  daily caps raised (≤40 closures, ≤20 PRs), sweep continues descending to #790.
+- **Phase 3 — wrap-up**: final campaign report (per-issue disposition table),
+  escalation digest for bakert, workspaces archived, state mirror finalized.
+
+Throughput estimate: 699 issues ≈ 140 triage + ~100–200 verify/fix workspaces. At cap
+16 and ~15–30 min per workspace, the sweep is multi-day; the constraint will likely be
+Max-plan rate limits (Assumption A1/A8), which the circuit breaker handles by pausing.
+
+## 6. Safeguard summary
+
+| Risk | Safeguard |
+|---|---|
+| Duplicate work | Single dispatcher, exact-number leases, journal, pre-mutation live GitHub check, PR/branch existence check before fixer dispatch |
+| Bad closures | Cast-iron classes only; independent verifier; recent-activity guard; per-day closure cap; every pilot closure spot-checked; closure comments cite evidence so humans can audit; `gh issue reopen` is the documented rollback |
+| Mixed/unrelated PRs | One issue per fixer workspace; branch naming `sweep/<issue>-<slug>`; dispatcher rejects fixer results touching >1 issue or exceeding line budget |
+| Lost state | Event journal + snapshots + off-sandbox mirror + documented full-recovery procedure |
+| Agent exits / stalls | Lease expiry + transcript-staleness detection + bounded retries + fresh-workspace retry |
+| Rate limits | Circuit breaker: pause spawning with exponential backoff (30 min → 4 h), leases frozen during pause |
+| Malformed worker output | Strict fenced-JSON contract; one in-session corrective nudge; one fresh-workspace retry; then escalate |
+| Coordinator death | Idempotent restart from journal (see `DISPATCHER_SPEC.md` §9); sandbox-death recovery from mirror |
+| Runaway spend | Concurrency cap, per-day mutation caps, total-workspace cap (default 500), Opus-approved phase gates |
+| Credential exposure | Dispatcher never echoes env; logs scrub `Authorization|token|key` patterns; worker prompts contain no secrets; state files store ids only |
+| Merges | Nothing in the system ever merges; `merge` is absent from every prompt's allowed actions and the dispatcher has no merge code path |
+
+## 7. Assumptions — status as of 2026-08-25
+
+**RESOLVED by bakert (2026-08-25):**
+
+- **A1 — Subscription billing. ✅ CONFIRMED.** Cloud `claude` workers bill to the
+  Claude Max subscription, not metered Anthropic API. Cleared to scale (rate-limit
+  behavior A8 still needs pilot characterization).
+- **A3 — Frontier & `triage` label. ✅ RESOLVED.** `triage` is auto-applied to all
+  new issues and removed only when humans hand-label area/type. It does NOT mark
+  prior investigation. Frontier stands at #12787: the sweep covers all 699 open
+  issues ≤ #12786 down to #790. The sweep never touches the `triage` label.
+- **A4 — Mutation authority & tone. ✅ APPROVED.** Closures/comments/PRs go out under
+  bakert's gh identity using the templates in `DISPATCHER_SPEC.md` §8.
+- **A5 — State mirror. ✅ DECIDED.** Orphan branch `sweep-state` in the repo (never
+  PRed, never merged). Configure `mirror: {"kind": "branch", "ref": "sweep-state"}`.
+
+**STILL OPEN — Opus MUST validate before Phase 1 (see OPUS_HANDOFF.md §2):**
+
+- **A2 — Worker git push auth.** Fresh cloud workspaces can `git push` branches to
+  origin (Conductor git auth shim). Required by fixers. Validate with a throwaway
+  branch push (then delete the branch).
+- **A6 — Workspace creation semantics.** `conductor workspace create --project-id …`
+  from this sandbox produces a booted *cloud* workspace whose repo is cloned and where
+  `uv run --frozen` works. Validate with one throwaway workspace; measure boot time to
+  tune lease durations.
+- **A7 — Scoped worker API.** Workers' scoped `CONDUCTOR_API_KEY` cannot create
+  workspaces or read other sessions (defense in depth; workers are instructed to never
+  touch the `conductor` CLI regardless).
+- **A8 — Rate-limit behavior.** How Max-plan limits surface (session error state?
+  stalled transcript?) and whether multiple Max accounts are pooled by Conductor.
+  Characterize during the pilot; tune circuit-breaker signatures.
+- **A9 — Manager persistence.** Whether a running background dispatcher process keeps
+  the sandbox alive past the idle timeout, and what survives a sandbox restart.
+  Determines Opus's keep-alive cadence (`OPUS_HANDOFF.md` §6).
+
+## 8. File map
+
+| File | Purpose |
+|---|---|
+| `PLAN.md` | This document |
+| `OPUS_HANDOFF.md` | Exact instructions for the Opus 5 manager |
+| `WORKER_PROMPT.md` | Triage worker contract + structured output |
+| `VERIFIER_PROMPT.md` | Independent closure-verification contract |
+| `FIXER_PROMPT.md` | One-issue implementation contract |
+| `FIXUP_PROMPT.md` | CI remediation contract (follow-up fixer on an existing branch) |
+| `STATE_SCHEMA.md` | Durable state: queue, leases, retries, workspaces, evidence, closures, PRs |
+| `DISPATCHER_SPEC.md` | Deterministic, restartable, zero-token dispatcher spec |

--- a/backlog_sweep/docs/STATE_SCHEMA.md
+++ b/backlog_sweep/docs/STATE_SCHEMA.md
@@ -1,0 +1,229 @@
+# STATE_SCHEMA — Durable Sweep State
+
+> **Historical note (2026-09):** written for the original `.context/backlog-sweep/` layout (code in `bin/`, prompts at the root). The committed layout is `backlog_sweep/` with prompts beside `dispatcher.py` and state in `backlog_sweep/state/` (gitignored). See `../README.md` and `../RUNBOOK.md`.
+
+
+Root: `.context/backlog-sweep/state/` (gitignored via `.context`). The dispatcher is
+the ONLY writer (single-writer enforced by `flock` on `state/.lock`); Opus reads
+freely and mutates only through dispatcher verbs.
+
+```
+state/
+  config.json          # tunables (caps, timeouts, phase)
+  journal.jsonl        # append-only event log — the source of truth
+  snapshot.json        # periodically materialized view of the journal
+  queue.json           # convenience export of snapshot.issues (read-only for humans)
+  metrics.json         # heartbeat + counters, rewritten every tick
+  evidence/<n>.json    # full structured results per issue (triage/verify/fix)
+  escalations/<n>.json # open escalation records (removed on adjudication)
+  reports/             # dispatcher-generated daily reports, Opus prose reports
+  outbox/              # rendered prompt files & pending Opus bundles
+```
+
+All writes are crash-safe: write `f.tmp`, fsync, `rename(f.tmp, f)`. The journal is
+append-only with one JSON object per line; a torn final line is detected (JSON parse
+failure) and truncated on load.
+
+## 1. config.json
+
+```json
+{
+  "schema": 1,
+  "phase": "phase0|pilot|scale|wrapup",
+  "frontier_max": 12786,
+  "frontier_min": 790,
+  "pilot_limit": 40,
+  "concurrency_cap": 8,
+  "daily_close_cap": 15,
+  "daily_pr_cap": 10,
+  "max_open_prs": 30,
+  "max_total_workspaces": 500,
+  "triage_batch_size": 5,
+  "verify_batch_size": 5,
+  "lease_minutes": {"triage": 45, "verify": 45, "fix": 90},
+  "max_stage_attempts": 2,
+  "mutations_enabled": false,
+  "worker_model": "sonnet-4-6",
+  "worker_effort": "high",
+  "project_id": "6da35401-db77-48a7-b9bf-ab9aa3be1a64",
+  "opus_session_id": null,
+  "mirror": {"kind": "branch", "ref": "sweep-state", "interval_minutes": 15},
+  "stale_transcript_minutes": 20,
+  "recent_activity_guard_days": 90,
+  "recent_activity_guard_mode": "comments",
+  "closures_enabled": false,
+  "prs_enabled": true,
+  "spawning_enabled": true,
+  "required_checks": ["mypy", "lint", "test", "jslint"],
+  "ci_recheck_minutes": 5,
+  "auto_update_behind_branches": true,
+  "reclaim_orphan_branches": true,
+  "github_token_file": "state/.gh_token",
+  "max_fixup_attempts": 1
+}
+```
+
+## 2. Issue record (inside snapshot.issues, keyed by issue number as string)
+
+```json
+{
+  "issue": 12781,
+  "title": "…",
+  "labels": ["+ bug", "* decks"],
+  "status": "pending",
+  "stage_attempts": {"triage": 0, "verify": 0, "fix": 0},
+  "lease": null,
+  "class": null,
+  "confidence": null,
+  "verdict": null,
+  "evidence_file": null,
+  "closure": null,
+  "pr": null,
+  "escalation": null,
+  "history": [{"ts": "2026-08-24T00:00:00Z", "event": "ISSUE_ENQUEUED"}],
+  "notes": null
+}
+```
+
+### status values (the state machine)
+
+| status | meaning | next |
+|---|---|---|
+| `pending` | awaiting triage | `triage_leased` |
+| `triage_leased` | assigned to a live triage batch | `triaged`, `pending` (lease expiry, attempts left), `escalated` (attempts exhausted / rejected result) |
+| `triaged` | classified with evidence | `verify_pending` (closure classes), `fix_pending` (easy-fix), `reported`, `escalated` |
+| `verify_pending` | queued for independent verification | `verify_leased` |
+| `verify_leased` | claim in a live verifier batch | `verified` (CONFIRMED), `escalated` (REFUTED/UNCERTAIN), `verify_pending` (expiry, attempts left) |
+| `verified` | cast-iron, cleared to close | `closing` |
+| `closing` | mutation queued/being executed | `closed` (confirmed on GitHub), `escalated` (mutation failed twice) |
+| `closed` | done — closed on GitHub with comment | terminal |
+| `fix_pending` | queued for a fixer workspace | `fix_leased` |
+| `fix_leased` | fixer working | `fix_pushed`, `fix_pending` (expiry, attempts left), `escalated` (abort/failed) |
+| `fix_pushed` | branch validated, PR queued (may be held by `max_open_prs` backpressure) | `pr_open`, `escalated` (validation failed) |
+| `pr_open` | draft PR exists, CI being watched | terminal for the sweep; `pr_ci_failed` if CI goes red, `deferred_human` if a human closes the PR unmerged |
+| `pr_ci_failed` | a Mergify-required check failed, or the branch conflicts with master | `fix_pending` (`queue-fixup`, max 1), `deferred_human` (`abandon-pr`), `escalated`, `pr_open` (recovered) |
+| `reported` | report-only class recorded | terminal |
+| `escalated` | waiting for Opus adjudication | any (via `adjudicate` verb) |
+| `deferred_human` | Opus deferred to bakert digest | terminal for the sweep |
+| `failed` | unrecoverable after retries + adjudication | terminal |
+| `skipped` | closed before we got to it / user-excluded | terminal |
+
+Legality of every transition is enforced in code; illegal transitions raise and
+journal `INVARIANT_VIOLATION` (issue freezes to `escalated`).
+
+### lease object
+
+```json
+{
+  "kind": "triage|verify|fix",
+  "batch_id": "t-12781-1",
+  "workspace_id": "…",
+  "session_id": "…",
+  "granted_at": "…Z",
+  "expires_at": "…Z",
+  "attempt": 1
+}
+```
+
+Expiry checks use dispatcher wall clock vs `expires_at`; a lease may be extended once
+(journal `LEASE_EXTENDED`) if the session transcript is still advancing at expiry.
+
+### closure / pr objects (set when executed)
+
+```json
+"closure": {"reason": "completed|not_planned", "comment_posted": true,
+            "executed_at": "…Z", "verified_by_batch": "v-12781-1",
+            "duplicate_of": null},
+"pr":      {"number": 14990, "branch": "sweep/12781-fix-foo", "head_sha": "…",
+            "opened_at": "…Z", "url": "…", "draft": true,
+            "ci": {"state": "pending|green|failed", "checked_at": "…Z",
+                   "failed": ["mypy"]}},
+"fixup":   {"branch": "sweep/12781-fix-foo", "pr": 14990, "failed": ["mypy"],
+            "attempt": 1, "log_tail": "…"}   // set only by a queue-fixup adjudication
+```
+
+## 3. journal.jsonl events
+
+Every line: `{"ts": "…Z", "seq": 1234, "event": "…", …payload}`. `seq` is strictly
+increasing; snapshot records `last_seq` so replay is `snapshot + journal[seq>last_seq]`.
+
+Events: `CAMPAIGN_INIT`, `ISSUE_ENQUEUED`, `CONFIG_CHANGED`, `LEASE_GRANTED`,
+`LEASE_EXTENDED`, `LEASE_EXPIRED`, `WORKSPACE_CREATED`, `WORKSPACE_ARCHIVED`,
+`WORKSPACE_FAILED`, `WORKSPACE_HARVESTED`, `RESULT_RECORDED`, `RESULT_REJECTED`, `RESULT_MALFORMED`,
+`NUDGE_SENT`, `RETRY_SCHEDULED`, `VERIFY_RECORDED`, `MUTATION_PLANNED`,
+`CLOSE_EXECUTED`, `PR_OPENED`, `PR_CI_GREEN`, `PR_CI_FAILED`, `CI_CHECKED`,
+`FIXUP_DISPATCHED`, `PR_MERGED`, `PR_WITHDRAWN`, `PR_CONFLICT`,
+`PR_BRANCH_UPDATED`, `PR_BACKPRESSURE_ON`, `PR_BACKPRESSURE_OFF`, `MASTER_ADVANCED`,
+`MUTATION_FAILED`, `ESCALATED`, `ADJUDICATED`, `ISSUE_SKIPPED`,
+`PAUSE_ON`, `PAUSE_OFF`, `SNAPSHOT_WRITTEN`, `MIRROR_PUSHED`, `INVARIANT_VIOLATION`,
+`ROLLBACK_RECORDED` (manual Opus rollback of a mutation).
+
+The journal, not the snapshot, is authoritative: replay must be deterministic and
+idempotent (applying the same event twice is a no-op keyed on `seq`).
+
+## 4. workspaces registry (snapshot.workspaces, keyed by workspace_id)
+
+```json
+{
+  "workspace_id": "…",
+  "session_id": "…",
+  "kind": "triage|verify|fix|canary",
+  "batch_id": "t-12781-1",
+  "issues": [12781, 12779, 12775, 12770, 12766],
+  "state": "creating|running|nudged|harvested|archived|failed",
+  // `harvested` = results recorded but the archive has not been CONFIRMED yet
+  "created_at": "…Z",
+  "last_transcript_at": "…Z",
+  "harvest": {"parsed": true, "malformed_attempts": 0}
+}
+```
+
+## 5. evidence/<n>.json
+
+Accumulates the full structured outputs for one issue — the audit trail behind any
+mutation:
+
+```json
+{
+  "issue": 12781,
+  "triage": [ {…full triage result object, "batch_id": "t-12781-1", "recorded_at": "…"} ],
+  "verify": [ {…full verifier result object…} ],
+  "fix":    [ {…full fixer result object…} ]
+}
+```
+
+Arrays because retries append. Mutations always cite the exact array entries they
+relied on (via batch_id).
+
+## 6. escalations/<n>.json
+
+```json
+{
+  "issue": 12781,
+  "created_at": "…Z",
+  "kind": "verifier-refuted|verifier-uncertain|attempts-exhausted|fix-abort|fix-validation|pr-ci-failed|pr-conflict|mutation-failed|class-escalate|malformed|invariant",
+  "question": "one sentence: what Opus must decide",
+  "summary": "<=5 lines of context",
+  "evidence_refs": ["evidence/12781.json#triage[0]"],
+  "bundled_at": null,
+  "adjudication": null
+}
+```
+
+Sent to Opus in bundles (DISPATCHER_SPEC §10); `adjudication` is filled by the
+`adjudicate` verb and the file then moves into the journal + evidence trail.
+
+## 7. Mirroring & recovery
+
+- Every `mirror.interval_minutes` (default 15) and on clean shutdown, the dispatcher
+  copies `journal.jsonl`, `snapshot.json`, `config.json`, `evidence/`, and
+  `escalations/` into a git worktree of the orphan `sweep-state` branch (or a gist
+  tarball, per config) and pushes. Journal is append-only ⇒ pushes are fast-forward;
+  on conflict (two managers — should never happen) the dispatcher STOPS and
+  escalates rather than force-pushing.
+- **Recovery invariant**: everything except ≤15 min of bookkeeping is reconstructible
+  from (mirror) ∪ (live GitHub: issue states, comments, branches, PRs) ∪
+  (`conductor workspace list` / `session status` / `conductor sql` transcripts).
+  `dispatcher.py recover` (DISPATCHER_SPEC §9) performs this reconciliation.
+- The mirror never contains credentials, transcripts, or env values — only the state
+  files above, which store ids, SHAs, and issue numbers.

--- a/backlog_sweep/test_dispatcher.py
+++ b/backlog_sweep/test_dispatcher.py
@@ -1,0 +1,1107 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure parts of dispatcher.py.
+
+Run:  python3 -m unittest discover -s .context/backlog-sweep/bin -t .context/backlog-sweep/bin
+(Do NOT use the repo's pytest config; its coverage addopts point at the repo.)
+"""
+
+import datetime as dt
+import json
+import re
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import dispatcher as D  # noqa: E402
+
+BASE = Path(__file__).resolve().parent
+
+
+_LOG_SANDBOX = {}
+
+
+def setUpModule():
+    """Nothing in this module may touch the live state dir or dispatcher.log.
+
+    Engine helpers call log() freely; fixture PR numbers landing in the real log
+    have twice looked like production events during this campaign.
+    """
+    _LOG_SANDBOX["dir"] = tempfile.mkdtemp()
+    _LOG_SANDBOX["saved"] = (D.LOGFILE, D.STATE)
+    D.STATE = Path(_LOG_SANDBOX["dir"])
+    D.LOGFILE = Path(_LOG_SANDBOX["dir"]) / "test-dispatcher.log"
+
+
+def tearDownModule():
+    D.LOGFILE, D.STATE = _LOG_SANDBOX["saved"]
+    shutil.rmtree(_LOG_SANDBOX["dir"], ignore_errors=True)
+
+
+def ev(seq, event, **kw):
+    d = {"ts": kw.pop("ts", "2026-08-24T00:00:%02dZ" % min(seq, 59)), "seq": seq, "event": event}
+    d.update(kw)
+    return d
+
+
+class TestJsonExtraction(unittest.TestCase):
+    def blob(self, issue=12781, role="triage", batch="t-12781-1"):
+        return json.dumps({
+            "backlog_sweep": "v1", "role": role, "batch_id": batch,
+            "results": [{"issue": issue, "class": "already-fixed", "confidence": "high"}],
+        })
+
+    def test_simple_fenced(self):
+        text = "Some prose.\n\n```json\n%s\n```\n" % self.blob()
+        got = D.extract_json_block(text, role="triage", batch_id="t-12781-1")
+        self.assertEqual(got["results"][0]["issue"], 12781)
+
+    def test_takes_the_last_block(self):
+        text = ("```json\n%s\n```\nthen I revised it\n```json\n%s\n```"
+                % (self.blob(issue=1), self.blob(issue=999)))
+        got = D.extract_json_block(text, role="triage", batch_id="t-12781-1")
+        self.assertEqual(got["results"][0]["issue"], 999)
+
+    def test_unfenced_fallback(self):
+        got = D.extract_json_block("here is the result: " + self.blob())
+        self.assertEqual(got["role"], "triage")
+
+    def test_bare_fence_without_language(self):
+        text = "```\n%s\n```" % self.blob()
+        self.assertIsNotNone(D.extract_json_block(text, role="triage", batch_id="t-12781-1"))
+
+    def test_role_mismatch_still_returns_shaped_block(self):
+        text = "```json\n%s\n```" % self.blob(role="verify")
+        got = D.extract_json_block(text, role="triage", batch_id="t-12781-1")
+        self.assertEqual(got["role"], "verify")  # surfaced, caller rejects on role
+
+    def test_no_json_at_all(self):
+        self.assertIsNone(D.extract_json_block("I could not finish, sorry."))
+
+    def test_malformed_json_ignored(self):
+        self.assertIsNone(D.extract_json_block("```json\n{\"backlog_sweep\": \"v1\",,,}\n```"))
+
+    def test_prose_braces_do_not_match(self):
+        self.assertIsNone(D.extract_json_block("the dict {a: 1} is not json"))
+
+    def test_json_containing_braces_in_strings(self):
+        payload = {"backlog_sweep": "v1", "role": "fix", "batch_id": "f-1-1",
+                   "results": [{"issue": 1, "notes": 'uses {"a": "}"} in a string'}]}
+        text = "```json\n%s\n```" % json.dumps(payload)
+        got = D.extract_json_block(text, role="fix", batch_id="f-1-1")
+        self.assertEqual(got["results"][0]["issue"], 1)
+
+
+class TestRendering(unittest.TestCase):
+    def test_closure_comment_appends_tag_once(self):
+        out = D.render_closure_comment("  Fixed in abc1234.  ")
+        self.assertTrue(out.startswith("Fixed in abc1234."))
+        self.assertEqual(out.count("Automated backlog sweep"), 1)
+        self.assertIn("Please reopen", out)
+
+    def test_closure_comment_handles_none(self):
+        self.assertTrue(D.render_closure_comment(None).startswith("\n\n<sub>"))
+
+    def test_render_claims_hides_triage_reasoning(self):
+        claims = [{"issue": 12781, "title": 'Broken "thing"', "class": "duplicate",
+                   "duplicate_of": 12000, "proposed_comment": "Dupe of #12000.",
+                   "evidence": [{"type": "issue", "ref": "#12000", "detail": "same request"}],
+                   "notes": "SECRET TRIAGE REASONING"}]
+        out = D.render_claims(claims)
+        self.assertIn("duplicate of #12000 (close NOT_PLANNED)", out)
+        self.assertIn("issue #12000", out)
+        self.assertNotIn("SECRET TRIAGE REASONING", out)
+
+    def test_render_claims_class_wording(self):
+        self.assertIn("already-fixed (close COMPLETED)",
+                      D.render_claims([{"issue": 1, "title": "t", "class": "already-fixed"}]))
+        self.assertIn("obsolete (close NOT_PLANNED)",
+                      D.render_claims([{"issue": 1, "title": "t", "class": "obsolete"}]))
+
+    def test_worker_template_substitutes(self):
+        out = D.render_template(BASE / "WORKER_PROMPT.md",
+                                {"ISSUE_NUMBERS": "#1, #2", "BATCH_ID": "t-1-1"})
+        self.assertIn("#1, #2", out)
+        self.assertIn("t-1-1", out)
+        self.assertNotIn("{{", out)
+        self.assertNotIn("TEMPLATE START", out)
+
+    def test_verifier_template_substitutes(self):
+        out = D.render_template(BASE / "VERIFIER_PROMPT.md",
+                                {"BATCH_ID": "v-1-1", "CLAIMS": "- issue: #1",
+                                 "PROPOSED_COMMENT": "x"})
+        self.assertNotIn("{{", out)
+
+    def test_fixer_template_substitutes(self):
+        out = D.render_template(BASE / "FIXER_PROMPT.md",
+                                {"ISSUE": 1, "TITLE": "t", "BATCH_ID": "f-1-1",
+                                 "FIX_SKETCH": "s", "BRANCH": "sweep/1-t"})
+        self.assertNotIn("{{", out)
+
+    def test_unsubstituted_placeholder_raises(self):
+        with self.assertRaises(RuntimeError):
+            D.render_template(BASE / "WORKER_PROMPT.md", {"BATCH_ID": "t-1-1"})
+
+    def test_slugify(self):
+        self.assertEqual(D.slugify("Fix the Thing!  (again)"), "fix-the-thing-again")
+        self.assertEqual(D.slugify(""), "issue")
+        self.assertLessEqual(len(D.slugify("x" * 100)), 40)
+
+
+class TestLeases(unittest.TestCase):
+    def test_expiry(self):
+        now = D.parse_iso("2026-08-24T12:00:00Z")
+        self.assertTrue(D.lease_is_expired({"expires_at": "2026-08-24T11:59:59Z"}, now))
+        self.assertFalse(D.lease_is_expired({"expires_at": "2026-08-24T12:00:01Z"}, now))
+
+    def test_pause_freezes_the_clock(self):
+        now = D.parse_iso("2026-08-24T12:00:00Z")
+        lease = {"expires_at": "2026-08-24T11:30:00Z"}
+        self.assertTrue(D.lease_is_expired(lease, now))
+        self.assertFalse(D.lease_is_expired(lease, now, pause_seconds=3600))
+
+    def test_missing_expiry_counts_as_expired(self):
+        self.assertTrue(D.lease_is_expired({}, D.utcnow()))
+
+    def test_eligible_respects_pilot_limit(self):
+        issues = {str(n): {} for n in range(100, 140)}
+        self.assertEqual(D.eligible_issue_numbers(issues, 5), [139, 138, 137, 136, 135])
+        self.assertEqual(len(D.eligible_issue_numbers(issues, 0)), 40)
+
+
+class TestReplay(unittest.TestCase):
+    def state_with_issue(self, n=12781):
+        s = D.State()
+        s.apply(ev(1, "CAMPAIGN_INIT"))
+        s.apply(ev(2, "ISSUE_ENQUEUED", issue=n, title="t", labels=["+ bug"]))
+        return s
+
+    def test_enqueue(self):
+        s = self.state_with_issue()
+        self.assertEqual(s.issue(12781)["status"], "pending")
+        self.assertEqual(s.last_seq, 2)
+
+    def test_seq_replay_is_idempotent(self):
+        s = self.state_with_issue()
+        s.apply(ev(2, "ISSUE_ENQUEUED", issue=999, title="dup", labels=[]))
+        self.assertIsNone(s.issue(999))
+
+    def test_full_happy_path_to_closed(self):
+        s = self.state_with_issue()
+        s.apply(ev(3, "WORKSPACE_CREATED", workspace_id="w1", session_id="s1", kind="triage",
+                   batch_id="t-12781-1", issues=[12781]))
+        s.apply(ev(4, "LEASE_GRANTED", issue=12781, kind="triage", batch_id="t-12781-1",
+                   workspace_id="w1", session_id="s1", expires_at="2026-08-24T01:00:00Z"))
+        self.assertEqual(s.issue(12781)["status"], "triage_leased")
+        s.apply(ev(5, "RESULT_RECORDED", issue=12781, kind="triage", batch_id="t-12781-1",
+                   status="triaged", **{"class": "already-fixed", "confidence": "high"}))
+        s.apply(ev(6, "RESULT_RECORDED", issue=12781, kind="triage", batch_id="t-12781-1",
+                   status="verify_pending", **{"class": "already-fixed"}))
+        s.apply(ev(7, "LEASE_GRANTED", issue=12781, kind="verify", batch_id="v-12781-1",
+                   workspace_id="w2", session_id="s2", expires_at="2026-08-24T02:00:00Z"))
+        s.apply(ev(8, "RESULT_RECORDED", issue=12781, kind="verify", batch_id="v-12781-1",
+                   verdict="CONFIRMED", status="verified"))
+        s.apply(ev(9, "MUTATION_PLANNED", issue=12781, kind="close"))
+        self.assertEqual(s.issue(12781)["status"], "closing")
+        s.apply(ev(10, "CLOSE_EXECUTED", issue=12781, reason="completed", comment_posted=True))
+        rec = s.issue(12781)
+        self.assertEqual(rec["status"], "closed")
+        self.assertEqual(rec["closure"]["reason"], "completed")
+        self.assertEqual(s.daily["closures"], 1)
+
+    def test_external_close_does_not_count_against_the_cap(self):
+        s = self.state_with_issue()
+        s.apply(ev(3, "RESULT_RECORDED", issue=12781, kind="triage", status="triaged",
+                   **{"class": "obsolete"}))
+        s.apply(ev(4, "RESULT_RECORDED", issue=12781, kind="triage", status="verify_pending"))
+        s.apply(ev(5, "RESULT_RECORDED", issue=12781, kind="verify", verdict="CONFIRMED",
+                   status="verified"))
+        s.apply(ev(6, "CLOSE_EXECUTED", issue=12781, reason="not_planned", external=True))
+        self.assertEqual(s.daily["closures"], 0)
+        self.assertEqual(s.issue(12781)["status"], "closed")
+
+    def test_daily_counters_roll_over_at_midnight(self):
+        s = self.state_with_issue()
+        s.apply(ev(3, "RESULT_RECORDED", issue=12781, kind="triage", status="triaged",
+                   **{"class": "obsolete"}))
+        s.apply(ev(4, "RESULT_RECORDED", issue=12781, kind="triage", status="verify_pending"))
+        s.apply(ev(5, "RESULT_RECORDED", issue=12781, kind="verify", verdict="CONFIRMED",
+                   status="verified"))
+        s.apply(ev(6, "CLOSE_EXECUTED", issue=12781, reason="not_planned", ts="2026-08-24T23:59:00Z"))
+        self.assertEqual(s.daily, {"day": "2026-08-24", "closures": 1, "prs": 0})
+        s.apply(ev(7, "ISSUE_ENQUEUED", issue=12780, title="t2", labels=[]))
+        s.apply(ev(8, "RESULT_RECORDED", issue=12780, kind="triage", status="triaged",
+                   **{"class": "easy-fix"}))
+        s.apply(ev(9, "RESULT_RECORDED", issue=12780, kind="triage", status="fix_pending"))
+        s.apply(ev(10, "LEASE_GRANTED", issue=12780, kind="fix", batch_id="f-12780-1",
+                   expires_at="2026-08-25T02:00:00Z"))
+        s.apply(ev(11, "RESULT_RECORDED", issue=12780, kind="fix", status="fix_pushed",
+                   pr_branch="sweep/12780-t2", head_sha="abc1234"))
+        s.apply(ev(12, "PR_OPENED", issue=12780, number=1, branch="sweep/12780-t2",
+                   ts="2026-08-25T00:01:00Z"))
+        self.assertEqual(s.issue(12780)["status"], "pr_open")
+        self.assertEqual(s.daily, {"day": "2026-08-25", "closures": 0, "prs": 1})
+
+    def test_lease_expiry_increments_attempts(self):
+        s = self.state_with_issue()
+        s.apply(ev(3, "LEASE_GRANTED", issue=12781, kind="triage", batch_id="t-12781-1",
+                   expires_at="2026-08-24T01:00:00Z"))
+        s.apply(ev(4, "LEASE_EXPIRED", issue=12781, kind="triage", batch_id="t-12781-1"))
+        s.apply(ev(5, "RETRY_SCHEDULED", issue=12781, kind="triage", status="pending"))
+        rec = s.issue(12781)
+        self.assertEqual(rec["stage_attempts"]["triage"], 1)
+        self.assertEqual(rec["status"], "pending")
+        self.assertIsNone(rec["lease"])
+
+    def test_illegal_transition_freezes_to_escalated(self):
+        s = self.state_with_issue()
+        s.apply(ev(3, "CLOSE_EXECUTED", issue=12781, reason="completed"))
+        rec = s.issue(12781)
+        self.assertEqual(rec["status"], "escalated")
+        self.assertEqual(rec["escalation"]["kind"], "invariant")
+        self.assertEqual(len(s.invariants), 1)
+        self.assertEqual(s.daily["closures"], 0)
+
+    def test_adjudication_moves_out_of_escalated(self):
+        s = self.state_with_issue()
+        s.apply(ev(3, "ESCALATED", issue=12781, kind="verifier-uncertain", question="q"))
+        s.apply(ev(4, "ADJUDICATED", issue=12781, verb="report-only", status="reported", note="n"))
+        rec = s.issue(12781)
+        self.assertEqual(rec["status"], "reported")
+        self.assertIsNone(rec["escalation"])
+
+    def test_pause_accumulates_frozen_time(self):
+        s = D.State()
+        s.apply(ev(1, "PAUSE_ON", until="2026-08-24T01:00:00Z", level=1,
+                   since="2026-08-24T00:00:00Z"))
+        self.assertTrue(s.paused)
+        s.apply(ev(2, "PAUSE_OFF", since="2026-08-24T00:00:00Z", ts="2026-08-24T00:30:00Z"))
+        self.assertFalse(s.paused)
+        self.assertEqual(s.pause_seconds, 1800)
+
+    def test_workspace_lifecycle(self):
+        s = self.state_with_issue()
+        s.apply(ev(3, "WORKSPACE_CREATED", workspace_id="w1", session_id="s1", kind="triage",
+                   batch_id="t-12781-1", issues=[12781]))
+        self.assertEqual(s.counters["workspaces_created"], 1)
+        s.apply(ev(4, "NUDGE_SENT", workspace_id="w1", batch_id="t-12781-1"))
+        self.assertEqual(s.workspaces["w1"]["state"], "nudged")
+        self.assertEqual(s.workspaces["w1"]["harvest"]["malformed_attempts"], 1)
+        s.apply(ev(5, "WORKSPACE_ARCHIVED", workspace_id="w1"))
+        self.assertEqual(s.workspaces["w1"]["state"], "archived")
+
+
+class TestScrubber(unittest.TestCase):
+    def test_env_values_blanked(self):
+        sc = D.Scrubber({"CONDUCTOR_API_KEY": "sk-abcdefghijklmnop", "GH_TOKEN": "ghu_12345678"})
+        self.assertNotIn("sk-abcdefghijklmnop", sc("using sk-abcdefghijklmnop now"))
+        self.assertIn("[REDACTED]", sc("using ghu_12345678 now"))
+
+    def test_pattern_scrub(self):
+        sc = D.Scrubber({})
+        self.assertNotIn("hunter2", sc("Authorization: hunter2"))
+        self.assertNotIn("abc123", sc("token=abc123"))
+
+    def test_short_values_are_not_used(self):
+        sc = D.Scrubber({"GH_TOKEN": "abc"})
+        self.assertEqual(sc("abcdef"), "abcdef")
+
+
+class TestStoreRoundTrip(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.saved = {k: getattr(D, k) for k in
+                      ("STATE", "EVIDENCE", "ESCALATIONS", "REPORTS", "OUTBOX", "LOCKFILE",
+                       "JOURNAL", "SNAPSHOT", "CONFIG", "QUEUE", "METRICS", "LOGFILE")}
+        D.STATE = self.tmp
+        D.EVIDENCE, D.ESCALATIONS = self.tmp / "evidence", self.tmp / "escalations"
+        D.REPORTS, D.OUTBOX = self.tmp / "reports", self.tmp / "outbox"
+        D.LOCKFILE, D.JOURNAL = self.tmp / ".lock", self.tmp / "journal.jsonl"
+        D.SNAPSHOT, D.CONFIG = self.tmp / "snapshot.json", self.tmp / "config.json"
+        D.QUEUE, D.METRICS = self.tmp / "queue.json", self.tmp / "metrics.json"
+        D.LOGFILE = self.tmp / "dispatcher.log"
+
+    def tearDown(self):
+        for k, v in self.saved.items():
+            setattr(D, k, v)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_journal_survives_a_restart(self):
+        s = D.Store()
+        s.journal("ISSUE_ENQUEUED", issue=1, title="a", labels=[])
+        s.journal("ISSUE_ENQUEUED", issue=2, title="b", labels=[])
+        s.snapshot()
+        s.journal("ESCALATED", issue=2, kind="unclear", question="q")
+        s.close()
+        s2 = D.Store()
+        self.assertEqual(s2.state.issue(1)["status"], "pending")
+        self.assertEqual(s2.state.issue(2)["status"], "escalated")
+        s2.close()
+
+    def test_torn_tail_line_is_truncated(self):
+        s = D.Store()
+        s.journal("ISSUE_ENQUEUED", issue=1, title="a", labels=[])
+        s.close()
+        with open(D.JOURNAL, "a") as fh:
+            fh.write('{"ts": "2026', )
+        s2 = D.Store()
+        self.assertEqual(len(s2.state.issues), 1)
+        s2.close()
+
+    def test_lock_is_exclusive(self):
+        s = D.Store()
+        with self.assertRaises(SystemExit) as cm:
+            D.Store()
+        self.assertEqual(cm.exception.code, 75)
+        s.close()
+
+    def test_snapshot_replay_equivalence(self):
+        s = D.Store()
+        for i in range(5):
+            s.journal("ISSUE_ENQUEUED", issue=100 + i, title="t%d" % i, labels=[])
+        s.journal("RESULT_RECORDED", issue=104, kind="triage", status="triaged",
+                  **{"class": "needs-work"})
+        s.journal("RESULT_RECORDED", issue=104, kind="triage", status="reported")
+        before = json.dumps(s.state.to_dict(), sort_keys=True)
+        s.snapshot()
+        s.close()
+        s2 = D.Store()
+        after = json.dumps(s2.state.to_dict(), sort_keys=True)
+        s2.close()
+        b, a = json.loads(before), json.loads(after)
+        self.assertEqual(b["issues"], a["issues"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+
+
+class TestStaleness(unittest.TestCase):
+    """The hung-worker detector must not kill slow-booting workspaces."""
+
+    class FakeEngine:
+        cfg = {"stale_transcript_minutes": 20}
+        is_stale = None  # bound below
+
+    def stale(self, created_min_ago, transcript_min_ago=None):
+        now = D.utcnow()
+        ws = {"created_at": D.iso(now - dt.timedelta(minutes=created_min_ago)),
+              "last_transcript_at": None if transcript_min_ago is None
+              else D.iso(now - dt.timedelta(minutes=transcript_min_ago))}
+        eng = self.FakeEngine()
+        return D.Engine.is_stale(eng, ws)
+
+    def test_young_workspace_with_no_transcript_is_not_stale(self):
+        self.assertFalse(self.stale(created_min_ago=5))
+
+    def test_old_workspace_with_no_transcript_is_stale(self):
+        self.assertTrue(self.stale(created_min_ago=25))
+
+    def test_recent_transcript_beats_old_creation(self):
+        self.assertFalse(self.stale(created_min_ago=90, transcript_min_ago=2))
+
+    def test_old_transcript_is_stale(self):
+        self.assertTrue(self.stale(created_min_ago=90, transcript_min_ago=30))
+
+    def test_unparseable_timestamps_are_never_stale(self):
+        eng = self.FakeEngine()
+        self.assertFalse(D.Engine.is_stale(eng, {"created_at": None, "last_transcript_at": None}))
+
+
+class TestPermissionDetection(unittest.TestCase):
+    """`gh issue close` exits 0 while printing a GraphQL permission error."""
+
+    def test_graphql_permission_error_detected(self):
+        self.assertTrue(D.PERMISSION_RE.search(
+            "GraphQL: Resource not accessible by integration (addComment)"))
+
+    def test_http_403_detected(self):
+        self.assertTrue(D.PERMISSION_RE.search("gh: Forbidden (HTTP 403)"))
+
+    def test_ordinary_failure_not_treated_as_permission(self):
+        self.assertIsNone(D.PERMISSION_RE.search("could not resolve to an Issue with number 999"))
+
+    def test_escalated_can_return_to_verified(self):
+        s = D.State()
+        s.apply(ev(1, "ISSUE_ENQUEUED", issue=1, title="t", labels=[]))
+        s.apply(ev(2, "LEASE_GRANTED", issue=1, kind="triage", batch_id="t-1-1",
+                   expires_at="2026-08-24T01:00:00Z"))
+        s.apply(ev(3, "RESULT_RECORDED", issue=1, kind="triage", status="triaged",
+                   **{"class": "already-fixed"}))
+        s.apply(ev(4, "RESULT_RECORDED", issue=1, kind="triage", status="verify_pending"))
+        s.apply(ev(5, "LEASE_GRANTED", issue=1, kind="verify", batch_id="v-1-1",
+                   expires_at="2026-08-24T02:00:00Z"))
+        s.apply(ev(6, "RESULT_RECORDED", issue=1, kind="verify", verdict="CONFIRMED",
+                   status="verified"))
+        s.apply(ev(7, "MUTATION_PLANNED", issue=1, kind="close"))
+        s.apply(ev(8, "ROLLBACK_RECORDED", issue=1, status="verified",
+                   action="closure blocked by token permissions"))
+        self.assertEqual(s.issue(1)["status"], "verified")
+        self.assertEqual(s.daily["closures"], 0)
+        self.assertEqual(len(s.invariants), 0)
+
+
+class TestDraftPolicy(unittest.TestCase):
+    """Draft is the merge brake for this campaign; assert the wiring can't regress."""
+
+    def test_create_pr_passes_draft_flag(self):
+        seen = {}
+
+        class R:
+            def run(self, argv, **kw):
+                seen["argv"] = argv
+                return "https://github.com/o/r/pull/123\n"
+
+        gh = D.GitHub(R(), "o/r")
+        gh.create_pr("sweep/1-x", "t", "/tmp/body.md")
+        self.assertIn("--draft", seen["argv"])
+        self.assertNotIn("--web", seen["argv"])
+
+    def test_pr_url_and_number_parsed_together(self):
+        m = re.search(r"(https://\S+/pull/(\d+))",
+                      "Creating pull request...\nhttps://github.com/o/r/pull/14943\n")
+        self.assertEqual(m.group(2), "14943")
+        self.assertEqual(m.group(1), "https://github.com/o/r/pull/14943")
+
+    def test_missing_pr_url_yields_no_number(self):
+        self.assertIsNone(re.search(r"(https://\S+/pull/(\d+))", "gh: something went wrong"))
+
+    def test_pr_is_draft_reads_the_field(self):
+        class R:
+            def __init__(self, val):
+                self.val = val
+
+            def run(self, argv, **kw):
+                return json.dumps({"isDraft": self.val})
+
+        self.assertTrue(D.GitHub(R(True), "o/r").pr_is_draft(1))
+        self.assertFalse(D.GitHub(R(False), "o/r").pr_is_draft(1))
+
+
+class TestCiWatch(unittest.TestCase):
+    REQ = ["mypy", "lint", "test", "jslint"]
+
+    def rows(self, *pairs):
+        return [{"name": n, "bucket": b, "state": b.upper()} for n, b in pairs]
+
+    def test_all_pass(self):
+        v = D.Engine.summarize_checks(
+            self.rows(("mypy", "pass"), ("lint", "pass"), ("test", "pass"), ("jslint", "pass")),
+            self.REQ)
+        self.assertTrue(all(x == "pass" for x in v.values()))
+
+    def test_duplicate_runs_one_failing_means_fail(self):
+        v = D.Engine.summarize_checks(
+            self.rows(("test", "pass"), ("test", "fail"), ("mypy", "pass"),
+                      ("lint", "pass"), ("jslint", "pass")), self.REQ)
+        self.assertEqual(v["test"], "fail")
+
+    def test_missing_check_is_pending_not_pass(self):
+        v = D.Engine.summarize_checks(self.rows(("mypy", "pass")), self.REQ)
+        self.assertEqual(v["mypy"], "pass")
+        self.assertEqual(v["lint"], "pending")
+
+    def test_in_progress_is_pending(self):
+        v = D.Engine.summarize_checks(
+            self.rows(("mypy", "pending"), ("lint", "pass"), ("test", "pass"), ("jslint", "pass")),
+            self.REQ)
+        self.assertEqual(v["mypy"], "pending")
+
+    def test_cancelled_counts_as_failure(self):
+        v = D.Engine.summarize_checks(self.rows(("test", "cancel")), self.REQ)
+        self.assertEqual(v["test"], "fail")
+
+    def test_skipped_counts_as_pass(self):
+        v = D.Engine.summarize_checks(self.rows(("jslint", "skipping")), self.REQ)
+        self.assertEqual(v["jslint"], "pass")
+
+    def test_unrelated_checks_ignored(self):
+        v = D.Engine.summarize_checks(
+            self.rows(("CodeQL", "fail"), ("mypy", "pass"), ("lint", "pass"),
+                      ("test", "pass"), ("jslint", "pass")), self.REQ)
+        self.assertTrue(all(x == "pass" for x in v.values()))
+
+    def test_ci_status_transitions(self):
+        s = D.State()
+        s.apply(ev(1, "ISSUE_ENQUEUED", issue=7, title="t", labels=[]))
+        s.apply(ev(2, "LEASE_GRANTED", issue=7, kind="triage", batch_id="t-7-1",
+                   expires_at="2026-08-24T01:00:00Z"))
+        s.apply(ev(3, "RESULT_RECORDED", issue=7, kind="triage", status="triaged",
+                   **{"class": "easy-fix"}))
+        s.apply(ev(4, "RESULT_RECORDED", issue=7, kind="triage", status="fix_pending"))
+        s.apply(ev(5, "LEASE_GRANTED", issue=7, kind="fix", batch_id="f-7-1",
+                   expires_at="2026-08-24T02:00:00Z"))
+        s.apply(ev(6, "RESULT_RECORDED", issue=7, kind="fix", status="fix_pushed",
+                   pr_branch="sweep/7-t", head_sha="abc"))
+        s.apply(ev(7, "PR_OPENED", issue=7, number=99, branch="sweep/7-t", head_sha="abc"))
+        s.apply(ev(8, "PR_CI_GREEN", issue=7, pr=99))
+        self.assertEqual(s.issue(7)["status"], "pr_open")
+        self.assertEqual(s.issue(7)["pr"]["ci"]["state"], "green")
+        s.apply(ev(9, "PR_CI_FAILED", issue=7, pr=99, failed=["mypy"]))
+        self.assertEqual(s.issue(7)["status"], "pr_ci_failed")
+        s.apply(ev(10, "FIXUP_DISPATCHED", issue=7, branch="sweep/7-t", pr=99,
+                   failed=["mypy"], attempt=1))
+        self.assertEqual(s.issue(7)["status"], "fix_pending")
+        self.assertEqual(s.issue(7)["fixup"]["attempt"], 1)
+
+    def test_fixup_bypasses_the_branch_guard(self):
+        class E:
+            fix_guards = D.Engine.fix_guards
+        self.assertEqual(D.Engine.fix_guards(E(), {"issue": 7, "fixup": {"branch": "sweep/7-t"}}),
+                         (True, ""))
+
+    def test_fixup_batch_id_is_distinct(self):
+        self.assertNotEqual("u-7-1", "f-7-1")
+
+
+class TestFixupTemplate(unittest.TestCase):
+    def render(self, problem, detail):
+        return D.render_template(BASE / "FIXUP_PROMPT.md", {
+            "ISSUE": 7, "TITLE": "t", "BATCH_ID": "u-7-1", "BRANCH": "sweep/7-t",
+            "PR": 99, "PROBLEM": problem, "DETAIL": detail})
+
+    def test_renders_and_forbids_ready_for_review(self):
+        out = self.render("these required checks are failing: mypy", "error: bad type")
+        self.assertNotIn("{{", out)
+        self.assertIn("sweep/7-t", out)
+        self.assertIn("error: bad type", out)
+        self.assertIn("must stay a draft", out)
+        self.assertIn("never force-push", out)
+
+    def test_conflict_variant_says_merge_not_rebase(self):
+        out = self.render("the branch conflicts with master and cannot be merged", "DIRTY")
+        self.assertIn("git merge origin/master", out)
+        self.assertIn("Do NOT rebase and do NOT force-push", out)
+
+
+class TestPrSettlement(unittest.TestCase):
+    def pr_open_state(self):
+        s = D.State()
+        s.apply(ev(1, "ISSUE_ENQUEUED", issue=7, title="t", labels=[]))
+        s.apply(ev(2, "LEASE_GRANTED", issue=7, kind="triage", batch_id="t-7-1",
+                   expires_at="2026-08-24T01:00:00Z"))
+        s.apply(ev(3, "RESULT_RECORDED", issue=7, kind="triage", status="triaged",
+                   **{"class": "easy-fix"}))
+        s.apply(ev(4, "RESULT_RECORDED", issue=7, kind="triage", status="fix_pending"))
+        s.apply(ev(5, "LEASE_GRANTED", issue=7, kind="fix", batch_id="f-7-1",
+                   expires_at="2026-08-24T02:00:00Z"))
+        s.apply(ev(6, "RESULT_RECORDED", issue=7, kind="fix", status="fix_pushed",
+                   pr_branch="sweep/7-t", head_sha="abc"))
+        s.apply(ev(7, "PR_OPENED", issue=7, number=99, branch="sweep/7-t", head_sha="abc"))
+        return s
+
+    def test_withdrawn_pr_settles_the_issue(self):
+        s = self.pr_open_state()
+        s.apply(ev(8, "PR_WITHDRAWN", issue=7, pr=99, branch="sweep/7-t", branch_deleted=True))
+        rec = s.issue(7)
+        self.assertEqual(rec["status"], "deferred_human")
+        self.assertTrue(rec["pr"]["branch_deleted"])
+        self.assertIn("without merging", rec["notes"])
+        self.assertEqual(len(s.invariants), 0)
+
+    def test_withdrawn_is_terminal_no_retry(self):
+        s = self.pr_open_state()
+        s.apply(ev(8, "PR_WITHDRAWN", issue=7, pr=99, branch="sweep/7-t"))
+        s.apply(ev(9, "RETRY_SCHEDULED", issue=7, kind="fix", status="fix_pending"))
+        self.assertEqual(s.issue(7)["status"], "escalated")  # frozen, never re-fixed
+
+    def test_withdrawn_from_red_pr_also_settles(self):
+        s = self.pr_open_state()
+        s.apply(ev(8, "PR_CI_FAILED", issue=7, pr=99, failed=["test"]))
+        s.apply(ev(9, "PR_WITHDRAWN", issue=7, pr=99, branch="sweep/7-t"))
+        self.assertEqual(s.issue(7)["status"], "deferred_human")
+
+    def test_merged_pr_stops_polling_but_stays_pr_open(self):
+        s = self.pr_open_state()
+        s.apply(ev(8, "PR_MERGED", issue=7, pr=99, merged_at="2026-08-23T21:55:28Z"))
+        rec = s.issue(7)
+        self.assertEqual(rec["status"], "pr_open")
+        self.assertEqual(rec["pr"]["ci"]["state"], "merged")
+        self.assertEqual(rec["pr"]["merged_at"], "2026-08-23T21:55:28Z")
+
+
+class TestOrphanBranchReclaim(unittest.TestCase):
+    """A fixer that pushes but never reports must not deadlock its own retry."""
+
+    class FakeGH:
+        def __init__(self, branches, prs=None, deletable=True):
+            self.branches, self.prs, self.deletable = branches, prs or [], deletable
+            self.deleted = []
+
+        def issue(self, n, fields):
+            return {"state": "OPEN"}
+
+        def open_prs_mentioning(self, n):
+            return []
+
+        def branches_matching(self, pattern):
+            return list(self.branches)
+
+        def prs_for_branch(self, branch):
+            return list(self.prs)
+
+        def delete_remote_branch(self, branch):
+            self.deleted.append(branch)
+            if self.deletable:
+                self.branches = [b for b in self.branches if not b.endswith(branch)]
+
+        def remote_branch_sha(self, branch):
+            return "abc" if any(b.endswith(branch) for b in self.branches) else None
+
+    class FakeStore:
+        def __init__(self):
+            self.events = []
+
+        def journal(self, event, **kw):
+            self.events.append((event, kw))
+
+    def engine(self, gh):
+        e = D.Engine.__new__(D.Engine)
+        e.cfg = {"reclaim_orphan_branches": True}
+        e.gh = gh
+        e.store = self.FakeStore()
+        e.dry = False
+        return e
+
+    def test_orphan_branch_is_deleted_and_dispatch_proceeds(self):
+        gh = self.FakeGH(["refs/heads/sweep/12618-sort-by-colors"])
+        e = self.engine(gh)
+        ok, why = D.Engine.fix_guards(e, {"issue": 12618})
+        self.assertTrue(ok, why)
+        self.assertEqual(gh.deleted, ["sweep/12618-sort-by-colors"])
+        self.assertEqual(e.store.events[0][0], "ROLLBACK_RECORDED")
+
+    def test_branch_with_a_pr_is_never_deleted(self):
+        gh = self.FakeGH(["refs/heads/sweep/12618-x"], prs=[{"number": 1, "state": "CLOSED"}])
+        e = self.engine(gh)
+        ok, why = D.Engine.fix_guards(e, {"issue": 12618})
+        self.assertFalse(ok)
+        self.assertIn("already has a PR", why)
+        self.assertEqual(gh.deleted, [])
+
+    def test_undeletable_branch_blocks_dispatch(self):
+        gh = self.FakeGH(["refs/heads/sweep/12618-x"], deletable=False)
+        ok, why = D.Engine.fix_guards(self.engine(gh), {"issue": 12618})
+        self.assertFalse(ok)
+        self.assertIn("could not delete", why)
+
+    def test_reclaim_can_be_switched_off(self):
+        gh = self.FakeGH(["refs/heads/sweep/12618-x"])
+        e = self.engine(gh)
+        e.cfg = {"reclaim_orphan_branches": False}
+        ok, why = D.Engine.fix_guards(e, {"issue": 12618})
+        self.assertFalse(ok)
+        self.assertEqual(gh.deleted, [])
+
+    def test_never_touches_a_differently_numbered_branch(self):
+        gh = self.FakeGH(["refs/heads/sweep/126180-other"])
+        ok, why = D.Engine.fix_guards(self.engine(gh), {"issue": 12618})
+        self.assertTrue(ok or "unexpected branch" in why)
+        self.assertEqual(gh.deleted, [])
+
+
+class TestMergeability(unittest.TestCase):
+    """A green PR can still be unmergeable once master moves under it."""
+
+    def engine(self, out="", update_calls=None):
+        class GH:
+            def pr_update_branch(self, n):
+                (update_calls if update_calls is not None else []).append(n)
+                return out
+
+        class Store:
+            def __init__(self):
+                self.events = []
+
+            def journal(self, event, **kw):
+                self.events.append((event, kw))
+
+        e = D.Engine.__new__(D.Engine)
+        e.cfg = {"auto_update_behind_branches": True}
+        e.gh, e.store, e.dry = GH(), Store(), False
+        e.escalate = lambda *a, **k: e.store.journal("ESCALATED", args=a)
+        return e
+
+    def test_conflicting_escalates_once(self):
+        e = self.engine()
+        pr = {"branch": "sweep/1-x", "ci": {}}
+        handled = D.Engine.handle_mergeability(
+            e, {"issue": 1}, pr, 99, {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"})
+        self.assertTrue(handled)
+        self.assertEqual([ev[0] for ev in e.store.events], ["PR_CONFLICT", "ESCALATED"])
+
+    def test_conflict_not_re_escalated(self):
+        e = self.engine()
+        pr = {"branch": "sweep/1-x", "ci": {"state": "conflict"}}
+        D.Engine.handle_mergeability(e, {"issue": 1}, pr, 99,
+                                     {"mergeable": "CONFLICTING", "mergeStateStatus": "DIRTY"})
+        self.assertEqual(e.store.events, [])
+
+    def test_behind_is_updated_automatically(self):
+        calls = []
+        e = self.engine(out="updated", update_calls=calls)
+        D.Engine.handle_mergeability(e, {"issue": 1}, {"branch": "b"}, 99,
+                                     {"mergeable": "MERGEABLE", "mergeStateStatus": "BEHIND"})
+        self.assertEqual(calls, [99])
+        self.assertEqual(e.store.events[0][0], "PR_BRANCH_UPDATED")
+
+    def test_behind_update_that_conflicts_is_not_journaled_as_success(self):
+        e = self.engine(out="merge conflict between base and head")
+        D.Engine.handle_mergeability(e, {"issue": 1}, {"branch": "b"}, 99,
+                                     {"mergeable": "MERGEABLE", "mergeStateStatus": "BEHIND"})
+        self.assertEqual(e.store.events, [])
+
+    def test_behind_is_not_retried_within_15_minutes(self):
+        calls = []
+        e = self.engine(update_calls=calls)
+        recent = D.iso(D.utcnow() - dt.timedelta(minutes=3))
+        D.Engine.handle_mergeability(e, {"issue": 1}, {"branch": "b", "last_branch_update": recent},
+                                     99, {"mergeable": "MERGEABLE", "mergeStateStatus": "BEHIND"})
+        self.assertEqual(calls, [])
+
+    def test_clean_pr_is_left_alone(self):
+        e = self.engine()
+        handled = D.Engine.handle_mergeability(
+            e, {"issue": 1}, {"branch": "b"}, 99,
+            {"mergeable": "MERGEABLE", "mergeStateStatus": "CLEAN"})
+        self.assertFalse(handled)
+        self.assertEqual(e.store.events, [])
+
+    def test_conflict_routes_to_pr_ci_failed(self):
+        s = D.State()
+        s.apply(ev(1, "ISSUE_ENQUEUED", issue=7, title="t", labels=[]))
+        s.apply(ev(2, "LEASE_GRANTED", issue=7, kind="triage", batch_id="t-7-1",
+                   expires_at="2026-08-24T01:00:00Z"))
+        s.apply(ev(3, "RESULT_RECORDED", issue=7, kind="triage", status="triaged",
+                   **{"class": "easy-fix"}))
+        s.apply(ev(4, "RESULT_RECORDED", issue=7, kind="triage", status="fix_pending"))
+        s.apply(ev(5, "LEASE_GRANTED", issue=7, kind="fix", batch_id="f-7-1",
+                   expires_at="2026-08-24T02:00:00Z"))
+        s.apply(ev(6, "RESULT_RECORDED", issue=7, kind="fix", status="fix_pushed",
+                   pr_branch="sweep/7-t", head_sha="abc"))
+        s.apply(ev(7, "PR_OPENED", issue=7, number=99, branch="sweep/7-t", head_sha="abc"))
+        s.apply(ev(8, "PR_CONFLICT", issue=7, pr=99))
+        self.assertEqual(s.issue(7)["status"], "pr_ci_failed")
+        self.assertEqual(s.issue(7)["pr"]["ci"]["failed"], ["merge-conflict"])
+
+
+class TestTokenFile(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.saved = (D.CONFIG, D.BASE, D.LOGFILE, D.STATE, list(D.SCRUB.values))
+        D.STATE = self.tmp
+        D.LOGFILE = self.tmp / "t.log"
+        D.BASE = self.tmp
+        D.CONFIG = self.tmp / "config.json"
+
+    def tearDown(self):
+        D.CONFIG, D.BASE, D.LOGFILE, D.STATE, D.SCRUB.values = self.saved
+
+    def test_absent_file_yields_no_overlay(self):
+        self.assertEqual(D.load_gh_token(), {})
+
+    def test_token_is_loaded_and_registered_for_scrubbing(self):
+        (self.tmp / "state").mkdir()
+        tok = self.tmp / "state" / ".gh_token"
+        tok.write_text("ghp_supersecrettokenvalue\n")
+        tok.chmod(0o600)
+        overlay = D.load_gh_token()
+        self.assertEqual(overlay["GH_TOKEN"], "ghp_supersecrettokenvalue")
+        self.assertEqual(overlay["GITHUB_TOKEN"], "ghp_supersecrettokenvalue")
+        self.assertNotIn("ghp_supersecrettokenvalue", D.SCRUB("using ghp_supersecrettokenvalue"))
+
+    def test_empty_file_yields_no_overlay(self):
+        (self.tmp / "state").mkdir()
+        (self.tmp / "state" / ".gh_token").write_text("   \n")
+        self.assertEqual(D.load_gh_token(), {})
+
+    def test_token_is_never_in_argv(self):
+        r = D.Runner(dict(D.DEFAULT_CONFIG), sleeper=lambda s: None,
+                     env_overlay={"GH_TOKEN": "ghp_x"})
+        out = r.run(["printenv", "GH_TOKEN"], check=False)
+        self.assertIn("ghp_x", out)  # reaches the child through env, not the command line
+
+
+class TestPrBackpressure(unittest.TestCase):
+    """max_open_prs bounds the standing review pile; daily_pr_cap only bounds rate."""
+
+    def engine(self, open_count=0, raises=False, backpressure=False, cap=30):
+        class GH:
+            def count_open_sweep_prs(self):
+                if raises:
+                    raise D.InfraError("gh exploded")
+                return open_count
+
+        class Store:
+            def __init__(self, st):
+                self.events, self.state = [], st
+
+            def journal(self, event, **kw):
+                self.events.append((event, kw))
+                if event == "PR_BACKPRESSURE_ON":
+                    self.state.pr_backpressure = True
+                elif event == "PR_BACKPRESSURE_OFF":
+                    self.state.pr_backpressure = False
+
+        st = D.State()
+        st.pr_backpressure = backpressure
+        e = D.Engine.__new__(D.Engine)
+        e.cfg = {"max_open_prs": cap}
+        e.gh, e.st = GH(), st
+        e.store = Store(st)
+        e.open_sweep_prs = None
+        return e
+
+    def test_under_cap_allows_prs(self):
+        e = self.engine(open_count=14)
+        self.assertTrue(D.Engine.pr_capacity_available(e, 3))
+        self.assertEqual(e.store.events, [])
+        self.assertEqual(e.open_sweep_prs, 14)
+
+    def test_at_cap_holds_and_journals_once(self):
+        e = self.engine(open_count=30)
+        self.assertFalse(D.Engine.pr_capacity_available(e, 5))
+        self.assertEqual([x[0] for x in e.store.events], ["PR_BACKPRESSURE_ON"])
+        self.assertEqual(e.store.events[0][1]["open_prs"], 30)
+        # second tick while still at cap must not journal again
+        self.assertFalse(D.Engine.pr_capacity_available(e, 5))
+        self.assertEqual(len(e.store.events), 1)
+
+    def test_recovery_journals_off_once(self):
+        e = self.engine(open_count=12, backpressure=True)
+        self.assertTrue(D.Engine.pr_capacity_available(e, 2))
+        self.assertEqual([x[0] for x in e.store.events], ["PR_BACKPRESSURE_OFF"])
+        self.assertTrue(D.Engine.pr_capacity_available(e, 2))
+        self.assertEqual(len(e.store.events), 1)
+
+    def test_count_failure_holds_rather_than_floods(self):
+        e = self.engine(raises=True)
+        self.assertFalse(D.Engine.pr_capacity_available(e, 4))
+        self.assertEqual(e.store.events, [])  # infra hiccup is not a backpressure event
+
+    def test_cap_of_zero_or_none_disables_backpressure(self):
+        self.assertTrue(D.Engine.pr_capacity_available(self.engine(open_count=999, cap=0), 1))
+        self.assertTrue(D.Engine.pr_capacity_available(self.engine(open_count=999, cap=None), 1))
+
+    def test_backpressure_never_escalates(self):
+        e = self.engine(open_count=40)
+        D.Engine.pr_capacity_available(e, 9)
+        self.assertNotIn("ESCALATED", [x[0] for x in e.store.events])
+
+    def test_state_flag_survives_replay(self):
+        s = D.State()
+        s.apply(ev(1, "PR_BACKPRESSURE_ON", open_prs=30, cap=30))
+        self.assertTrue(s.pr_backpressure)
+        self.assertTrue(s.to_dict()["pr_backpressure"])
+        s.apply(ev(2, "PR_BACKPRESSURE_OFF", open_prs=20, cap=30))
+        self.assertFalse(s.pr_backpressure)
+
+    def test_counts_only_sweep_branches(self):
+        class R:
+            def run(self, argv, **kw):
+                return json.dumps([
+                    {"number": 1, "headRefName": "sweep/12-a"},
+                    {"number": 2, "headRefName": "dependabot/npm/x"},
+                    {"number": 3, "headRefName": "sweep/13-b"},
+                    {"number": 4, "headRefName": "feature/unrelated"},
+                ])
+
+        self.assertEqual(D.GitHub(R(), "o/r").count_open_sweep_prs(), 2)
+
+
+class TestMasterAdvanced(unittest.TestCase):
+    """Conflicts are caused by master moving, so poll on that event, not a timer."""
+
+    def test_sha_recorded_and_replayed(self):
+        s = D.State()
+        self.assertIsNone(s.last_master_sha)
+        s.apply(ev(1, "MASTER_ADVANCED", sha="a" * 40))
+        self.assertEqual(s.last_master_sha, "a" * 40)
+        self.assertEqual(s.to_dict()["last_master_sha"], "a" * 40)
+        s.apply(ev(2, "MASTER_ADVANCED", sha="b" * 40))
+        self.assertEqual(s.last_master_sha, "b" * 40)
+
+    def test_first_observation_does_not_count_as_movement(self):
+        # last_master_sha is None on a fresh campaign; that must not force a
+        # full recheck storm on the very first tick.
+        s = D.State()
+        first = s.last_master_sha is None
+        self.assertTrue(first)
+        moved = s.last_master_sha is not None
+        self.assertFalse(moved)
+
+    def test_default_recheck_is_minutes_not_half_an_hour(self):
+        self.assertLessEqual(D.DEFAULT_CONFIG["ci_recheck_minutes"], 10)
+
+
+class TestReadyForReviewIsNotAnIncident(unittest.TestCase):
+    """The draft brake failing and bakert reviewing must not look the same."""
+
+    def gh(self, timeline_rows):
+        class R:
+            def run(self, argv, **kw):
+                return json.dumps(timeline_rows)
+        return D.GitHub(R(), "o/r")
+
+    def test_readied_pr_is_recognised(self):
+        self.assertTrue(self.gh([{"event": "ready_for_review"}]).pr_readied_by_human(1))
+
+    def test_never_readied_pr_is_not(self):
+        self.assertFalse(self.gh([]).pr_readied_by_human(1))
+
+    def test_api_failure_is_treated_as_not_readied(self):
+        class R:
+            def run(self, argv, **kw):
+                raise D.InfraError("boom")
+        # Fail safe: an unknown state escalates rather than being waved through.
+        self.assertFalse(D.GitHub(R(), "o/r").pr_readied_by_human(1))
+
+    def test_readied_timestamp_recorded(self):
+        s = D.State()
+        s.apply(ev(1, "ISSUE_ENQUEUED", issue=7, title="t", labels=[]))
+        s.apply(ev(2, "LEASE_GRANTED", issue=7, kind="triage", batch_id="t-7-1",
+                   expires_at="2026-08-24T01:00:00Z"))
+        s.apply(ev(3, "RESULT_RECORDED", issue=7, kind="triage", status="triaged",
+                   **{"class": "easy-fix"}))
+        s.apply(ev(4, "RESULT_RECORDED", issue=7, kind="triage", status="fix_pending"))
+        s.apply(ev(5, "LEASE_GRANTED", issue=7, kind="fix", batch_id="f-7-1",
+                   expires_at="2026-08-24T02:00:00Z"))
+        s.apply(ev(6, "RESULT_RECORDED", issue=7, kind="fix", status="fix_pushed",
+                   pr_branch="sweep/7-t", head_sha="abc"))
+        s.apply(ev(7, "PR_OPENED", issue=7, number=99, branch="sweep/7-t", head_sha="abc"))
+        s.apply(ev(8, "PR_READIED_BY_HUMAN", issue=7, pr=99))
+        self.assertTrue(s.issue(7)["pr"]["readied_by_human_at"])
+        self.assertEqual(s.issue(7)["status"], "pr_open")
+
+
+class TestDeferredCanBeHandedBack(unittest.TestCase):
+    """deferred_human is terminal for the sweep, not for bakert."""
+
+    def deferred(self):
+        s = D.State()
+        s.apply(ev(1, "ISSUE_ENQUEUED", issue=5, title="t", labels=[]))
+        s.apply(ev(2, "LEASE_GRANTED", issue=5, kind="triage", batch_id="t-5-1",
+                   expires_at="2026-08-24T01:00:00Z"))
+        s.apply(ev(3, "RESULT_RECORDED", issue=5, kind="triage", status="triaged",
+                   **{"class": "needs-product-decision"}))
+        s.apply(ev(4, "ESCALATED", issue=5, kind="class-escalate", question="q"))
+        s.apply(ev(5, "ADJUDICATED", issue=5, verb="defer-to-human",
+                   status="deferred_human", note="bakert decides"))
+        return s
+
+    def test_automatic_retry_cannot_leave_deferred(self):
+        s = self.deferred()
+        s.apply(ev(6, "RETRY_SCHEDULED", issue=5, kind="fix", status="fix_pending"))
+        self.assertEqual(s.issue(5)["status"], "escalated")  # frozen, not resurrected
+
+    def test_defer_then_queue_fix_is_legal(self):
+        s = self.deferred()
+        self.assertEqual(s.issue(5)["status"], "deferred_human")
+        s.apply(ev(6, "ADJUDICATED", issue=5, verb="queue-fix", status="fix_pending",
+                   note="bakert said do it"))
+        self.assertEqual(s.issue(5)["status"], "fix_pending")
+        self.assertEqual(len(s.invariants), 0)
+
+    def test_bakert_can_close_a_deferred_issue(self):
+        s = self.deferred()
+        s.apply(ev(6, "ADJUDICATED", issue=5, verb="close-completed", status="closing",
+                   note="resolved by events"))
+        s.apply(ev(7, "CLOSE_EXECUTED", issue=5, reason="completed", comment_posted=True))
+        self.assertEqual(s.issue(5)["status"], "closed")
+        self.assertEqual(len(s.invariants), 0)
+
+    def test_annotate_records_without_moving(self):
+        s = self.deferred()
+        s.apply(ev(6, "ADJUDICATED", issue=5, verb="annotate", note="deliberately punted"))
+        self.assertEqual(s.issue(5)["status"], "deferred_human")
+        self.assertEqual(s.issue(5)["notes"], "deliberately punted")
+        self.assertEqual(len(s.invariants), 0)
+
+    def test_annotate_is_a_known_verb_with_no_transition(self):
+        self.assertIn("annotate", D.ADJUDICATIONS)
+        self.assertIsNone(D.ADJUDICATIONS["annotate"])
+
+
+class TestArchiveVerification(unittest.TestCase):
+    """39 workspaces sat in `sleeping` while the journal claimed `archived`."""
+
+    def engine(self, states, raise_on_archive=False):
+        calls = {"archive": []}
+
+        class Cond:
+            def archive_workspace(self, wid):
+                calls["archive"].append(wid)
+                if raise_on_archive:
+                    raise D.InfraError("HTTP 400 on archive")
+                return {}
+
+            def workspace_status(self, wid):
+                return {"status": states.pop(0) if states else "ready"}
+
+        class Store:
+            def __init__(self, st):
+                self.events, self.state = [], st
+
+            def journal(self, event, **kw):
+                self.events.append((event, kw))
+                ws = self.state.workspaces.get(kw.get("workspace_id"))
+                if ws and event == "WORKSPACE_ARCHIVED":
+                    ws["state"] = "archived"
+                elif ws and event == "WORKSPACE_HARVESTED":
+                    ws["state"] = "harvested"
+
+        st = D.State()
+        st.workspaces["w1"] = {"workspace_id": "w1", "batch_id": "t-1-1", "state": "running",
+                               "kind": "triage", "issues": [1]}
+        e = D.Engine.__new__(D.Engine)
+        e.cond, e.st, e.dry = Cond(), st, False
+        e.store = Store(st)
+        e.calls = calls
+        return e
+
+    def test_confirmed_archive_is_journaled(self):
+        e = self.engine(["archived"])
+        self.assertTrue(D.Engine.archive(e, e.st.workspaces["w1"]))
+        self.assertEqual([x[0] for x in e.store.events], ["WORKSPACE_ARCHIVED"])
+
+    def test_sleeping_workspace_is_not_claimed_as_archived(self):
+        e = self.engine(["sleeping"])
+        self.assertFalse(D.Engine.archive(e, e.st.workspaces["w1"]))
+        self.assertEqual([x[0] for x in e.store.events], ["WORKSPACE_HARVESTED"])
+        self.assertEqual(e.st.workspaces["w1"]["state"], "harvested")
+
+    def test_failed_call_still_verifies_and_does_not_lie(self):
+        e = self.engine(["ready"], raise_on_archive=True)
+        self.assertFalse(D.Engine.archive(e, e.st.workspaces["w1"]))
+        self.assertNotIn("WORKSPACE_ARCHIVED", [x[0] for x in e.store.events])
+
+    def test_deleted_counts_as_archived(self):
+        e = self.engine(["deleted"])
+        self.assertTrue(D.Engine.archive(e, e.st.workspaces["w1"]))
+
+    def test_harvested_workspaces_are_retried(self):
+        e = self.engine(["sleeping", "archived"])
+        D.Engine.archive(e, e.st.workspaces["w1"])          # first attempt fails
+        D.Engine.retry_archives(e)                            # second succeeds
+        self.assertEqual(len(e.calls["archive"]), 2)
+        self.assertEqual(e.st.workspaces["w1"]["state"], "archived")
+
+    def test_harvested_is_not_counted_as_active(self):
+        s = D.State()
+        s.apply(ev(1, "WORKSPACE_CREATED", workspace_id="w1", session_id="s1", kind="triage",
+                   batch_id="t-1-1", issues=[1]))
+        s.apply(ev(2, "WORKSPACE_HARVESTED", workspace_id="w1", state="sleeping"))
+        active = [w for w in s.workspaces.values() if w["state"] in ("creating", "running", "nudged")]
+        self.assertEqual(active, [])
+
+
+class TestBodylessPost(unittest.TestCase):
+    def test_content_type_only_when_a_body_is_sent(self):
+        import inspect
+        src = inspect.getsource(D.Conductor._request)
+        self.assertIn("if data is not None:", src)
+        i_guard = src.index("if data is not None:")
+        i_ct = src.index('req.add_header("Content-Type"')
+        self.assertGreater(i_ct, i_guard, "Content-Type must be inside the body guard")

--- a/backlog_sweep/test_dispatcher.py
+++ b/backlog_sweep/test_dispatcher.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import dispatcher as D  # noqa: E402
@@ -909,6 +910,40 @@ class TestPrBackpressure(unittest.TestCase):
                 ])
 
         self.assertEqual(D.GitHub(R(), "o/r").count_open_sweep_prs(), 2)
+
+
+class TestManagerSessionRecovery(unittest.TestCase):
+    class Store:
+        def __init__(self, session_id="old-session"):
+            self.config = {"opus_session_id": session_id}
+            self.saved = 0
+            self.events = []
+
+        def save_config(self):
+            self.saved += 1
+
+        def journal(self, event, **kw):
+            self.events.append((event, kw))
+
+    def test_recovery_rebinds_escalations_to_current_manager(self):
+        store = self.Store()
+        with mock.patch.dict(D.os.environ, {"CONDUCTOR_SESSION_ID": "new-session"}):
+            note = D.refresh_manager_session(store)
+        self.assertEqual(store.config["opus_session_id"], "new-session")
+        self.assertEqual(store.saved, 1)
+        self.assertEqual(store.events, [
+            ("CONFIG_CHANGED", {"changes": {"opus_session_id": "<this session>"}}),
+        ])
+        self.assertIn("manager session updated", note)
+
+    def test_dry_run_reports_without_changing_session(self):
+        store = self.Store()
+        with mock.patch.dict(D.os.environ, {"CONDUCTOR_SESSION_ID": "new-session"}):
+            note = D.refresh_manager_session(store, dry_run=True)
+        self.assertEqual(store.config["opus_session_id"], "old-session")
+        self.assertEqual(store.saved, 0)
+        self.assertEqual(store.events, [])
+        self.assertTrue(note.startswith("WOULD"))
 
 
 class TestMasterAdvanced(unittest.TestCase):

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 plugins = pydantic.mypy
-exclude = (src|logsite_migrations|logsite)
+exclude = (src|logsite_migrations|logsite|backlog_sweep)
 show_error_codes = True
 ignore_missing_imports = True
 strict_equality = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"backlog_sweep/*" = ["T201", "UP031", "E741"]
 "rotation_script/*" = ["T201"]
 "shared/*" = ["T201"]
 "maintenance/*" = ["T201"]


### PR DESCRIPTION
## Summary

- add the deterministic, restartable coordinator and its triage, verification, fixer, and fixup contracts
- keep runtime campaign state gitignored while mirroring durable checkpoints to the never-merged `sweep-state` branch
- ship conservative defaults, executable recovery procedures, safety gates, and the design record from the August pilot
- add shared Conductor cloud setup so fresh worker workspaces bootstrap the required Python toolchain
- document the pilot-verified classic `repo`-scoped operator PAT and its containment rules
- rebind escalation delivery to the current manager session during recovery

No live campaign state or credentials are included. Every spawning and mutation gate in the example configuration ships disabled.

## Verification

- `uv tool run pre-commit run --all-files`
- `uv run --frozen python -m unittest -q backlog_sweep.test_dispatcher` (113 tests)
- `uv run --frozen ruff check .`
- `uv run --frozen mypy --config-file mypy.ini .`
- `git diff --check origin/master...HEAD`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7e7f8c99-ba9f-49d1-86be-aa64dc9c78d3)
