### PR TITLE
Fix metagame grid tiles stretching wide with few results (#12599)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2852,7 +2852,7 @@ Metagame
 .metagame-grid {
     display: grid;
     gap: 0.422rem;
-    grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
     margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
## What was wrong

The `.metagame-grid` CSS rule used `repeat(auto-fit, minmax(11rem, 1fr))`. The `auto-fit` keyword collapses empty grid tracks, causing the remaining tiles to stretch and fill the entire container width. When a search on `/metagame` returns only a few results, the tiles become excessively wide.

## What changed

Changed `auto-fit` to `auto-fill` in `shared_web/static/css/pd.css` (line 2855). With `auto-fill`, empty tracks are preserved rather than collapsed, so tiles stay at most `1fr` of a row that could hold `floor(container / 11rem)` columns — they no longer stretch beyond their natural size.

## How it was validated

- `uv run --frozen python dev.py lint` passed with no errors.
- The change is a single CSS keyword with no server-side logic, so no unit tests exist for it; the behaviour is verifiable by loading `/metagame` with a search that returns a small number of results and confirming the tiles remain narrow.

Fixes #12599