### PR TITLE
Fix meta share bar disappearing on metagame grid tile hover (#12583)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2864,6 +2864,11 @@ Metagame
     border-radius: inherit; /* Don't round the corners on hover. */
 }
 
+.metagame-grid a:hover .stacked-bar-highlight {
+    background-color: var(--highlight-border);
+    transition-duration: 0s;
+}
+
 .metagame-grid .archetype {
     border: 0.05rem solid #ccc;
     font-size: var(--table-font-size);


### PR DESCRIPTION
## What was wrong

When hovering over a metagame grid tile, the `.stacked-bar-highlight` element (the meta share bar) became invisible. The tile's hover background transitions to `var(--highlight)` over 1 second (`main a:hover` rule), and `.stacked-bar-highlight` also uses `var(--highlight)` as its background color. Although `a:hover .stacked-bar-highlight` was already supposed to switch the bar to `var(--highlight-border)`, it too has `transition-duration: 1s`, so during the transition both the tile background and the bar are the same color — the bar disappears.

## What changed

Added a scoped override in `pd.css` under `.metagame-grid a:hover .stacked-bar-highlight` that sets `transition-duration: 0s`. This makes the bar immediately switch to `var(--highlight-border)` on hover, keeping it visually distinct from the tile's `var(--highlight)` hover background. Only 5 lines added, single file touched.

## Validation

`uv run --frozen python dev.py lint` — passed. CSS changes have no unit test coverage in this repo; the fix was verified by code inspection: the two conflicting colors (`--highlight` for both tile background and bar) are resolved by immediately switching the bar to the darker `--highlight-border` on hover.

Fixes #12583