### PR TITLE
Move className propType from DataManager to Table and Grid separately (#12586)

### DIFF
--- a/shared_web/static/js/datamanager.jsx
+++ b/shared_web/static/js/datamanager.jsx
@@ -138,7 +138,6 @@ DataManager.propTypes = {
     "archetypeId": PropTypes.string,
     "baseQuery": PropTypes.string,
     "cardName": PropTypes.string,
-    "className": PropTypes.oneOf(["", "with-marginalia", "metagame-grid"]),
     "competitionId": PropTypes.string,
     "competitionFlagId": PropTypes.string,
     "competitionSeriesId": PropTypes.string,

--- a/shared_web/static/js/grid.jsx
+++ b/shared_web/static/js/grid.jsx
@@ -83,5 +83,6 @@ export class Grid extends DataManager {
 }
 
 Grid.propTypes = {
+    "className": PropTypes.oneOf(["", "metagame-grid"]),
     "renderSort": PropTypes.func
 };

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -120,6 +120,7 @@ export const renderCard = (card) => (
 );
 
 Table.propTypes = {
+    "className": PropTypes.oneOf(["", "with-marginalia"]),
     "renderHeaderRow": PropTypes.func.isRequired,
     "renderRow": PropTypes.func.isRequired
 };


### PR DESCRIPTION
## What was wrong

`DataManager.propTypes` declared `className` as `PropTypes.oneOf(["", "with-marginalia", "metagame-grid"])`, mixing values that belong to two different child components. `"with-marginalia"` is only valid for `Table` and `"metagame-grid"` is only valid for `Grid`, so the shared base class was conflating them.

## What changed

- **`datamanager.jsx`**: Removed the `className` entry from `DataManager.propTypes`.
- **`table.jsx`**: Added `"className": PropTypes.oneOf(["", "with-marginalia"])` to `Table.propTypes`.
- **`grid.jsx`**: Added `"className": PropTypes.oneOf(["", "metagame-grid"])` to `Grid.propTypes`.

No caller changes were needed — callers already pass `className` under that name to the correct child component.

## Validation

`uv run --frozen python dev.py lint` passed on all three touched files. Unit tests require a live MariaDB instance; the fix is purely static PropTypes metadata (no runtime logic change), so there is no meaningful unit test to add or run.

Fixes #12586