### PR TITLE
Add --legibility-text-shadow CSS variable for text over images (#12576)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -404,7 +404,6 @@ header h1 {
 header .search {
     flex-grow: 1;
     flex-shrink: 1;
-    text-shadow: var(--legibility-text-shadow);
 }
 
 main, nav {

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -404,6 +404,7 @@ header h1 {
 header .search {
     flex-grow: 1;
     flex-shrink: 1;
+    text-shadow: var(--legibility-text-shadow);
 }
 
 main, nav {
@@ -587,6 +588,7 @@ Color attributes are mostly found with their related structural elements in this
     --error: var(--red);
     --button: var(--light-gray);
     --text-over-images: var(--white);
+    --legibility-text-shadow: 0.05rem 0.05rem 8px black; /* Always dark, even in dark mode, because it's over an image. */
     --toggle-off: var(--light-gray);
     --toggle-on: var(--dark-gray);
     --language-menu-highlight-text: var(--dark-gray);
@@ -690,7 +692,7 @@ header h1 {
     font-size: var(--large-font-size);
     margin-bottom: 0;
     margin-right: 3rem;
-    text-shadow:  0.05rem 0.05rem 8px black; /* We want this dark in both light mode and dark mode because it's over an image. */
+    text-shadow: var(--legibility-text-shadow);
     text-transform: lowercase;
 }
 


### PR DESCRIPTION
## What was wrong

The legibility drop shadow (`0.05rem 0.05rem 8px black`) applied to `header h1` was hardcoded inline with no way to reuse it on other elements that also appear over the site's banner image. There was no standard variable for this pattern.

## What changed

In `shared_web/static/css/pd.css`:
1. Added `--legibility-text-shadow: 0.05rem 0.05rem 8px black` to the `:root` color block (near `--text-over-images`), with a comment explaining it is always dark even in dark mode because it overlays an image.
2. Replaced the hardcoded inline value on `header h1` with `var(--legibility-text-shadow)`.
3. Applied `text-shadow: var(--legibility-text-shadow)` to `header .search`, which also sits over the banner image alongside `header h1`.

## Validation

`uv run --frozen python dev.py lint` — passed. Unit tests were not run (no database available in this environment), but the change is pure CSS with no logic paths to test.

Fixes #12576