### PR TITLE
Move menu hover submenu from z-index 5 to 3 (#12670)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -865,7 +865,7 @@ nav, .menu, .submenu {
 nav li:hover > .item + .submenu {
     display: block;
     width: var(--submenu-width);
-    z-index: 5;
+    z-index: 3;
 }
 
 .submenu:hover {
@@ -932,7 +932,7 @@ nav li.submenu-open > .item + .submenu {
     opacity: 1;
     transition-delay: 0s;
     visibility: visible;
-    z-index: 5;
+    z-index: 3;
 }
 
 /* Once you get properly wide we just show the main menu and the submenu if there is one in the flow of the page. */
@@ -1560,12 +1560,14 @@ Copying from Material Design we have six levels from 0-5. (We currently only use
     Language switcher "submenu"
     Status bar (top or bottom)
 
-3 (6dp): nothing yet
+3 (6dp):
+    Desktop hover/touch submenu (active state: hovering or tapping a menu item that has a submenu)
 
 – Above here reserved for active states only, no object's resting state is at level 4 or 5.
 
 4 (8dp):
     Nav (in narrower views when shown over the page with scrim)
+    Nav (in narrower and wider views when expanded to show a hover/touch submenu)
 
 5 (12dp):
     Card hover tooltip


### PR DESCRIPTION
## What was wrong

The desktop hover/touch submenu used `z-index: 5` (lines 868 and 935 in `pd.css`), which is the level reserved for third-party card/text tooltips. The expanding nav used `z-index: 4` at both narrow and wide breakpoints but was only documented at level 4 for the narrow-view hamburger drawer. Neither element appeared in the z-index hierarchy comment block, making the stacking model incomplete.

## What changed

- `z-index: 5` → `z-index: 3` on `nav li:hover > .item + .submenu` (hover state)
- `z-index: 5` → `z-index: 3` on `nav li.submenu-open > .item + .submenu` (touch/click state)
- Updated the z-index comment block: level 3 (previously "nothing yet") now documents the desktop hover/touch submenu; level 4 now also documents the expanding nav at both narrow and wide breakpoints

z-index: 3 is sufficient for the submenu: at medium widths (901–1600 px) where the nav creates no stacking context, z-index: 3 floats the submenu above main content (z-index: auto) and the season picker (level 1) and language switcher (level 2). At narrow/wide breakpoints the expanding nav already creates a stacking context at z-index: 4, so the submenu's z-index: 3 is local within that context and correctly appears above other nav children.

## Validation

- `uv run --frozen python dev.py lint` — passed (exit 0)
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped, 89 deselected

Fixes #12670