### PR TITLE
Return None instead of '' for win_percent when there are no matches (#12600)

### DIFF
--- a/analysis/analysis.py
+++ b/analysis/analysis.py
@@ -76,7 +76,7 @@ def played_cards_by_person(person_id: int, season_id: int) -> list[Card]:
             SUM(losses) AS losses,
             SUM(draws) AS draws,
             SUM(wins - losses) AS record,
-            IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent
+            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent
         FROM
             _played_card_person_stats
         WHERE

--- a/analysis/analysis.py
+++ b/analysis/analysis.py
@@ -76,7 +76,7 @@ def played_cards_by_person(person_id: int, season_id: int) -> list[Card]:
             SUM(losses) AS losses,
             SUM(draws) AS draws,
             SUM(wins - losses) AS record,
-            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent
+            CAST(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS DOUBLE) AS win_percent
         FROM
             _played_card_person_stats
         WHERE

--- a/decksite/controllers/api_test.py
+++ b/decksite/controllers/api_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from decksite.controllers import api
 from decksite.main import APP
+from shared.container import Container
 
 
 def test_status_includes_stale_card_information_warning(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -26,3 +27,24 @@ def test_status_omits_recent_card_information_warning(monkeypatch: pytest.Monkey
 
     data = json.loads(response.get_data(as_text=True))
     assert data['card_information_warning'] == ''
+
+
+def test_archetypes2_serializes_win_percent_as_number_or_null(monkeypatch: pytest.MonkeyPatch) -> None:
+    results = [
+        Container({'id': 1, 'name': 'Defined', 'wins': 1, 'losses': 1, 'draws': 0, 'win_percent': 50.0}),
+        Container({'id': 2, 'name': 'Undefined', 'wins': 0, 'losses': 0, 'draws': 1, 'win_percent': None}),
+    ]
+    monkeypatch.setattr(api.archs, 'load_disjoint_archetypes', lambda **_kwargs: (results, len(results)))
+    monkeypatch.setattr(api.playability, 'key_cards_long', lambda _season_id: {})
+    monkeypatch.setattr(api.oracle, 'cards_by_name', lambda: {})
+    monkeypatch.setattr(api, 'find_colors', lambda _cards: ([], []))
+    monkeypatch.setattr(api, 'colors_html', lambda _colors, _symbols: '')
+    monkeypatch.setattr(api, 'prepare_archetypes', lambda *_args: None)
+
+    with APP.test_request_context('/api/archetypes2/?seasonId=all'):
+        response = api.archetypes2_api()
+
+    data = json.loads(response.get_data(as_text=True))
+    assert data['objects'][0]['winPercent'] == 50.0
+    assert isinstance(data['objects'][0]['winPercent'], float)
+    assert data['objects'][1]['winPercent'] is None

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -54,7 +54,7 @@ def load_competition_archetypes(competition_id: int) -> list[Archetype]:
             SUM(CASE WHEN dsum.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN dsum.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,
             (CASE WHEN ct.name = 'League' THEN 'league' WHEN ct.name = 'Gatherling' THEN 'tournament' ELSE 'other' END) AS deck_type,
-            ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1) AS win_percent,
+            CAST(ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             archetype AS a
@@ -512,7 +512,7 @@ def load_matchups(where: str = 'TRUE', archetype_id: int | None = None, person_i
             SUM(wins) AS wins,
             SUM(losses) AS losses,
             SUM(draws) AS draws,
-            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent
+            CAST(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS DOUBLE) AS win_percent
         FROM
             {table} AS mps
         INNER JOIN
@@ -556,7 +556,7 @@ def load_archetypes(order_by: str | None = None, person_id: int | None = None, s
             SUM(perfect_runs) AS perfect_runs,
             SUM(tournament_wins) AS tournament_wins,
             SUM(tournament_top8s) AS tournament_top8s,
-            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
+            CAST(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             archetype AS a
@@ -617,7 +617,7 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
             SUM(perfect_runs) AS perfect_runs,
             SUM(tournament_wins) AS tournament_wins,
             SUM(tournament_top8s) AS tournament_top8s,
-            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
+            CAST(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             COUNT(*) OVER () AS total,
             SUM(wins + losses + draws) / tc.total_matches AS meta_share,
             {clauses.wilson_lower_bound_sql()} AS quality_score

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -54,7 +54,7 @@ def load_competition_archetypes(competition_id: int) -> list[Archetype]:
             SUM(CASE WHEN dsum.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN dsum.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,
             (CASE WHEN ct.name = 'League' THEN 'league' WHEN ct.name = 'Gatherling' THEN 'tournament' ELSE 'other' END) AS deck_type,
-            IFNULL(ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1), '') AS win_percent,
+            ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             archetype AS a
@@ -512,7 +512,7 @@ def load_matchups(where: str = 'TRUE', archetype_id: int | None = None, person_i
             SUM(wins) AS wins,
             SUM(losses) AS losses,
             SUM(draws) AS draws,
-            IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent
+            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent
         FROM
             {table} AS mps
         INNER JOIN
@@ -556,7 +556,7 @@ def load_archetypes(order_by: str | None = None, person_id: int | None = None, s
             SUM(perfect_runs) AS perfect_runs,
             SUM(tournament_wins) AS tournament_wins,
             SUM(tournament_top8s) AS tournament_top8s,
-            IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent,
+            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             archetype AS a
@@ -617,7 +617,7 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
             SUM(perfect_runs) AS perfect_runs,
             SUM(tournament_wins) AS tournament_wins,
             SUM(tournament_top8s) AS tournament_top8s,
-            IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent,
+            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
             COUNT(*) OVER () AS total,
             SUM(wins + losses + draws) / tc.total_matches AS meta_share,
             {clauses.wilson_lower_bound_sql()} AS quality_score

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from decksite.data import archetype
+from decksite.data import archetype, clauses
 from decksite.database import db
 from decksite.testutil import with_test_db
 
@@ -57,12 +57,17 @@ def test_load_disjoint_archetypes_returns_float_or_none_for_win_percent() -> Non
             (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
         VALUES
             (1, 1, 3, 2, 1, 0, 0, 0, 0, 'league'),
-            (2, 1, 1, 0, 0, 1, 0, 0, 0, 'league')
+            (2, 1, 1, 0, 0, 1, 0, 0, 0, 'league'),
+            (3, 1, 4, 1, 3, 0, 0, 0, 0, 'league'),
+            (4, 1, 4, 3, 1, 0, 0, 0, 0, 'league')
     """)
 
-    archetypes, _ = archetype.load_disjoint_archetypes(order_by='a.id', season_id=1)
-    win_percent_by_id = {a.id: a.win_percent for a in archetypes}
+    ascending, _ = archetype.load_disjoint_archetypes(order_by=clauses.archetype_order_by('winPercent', 'ASC'), season_id=1)
+    descending, _ = archetype.load_disjoint_archetypes(order_by=clauses.archetype_order_by('winPercent', 'DESC'), season_id=1)
+    win_percent_by_id = {a.id: a.win_percent for a in ascending}
 
+    assert [a.id for a in ascending] == [3, 1, 4, 2]
+    assert [a.id for a in descending] == [4, 1, 3, 2]
     assert win_percent_by_id[1] == 66.7
     assert isinstance(win_percent_by_id[1], float)
     assert win_percent_by_id[2] is None

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -5,6 +5,8 @@ from unittest import mock
 import pytest
 
 from decksite.data import archetype
+from decksite.database import db
+from decksite.testutil import with_test_db
 
 
 class FakeDatabase:
@@ -44,3 +46,23 @@ def test_assign_clears_cached_deck_after_committing(monkeypatch: pytest.MonkeyPa
 
     database.commit.assert_called_once_with('assign_archetype')
     clear.assert_called_once_with('decksite:deck:42')
+
+
+@with_test_db
+@pytest.mark.functional
+def test_load_disjoint_archetypes_returns_float_or_none_for_win_percent() -> None:
+    archetype.preaggregate_disjoint_archetypes()
+    db().execute("""
+        INSERT INTO _arch_disjoint_stats
+            (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
+        VALUES
+            (1, 1, 3, 2, 1, 0, 0, 0, 0, 'league'),
+            (2, 1, 1, 0, 0, 1, 0, 0, 0, 'league')
+    """)
+
+    archetypes, _ = archetype.load_disjoint_archetypes(order_by='a.id', season_id=1)
+    win_percent_by_id = {a.id: a.win_percent for a in archetypes}
+
+    assert win_percent_by_id[1] == 66.7
+    assert isinstance(win_percent_by_id[1], float)
+    assert win_percent_by_id[2] is None

--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -20,7 +20,7 @@ def load_competition_cards(competition_id: int, order_by: str, limit: str) -> tu
             SUM(CASE WHEN dsum.wins >= 5 AND dsum.losses = 0 AND d.source_id IN (SELECT id FROM source WHERE name = 'League') THEN 1 ELSE 0 END) AS perfect_runs,
             SUM(CASE WHEN dsum.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN dsum.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,
-            IFNULL(ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1), '') AS win_percent,
+            ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             deck AS d
@@ -299,7 +299,7 @@ def load_cards(
             SUM(IFNULL(perfect_runs, 0)) AS perfect_runs,
             SUM(IFNULL(tournament_wins, 0)) AS tournament_wins,
             SUM(IFNULL(tournament_top8s, 0)) AS tournament_top8s,
-            IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent,
+            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             {from_clause}
@@ -329,7 +329,7 @@ def load_card(name: str, tournament_only: bool = False, season_id: int | None = 
     c = Card(oracle.load_card(name), True)  # New Card, don't store these values in CARDS_BY_NAME copy
     c.num_decks = c.wins = c.losses = c.draws = c.record = c.tournament_wins = c.tournament_top8s = 0
     c.played_competitively = False
-    c.win_percent = ''
+    c.win_percent = None
     return c
 
 @retry_after_calling(preaggregate_unique)

--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -20,7 +20,7 @@ def load_competition_cards(competition_id: int, order_by: str, limit: str) -> tu
             SUM(CASE WHEN dsum.wins >= 5 AND dsum.losses = 0 AND d.source_id IN (SELECT id FROM source WHERE name = 'League') THEN 1 ELSE 0 END) AS perfect_runs,
             SUM(CASE WHEN dsum.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN dsum.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,
-            ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1) AS win_percent,
+            CAST(ROUND((SUM(dsum.wins) / NULLIF(SUM(dsum.wins + dsum.losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             deck AS d
@@ -299,7 +299,7 @@ def load_cards(
             SUM(IFNULL(perfect_runs, 0)) AS perfect_runs,
             SUM(IFNULL(tournament_wins, 0)) AS tournament_wins,
             SUM(IFNULL(tournament_top8s, 0)) AS tournament_top8s,
-            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
+            CAST(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             {from_clause}

--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -15,6 +15,10 @@ DEFAULT_LIVE_TABLE_PAGE_SIZE = 20
 DEFAULT_GRID_PAGE_SIZE = 24  # Looks good at 1, 2, 4, 6, 8, 12 columns wide which is the vast majority of cases
 MAX_PAGE_SIZE = 500
 
+def order_by_nulls_last(column: str, sort_order: str) -> str:
+    assert sort_order in ['ASC', 'DESC']
+    return f'{column} IS NULL ASC, {column} {sort_order}'
+
 def decks_order_by(sort_by: str | None, sort_order: str | None, competition_id: str | None) -> str:
     if not sort_by and competition_id:
         sort_by = 'top8'
@@ -68,7 +72,8 @@ def cards_order_by(sort_by: str | None, sort_order: str | None) -> str:
         'tournamentTop8s': 'tournament_top8s',
         'perfectRuns': 'perfect_runs',
     }
-    return sort_options[sort_by] + f' {sort_order}, num_decks DESC, record, name'
+    primary_order = order_by_nulls_last(sort_options[sort_by], sort_order) if sort_by == 'winPercent' else f'{sort_options[sort_by]} {sort_order}'
+    return f'{primary_order}, num_decks DESC, record, name'
 
 def people_order_by(sort_by: str | None, sort_order: str | None) -> str:
     if not sort_by:
@@ -88,7 +93,8 @@ def people_order_by(sort_by: str | None, sort_order: str | None) -> str:
         'tournamentTop8s': 'tournament_top8s',
         'perfectRuns': 'perfect_runs',
     }
-    return sort_options[sort_by] + f' {sort_order}, num_decks DESC, record, name'
+    primary_order = order_by_nulls_last(sort_options[sort_by], sort_order) if sort_by == 'winPercent' else f'{sort_options[sort_by]} {sort_order}'
+    return f'{primary_order}, num_decks DESC, record, name'
 
 def head_to_head_order_by(sort_by: str | None, sort_order: str | None) -> str:
     if not sort_by:
@@ -104,7 +110,8 @@ def head_to_head_order_by(sort_by: str | None, sort_order: str | None) -> str:
         'record': f'(SUM(wins) - SUM(losses)) {sort_order}, SUM(wins)',
         'winPercent': 'ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1)',
     }
-    return sort_options[sort_by] + f' {sort_order}, num_matches DESC, record, name'
+    primary_order = order_by_nulls_last(sort_options[sort_by], sort_order) if sort_by == 'winPercent' else f'{sort_options[sort_by]} {sort_order}'
+    return f'{primary_order}, num_matches DESC, record, name'
 
 def leaderboard_order_by(sort_by: str | None, sort_order: str | None) -> str:
     if not sort_by:
@@ -180,11 +187,13 @@ def archetype_order_by(sort_by: str | None, sort_order: str | None) -> str:
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    win_rate = 'SUM(wins) / NULLIF(SUM(wins + losses), 0)'
+    win_percent = f'ROUND(({win_rate}) * 100, 1)'
     sort_options = {
         'name': ('name', 'ASC'),
         'metaShare': ('SUM(wins + losses + draws) / SUM(SUM(wins + losses + draws)) OVER ()', 'DESC'),
         'quality': (wilson_lower_bound_sql(), 'DESC'),
-        'winPercent': ('SUM(wins) / NULLIF(SUM(wins + losses), 0)', 'DESC'),
+        'winPercent': (win_rate, 'DESC'),
         'tournamentWins': ('tournament_wins', 'DESC'),
         'tournamentTop8s': ('tournament_top8s', 'DESC'),
         'perfectRuns': ('perfect_runs', 'DESC'),
@@ -193,7 +202,8 @@ def archetype_order_by(sort_by: str | None, sort_order: str | None) -> str:
     if sort_order == 'AUTO':
         sort_order = default_order
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
-    return f'{col} {sort_order}, {wilson_lower_bound_sql()} DESC, num_decks DESC, win_percent DESC, name ASC'
+    primary_order = order_by_nulls_last(col, sort_order) if sort_by == 'winPercent' else f'{col} {sort_order}'
+    return f'{primary_order}, {wilson_lower_bound_sql()} DESC, num_decks DESC, {order_by_nulls_last(win_percent, "DESC")}, name ASC'
 
 def exclude_active_league_runs(except_person_id: int | None) -> str:
     clause = """

--- a/decksite/data/clauses_test.py
+++ b/decksite/data/clauses_test.py
@@ -1,10 +1,38 @@
 import re
+from collections.abc import Callable
 
 import pytest
 
 from decksite.data import clauses
 from decksite.deck_type import DeckType
 from shared.pd_exception import InvalidArgumentException
+
+
+@pytest.mark.parametrize('sort_order', ['ASC', 'DESC'])
+@pytest.mark.parametrize(
+    'order_by',
+    [
+        clauses.archetype_order_by,
+        clauses.cards_order_by,
+        clauses.people_order_by,
+        clauses.head_to_head_order_by,
+    ],
+)
+def test_win_percent_ordering_puts_nulls_last(
+    order_by: Callable[[str | None, str | None], str],
+    sort_order: str,
+) -> None:
+    sql = order_by('winPercent', sort_order)
+    expression, ordered = sql.split(' IS NULL ASC, ', 1)
+
+    assert ordered.startswith(f'{expression} {sort_order}')
+
+
+def test_archetype_win_percent_auto_order_remains_descending() -> None:
+    sql = clauses.archetype_order_by('winPercent', 'AUTO')
+    expression, ordered = sql.split(' IS NULL ASC, ', 1)
+
+    assert ordered.startswith(f'{expression} DESC')
 
 
 def test_decks_where() -> None:

--- a/decksite/data/matchup.py
+++ b/decksite/data/matchup.py
@@ -23,8 +23,8 @@ class MatchupResults:
         return len(self.hero_deck_ids)
 
     @property
-    def win_percent(self) -> str:
-        return str(round((self.wins / (self.wins + self.losses)) * 100, 1)) if (self.wins + self.losses) > 0 else ''
+    def win_percent(self) -> float | None:
+        return round((self.wins / (self.wins + self.losses)) * 100, 1) if (self.wins + self.losses) > 0 else None
 
 def matchup(hero: dict[str, str], enemy: dict[str, str], season_id: int | None = None) -> MatchupResults:
     where = 'TRUE'

--- a/decksite/data/matchup_test.py
+++ b/decksite/data/matchup_test.py
@@ -1,0 +1,26 @@
+import pytest
+
+from decksite.data.matchup import MatchupResults
+
+
+@pytest.mark.parametrize(
+    ('wins', 'losses', 'expected'),
+    [
+        (1, 1, 50.0),
+        (0, 0, None),
+    ],
+)
+def test_win_percent_is_float_or_none(wins: int, losses: int, expected: float | None) -> None:
+    results = MatchupResults(
+        hero_deck_ids=[],
+        enemy_deck_ids=[],
+        match_ids=[],
+        wins=wins,
+        draws=0,
+        losses=losses,
+        hero_decks=[],
+        matches=[],
+    )
+
+    assert results.win_percent == expected
+    assert results.win_percent is None or isinstance(results.win_percent, float)

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -117,7 +117,7 @@ def load_people(where: str = 'TRUE',
             SUM(CASE WHEN dc.wins >= 5 AND dc.losses = 0 AND d.source_id IN (SELECT id FROM source WHERE name = 'League') THEN 1 ELSE 0 END) AS perfect_runs,
             SUM(CASE WHEN d.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN d.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,
-            IFNULL(ROUND((SUM(dc.wins) / NULLIF(SUM(dc.wins + dc.losses), 0)) * 100, 1), '') AS win_percent,
+            ROUND((SUM(dc.wins) / NULLIF(SUM(dc.wins + dc.losses), 0)) * 100, 1) AS win_percent,
             SUM(DISTINCT CASE WHEN d.competition_id IS NOT NULL THEN 1 ELSE 0 END) AS num_competitions,
             COUNT(*) OVER () AS total
         FROM
@@ -225,7 +225,7 @@ def load_head_to_head(person_id: int, where: str = 'TRUE', order_by: str = 'num_
             SUM(wins) AS wins,
             SUM(losses) AS losses,
             SUM(draws) AS draws,
-            IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent,
+            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             _head_to_head_stats AS hths

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -117,7 +117,7 @@ def load_people(where: str = 'TRUE',
             SUM(CASE WHEN dc.wins >= 5 AND dc.losses = 0 AND d.source_id IN (SELECT id FROM source WHERE name = 'League') THEN 1 ELSE 0 END) AS perfect_runs,
             SUM(CASE WHEN d.finish = 1 THEN 1 ELSE 0 END) AS tournament_wins,
             SUM(CASE WHEN d.finish <= 8 THEN 1 ELSE 0 END) AS tournament_top8s,
-            ROUND((SUM(dc.wins) / NULLIF(SUM(dc.wins + dc.losses), 0)) * 100, 1) AS win_percent,
+            CAST(ROUND((SUM(dc.wins) / NULLIF(SUM(dc.wins + dc.losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             SUM(DISTINCT CASE WHEN d.competition_id IS NOT NULL THEN 1 ELSE 0 END) AS num_competitions,
             COUNT(*) OVER () AS total
         FROM
@@ -225,7 +225,7 @@ def load_head_to_head(person_id: int, where: str = 'TRUE', order_by: str = 'num_
             SUM(wins) AS wins,
             SUM(losses) AS losses,
             SUM(draws) AS draws,
-            ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS win_percent,
+            CAST(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             COUNT(*) OVER () AS total
         FROM
             _head_to_head_stats AS hths

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -42,7 +42,7 @@ const renderItem = (grid, archetype) => (
         <div className="row flex-row baseline">
             <div className="percentage-with-additional">
                 <span className={"percentage"} title="Win %">
-                    {archetype.winPercent != null ? n(archetype.winPercent) + "%" : "—"}
+                    {archetype.winPercent !== null ? n(archetype.winPercent) + "%" : "—"}
                 </span>
                 <span className="additional">
                     <span title="Win-Loss Record">

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -42,7 +42,7 @@ const renderItem = (grid, archetype) => (
         <div className="row flex-row baseline">
             <div className="percentage-with-additional">
                 <span className={"percentage"} title="Win %">
-                    {n(archetype.winPercent)}%
+                    {archetype.winPercent != null ? n(archetype.winPercent) + "%" : "—"}
                 </span>
                 <span className="additional">
                     <span title="Win-Loss Record">


### PR DESCRIPTION
## What was wrong

`win_percent` was typed as `str` but returned a numeric string like `'55.3'` when there were matches and `''` (empty string) when there were none. This mixed-type behaviour prevented callers from doing arithmetic on the value and was inconsistent.

## What changed

- **9 SQL sites** (`decksite/data/card.py` ×2, `decksite/data/archetype.py` ×4, `decksite/data/person.py` ×2, `analysis/analysis.py` ×1): removed the outer `IFNULL(..., '')` wrapper, leaving `ROUND((SUM(wins) / NULLIF(SUM(wins+losses), 0)) * 100, 1)` which naturally returns `NULL` on divide-by-zero.
- **`decksite/data/card.py:332`**: changed the placeholder `c.win_percent = ''` to `c.win_percent = None` for the fake card returned when no DB row exists.
- **`decksite/data/matchup.py`**: changed `MatchupResults.win_percent` return type from `str` to `float | None` and returned `None` instead of `''` for the zero-match case.
- **`shared_web/static/js/metagamegrid.jsx`**: added a null-guard so that `null` renders as `—` instead of calling `n(null)` which would coerce to `0` and display `0%`.

## How it was validated

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped

Fixes #12600

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/27c74aaf-63f8-4042-87b7-0c9a163858b1)
