### PR TITLE
Move /api/archetypes2 decoration into a dedicated preparation path (#12590)

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -16,12 +16,11 @@ from decksite.data import rotation as rot
 from decksite.data import rule as rs
 from decksite.data.achievements import Achievement
 from decksite.data.clauses import DEFAULT_GRID_PAGE_SIZE, DEFAULT_LIVE_TABLE_PAGE_SIZE
-from decksite.prepare import colors_html, prepare_archetypes, prepare_cards, prepare_decks, prepare_leaderboard, prepare_matches, prepare_people
+from decksite.prepare import prepare_archetypes_for_api, prepare_cards, prepare_decks, prepare_leaderboard, prepare_matches, prepare_people
 from decksite.views import DeckEmbed
 from magic import database as magic_database
-from magic import image_fetcher, layout, oracle, seasons, tournaments
-from magic.colors import find_colors
-from magic.models import Card, Deck
+from magic import layout, oracle, seasons, tournaments
+from magic.models import Deck
 from shared import configuration, dtutil, guarantee
 from shared.container import Container
 from shared.pd_exception import DoesNotExistException, InvalidArgumentException, TooManyItemsException
@@ -448,15 +447,7 @@ def archetypes2_api() -> Response:
     results, total = archs.load_disjoint_archetypes(where=where, order_by=order_by, limit=limit, season_id=season_id, tournament_only=tournament_only)
     archetype_key_cards = playability.key_cards_long(season_id)
     cards = oracle.cards_by_name()
-    for result in results:
-        kcs = [cards[name] for name in archetype_key_cards.get(result.id, [])]
-        result.key_cards = [c for c in kcs if not is_uninteresting(c)][0:5]
-        result.num_matches = (result.wins or 0) + (result.losses or 0) + (result.draws or 0)
-        colors, colored_symbols = find_colors(kcs)
-        result.colors_safe = colors_html(colors, colored_symbols)
-        kcs = [Card({'name': c['name'], 'url': image_fetcher.scryfall_image(c, 'art_crop')}) for c in result.key_cards]
-        result.key_cards = kcs
-    prepare_archetypes(results, None, tournament_only, season_id)
+    prepare_archetypes_for_api(results, archetype_key_cards, cards, tournament_only, season_id)
     # Remove infinite loops from the results
     results = [Container({k: v for k, v in result.items() if 'NodeMixin' not in k}) for result in results]
     r = {'page': page, 'total': total, 'objects': results}
@@ -837,8 +828,3 @@ def pagination(args: dict[str, str], default_page_size: int = DEFAULT_LIVE_TABLE
 
 def send_scryfall_two_names(lo: str) -> bool:
     return lo in layout.has_two_names() and lo not in layout.has_meld_back()
-
-def is_uninteresting(c: Card) -> bool:
-    is_basic = 'Basic' in c.type_line
-    is_dual = '} or {' in c.oracle_text or '}, or {' in c.oracle_text
-    return c.is_land() and (is_basic or is_dual)

--- a/decksite/controllers/api_test.py
+++ b/decksite/controllers/api_test.py
@@ -35,11 +35,9 @@ def test_archetypes2_serializes_win_percent_as_number_or_null(monkeypatch: pytes
         Container({'id': 2, 'name': 'Undefined', 'wins': 0, 'losses': 0, 'draws': 1, 'win_percent': None}),
     ]
     monkeypatch.setattr(api.archs, 'load_disjoint_archetypes', lambda **_kwargs: (results, len(results)))
-    monkeypatch.setattr(api.playability, 'key_cards_long', lambda _season_id: {})
+    monkeypatch.setattr(api.playability, 'key_cards_long', lambda *_args: {})
     monkeypatch.setattr(api.oracle, 'cards_by_name', lambda: {})
-    monkeypatch.setattr(api, 'find_colors', lambda _cards: ([], []))
-    monkeypatch.setattr(api, 'colors_html', lambda _colors, _symbols: '')
-    monkeypatch.setattr(api, 'prepare_archetypes', lambda *_args: None)
+    monkeypatch.setattr(api, 'prepare_archetypes_for_api', lambda *_args: None)
 
     with APP.test_request_context('/api/archetypes2/?seasonId=all'):
         response = api.archetypes2_api()

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -1,5 +1,5 @@
 import urllib.parse
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from anytree import PreOrderIter
 from flask import g, session, url_for
@@ -8,7 +8,8 @@ from decksite.data import archetype
 from decksite.data.archetype import Archetype
 from decksite.data.models.person import Person
 from decksite.deck_type import DeckType
-from magic import fetcher, oracle, seasons
+from magic import fetcher, image_fetcher, oracle, seasons
+from magic.colors import find_colors
 from magic.models import Card, Deck
 from shared import dtutil
 from shared.container import Container
@@ -189,6 +190,24 @@ def prepare_archetype(a: archetype.Archetype, archetypes: list[archetype.Archety
         b['url'] = url_for('seasons.archetype', archetype_id=b['id'], deck_type=DeckType.TOURNAMENT.value if tournament_only else None, season_id=season_id)
         # It perplexes me that this is necessary. It's something to do with the way NodeMixin magic works. Mustache doesn't like it.
         b['depth'] = b.depth
+
+def prepare_archetypes_for_api(archetypes: list[Archetype], key_card_names: Mapping[int, Sequence[str]], cards_by_name: Mapping[str, Card], tournament_only: bool, season_id: int | str | None) -> None:
+    for a in archetypes:
+        key_cards = [cards_by_name[name] for name in key_card_names.get(a.id, [])]
+        a.key_cards = [
+            Card({'name': card.name, 'url': image_fetcher.scryfall_image(card, 'art_crop')})
+            for card in key_cards
+            if not is_uninteresting(card)
+        ][:5]
+        a.num_matches = (a.wins or 0) + (a.losses or 0) + (a.draws or 0)
+        colors, colored_symbols = find_colors(key_cards)
+        a.colors_safe = colors_html(colors, colored_symbols)
+    prepare_archetypes(archetypes, None, tournament_only, season_id)
+
+def is_uninteresting(c: Card) -> bool:
+    is_basic = 'Basic' in c.type_line
+    is_dual = '} or {' in c.oracle_text or '}, or {' in c.oracle_text
+    return c.is_land() and (is_basic or is_dual)
 
 def display_round(m: Container) -> str:
     if not m.get('elimination'):

--- a/decksite/prepare_test.py
+++ b/decksite/prepare_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from decksite import prepare
+from decksite.data.archetype import Archetype
 from decksite.main import APP
 from magic import seasons
 from magic.models import Card, Printing
@@ -92,3 +93,39 @@ def test_prepare_card_uses_preferred_printing_for_image(monkeypatch: pytest.Monk
         prepare.prepare_card(card)
 
     assert card.img_url == '/image/Agent Venom/?printing=om1&printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760'
+
+
+def test_prepare_archetypes_for_api_adds_grid_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    archetypes = [
+        Archetype({'id': 1, 'name': 'Populated', 'wins': None, 'losses': 2, 'draws': 3, 'num_decks': 1}),
+        Archetype({'id': 2, 'name': 'Empty', 'wins': None, 'losses': None, 'draws': None, 'num_decks': 0}),
+    ]
+    cards = {
+        'Plains': Card({'name': 'Plains', 'type_line': 'Basic Land — Plains', 'oracle_text': '', 'mana_cost': None}),
+        **{
+            f'Card {n}': Card({'name': f'Card {n}', 'type_line': 'Creature', 'oracle_text': '', 'mana_cost': '{R}'})
+            for n in range(1, 7)
+        },
+    }
+    key_card_names = {1: list(cards)}
+    colors_calls: list[list[str]] = []
+
+    def fake_find_colors(key_cards: list[Card]) -> tuple[list[str], list[str]]:
+        colors_calls.append([card.name for card in key_cards])
+        return (['R'], ['R']) if key_cards else ([], [])
+
+    monkeypatch.setattr(prepare, 'find_colors', fake_find_colors)
+    monkeypatch.setattr(prepare.image_fetcher, 'scryfall_image', lambda card, version: f'https://images.test/{card.name}/{version}')
+
+    with APP.test_request_context('/'):
+        prepare.prepare_archetypes_for_api(archetypes, key_card_names, cards, False, 42)
+
+    assert [(card.name, card.url) for card in archetypes[0].key_cards] == [
+        (f'Card {n}', f'https://images.test/Card {n}/art_crop') for n in range(1, 6)
+    ]
+    assert archetypes[0].num_matches == 5
+    assert archetypes[0].colors_safe == '<div class="mana-bar"><span class="stacked-bar mana-R" style="flex-grow: 100"></span></div>'
+    assert archetypes[1].key_cards == []
+    assert archetypes[1].num_matches == 0
+    assert archetypes[1].colors_safe == '<div class="mana-bar"><span class="stacked-bar mana" style="flex-grow: 1"></span></div>'
+    assert colors_calls == [list(cards), []]


### PR DESCRIPTION
## What was wrong

`/api/archetypes2` decorated every result inline with key-card images, match count, and mana-color HTML. The original version of this PR moved that work by adding two related optional arguments to the generic `prepare_archetype` and `prepare_archetypes` functions. That made an endpoint-specific concern part of every archetype preparation call and allowed incomplete argument combinations.

## What changed

- Add a typed, dedicated `prepare_archetypes_for_api` path for the `/api/archetypes2` result shape.
- Move key-card filtering, five-card limiting, Scryfall art URLs, null-safe `num_matches`, and `colors_safe` calculation into that path.
- Keep the generic `prepare_archetype` and `prepare_archetypes` signatures unchanged, and call them after the API-specific decoration.
- Reduce the controller to loading the two inputs and invoking the dedicated preparation function.
- Move the key-card-interest helper alongside the decoration that uses it.

API output and behavior are unchanged.

## Interaction with #15075

This branch is based on current `master`; #15075 is queued but has not merged. I also applied #15075 followed by this commit in a clean integration worktree. Both commits apply without conflicts, the controller retains #15075's current-page key-card scoping, and the focused tests pass on the combined tree.

## Tests

- Add focused coverage for populated and empty archetypes, including filtered/capped `key_cards`, art URLs, null-safe `num_matches`, `colors_safe`, and the full card set used for color calculation.
- `uv run --frozen pytest decksite/prepare_test.py decksite/controllers/api_test.py` — 8 passed
- `uv run --frozen python dev.py unit` — 874 passed, 1 skipped, 94 deselected
- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py mypy` — passed (366 files)
- Combined #15075 + #15057 focused tests — 8 passed

Fixes #12590
