### PR TITLE
Fix Anthropic structured output schema

### DIFF
--- a/decksite/data/archetype_classifier.py
+++ b/decksite/data/archetype_classifier.py
@@ -88,7 +88,9 @@ OUTPUT_SCHEMA = {
     'type': 'object',
     'properties': {
         'archetype': {'type': 'string'},
-        'confidence': {'type': 'integer', 'minimum': 0, 'maximum': 100},
+        # Anthropic structured outputs do not support the JSON Schema minimum/maximum
+        # keywords when schemas are sent directly rather than through an SDK.
+        'confidence': {'type': 'integer', 'description': 'An integer from 0 to 100 inclusive.'},
         'possible_new_variant': {'type': 'boolean'},
         'variant_note': {'type': 'string'},
     },
@@ -132,7 +134,7 @@ def _classify_one(api_key: str, model: str, d: Deck, meta: Metadata, new_cards: 
         logger.info('archetype_classifier: deck %s -> no candidate (%r, new_variant=%s)', d.id, chosen, data.get('possible_new_variant'))
         return
     archetype_id = name_to_id[chosen.lower()]
-    confidence = int(data.get('confidence') or 0)
+    confidence = max(0, min(100, int(data.get('confidence') or 0)))
     archetype.assign(d.id, archetype_id, None, False, confidence)
 
 
@@ -207,7 +209,12 @@ def _call(api_key: str, model: str, prompt: str) -> dict[str, Any] | None:
         },
         timeout=120,
     )
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        # requests' default exception omits Anthropic's useful JSON error message.
+        logger.error('archetype_classifier: Anthropic API error response: %s', response.text[:2000])
+        raise
     result = response.json()
     if result.get('stop_reason') == 'refusal':
         return None

--- a/decksite/data/archetype_classifier_test.py
+++ b/decksite/data/archetype_classifier_test.py
@@ -96,5 +96,39 @@ def test_call_requests_structured_json(monkeypatch: pytest.MonkeyPatch) -> None:
     response.raise_for_status.assert_called_once_with()
     _, kwargs = post.call_args
     assert kwargs['headers']['x-api-key'] == 'secret'
-    assert kwargs['json']['output_config']['format']['type'] == 'json_schema'
+    output_format = kwargs['json']['output_config']['format']
+    assert output_format['type'] == 'json_schema'
+    confidence_schema = output_format['schema']['properties']['confidence']
+    assert confidence_schema['type'] == 'integer'
+    assert 'minimum' not in confidence_schema
+    assert 'maximum' not in confidence_schema
     assert kwargs['json']['messages'] == [{'role': 'user', 'content': 'deck prompt'}]
+
+
+@pytest.mark.parametrize(('reported', 'stored'), [(-10, 0), (92, 92), (120, 100)])
+def test_classify_one_clamps_confidence(monkeypatch: pytest.MonkeyPatch, reported: int, stored: int) -> None:
+    assign = mock.Mock()
+    monkeypatch.setattr(archetype_classifier, '_shortlist', lambda _d, _meta: [(7, 'Aggro')])
+    monkeypatch.setattr(archetype_classifier, '_deck_prompt', lambda _d, _candidates, _meta, _new_cards: 'prompt')
+    monkeypatch.setattr(archetype_classifier, '_call', lambda _api_key, _model, _prompt: {
+        'archetype': 'Aggro',
+        'confidence': reported,
+        'possible_new_variant': False,
+        'variant_note': '',
+    })
+    monkeypatch.setattr(archetype_classifier.archetype, 'assign', assign)
+
+    archetype_classifier._classify_one('secret', 'model', Container(id=1), {}, set())
+
+    assign.assert_called_once_with(1, 7, None, False, stored)
+
+
+def test_call_logs_anthropic_error_response(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    response = mock.Mock(status_code=400, text='{"type":"error","error":{"message":"bad schema"}}')
+    response.raise_for_status.side_effect = archetype_classifier.requests.HTTPError('400 Client Error')
+    monkeypatch.setattr(archetype_classifier.requests, 'post', mock.Mock(return_value=response))
+
+    with pytest.raises(archetype_classifier.requests.HTTPError):
+        archetype_classifier._call('secret', 'model', 'prompt')
+
+    assert 'bad schema' in caplog.text


### PR DESCRIPTION
## What

- remove unsupported `minimum` and `maximum` constraints from the raw Anthropic JSON schema
- clamp returned confidence values to the stored 0-100 range
- include the Anthropic response body in API error logs
- add regression coverage for the schema, confidence normalization, and error diagnostics

## Why

The production classifier reached the Messages API but every structured-output request returned HTTP 400. Anthropic does not support `minimum` or `maximum` in raw structured-output schemas; its SDK transforms those constraints automatically, but this integration intentionally uses direct HTTP requests.

## Verification

- live patched structured-output request to `claude-haiku-4-5`: HTTP 200 with every expected field
- end-to-end development classification: deck 283095 was assigned Azorius Tempo at confidence 72 and remained unreviewed
- classifier and deck tests: 18 passed
- Ruff: passed
- mypy: passed across 364 source files
- full pytest: 815 passed, 2 skipped; the 5 failures are unrelated logsite tests because the local `pdlogs` fixture database lacks its `format` and `match` tables

The API key used for live verification was held only in process memory and was not written to the repository or workspace files.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2638355e-b4ee-46a8-b32b-4557c7425736)
