### PR TITLE
Avoid redundant oracle.load_cards call in archetypes2 API (#12595)

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -453,7 +453,7 @@ def archetypes2_api() -> Response:
         kcs = [cards[name] for name in archetype_key_cards.get(result.id, [])]
         result.key_cards = [c for c in kcs if not is_uninteresting(c)][0:5]
         result.num_matches = (result.wins or 0) + (result.losses or 0) + (result.draws or 0)
-        colors, colored_symbols = find_colors(oracle.load_cards(archetype_key_cards.get(result.id, [])))
+        colors, colored_symbols = find_colors(kcs)
         result.colors_safe = colors_html(colors, colored_symbols)
         kcs = [Card({'name': c['name'], 'url': image_fetcher.scryfall_image(c, 'art_crop')}) for c in result.key_cards]
         result.key_cards = kcs


### PR DESCRIPTION
## What was wrong

In `decksite/controllers/api.py`, the `archetypes2_api()` function loop over archetypes already built the key-card list (`kcs`) from the in-memory `cards` dict returned by `oracle.cards_by_name()` (line 453). However, on line 456 the code called `oracle.load_cards(archetype_key_cards.get(result.id, []))` again with the same card names to compute colors — a redundant database/cache round-trip for every archetype on every API request.

## What changed

Line 456: replaced `oracle.load_cards(archetype_key_cards.get(result.id, []))` with `kcs`, which already holds the identical Card list assembled from the in-memory dict two lines above. The `oracle` import is retained because it is still used on lines 237, 451, and 657.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped (17.99s)

Fixes #12595