### PR TITLE
Use compact format for eslint output to reduce verbosity (#12584)

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -270,7 +270,7 @@ def pull_request(argv: list[str]) -> None:
 def do_jslint(fix: bool) -> None:
     print('>>>> Linting javascript')
     files = find_files(file_extension='js', exclude=['shared_web/static/js/tipped.min.js']) + find_files(file_extension='jsx')
-    cmd = [os.path.join('.', 'node_modules', '.bin', 'eslint')]
+    cmd = [os.path.join('.', 'node_modules', '.bin', 'eslint'), '--format', 'compact']
     if fix:
         cmd.append('--fix')
     subprocess.check_call(cmd + files, shell=ON_WINDOWS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "babel-loader": "^10.1.1",
         "css-loader": "^7.1.5",
         "eslint": "^9.39.2",
+        "eslint-formatter-compact": "^9.0.1",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^17.7.0",
         "react": "^19.2.6",
@@ -3317,6 +3318,16 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-formatter-compact": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-compact/-/eslint-formatter-compact-9.0.1.tgz",
+      "integrity": "sha512-mBAti2tb403dQGMyilQTYHU80stem3N7jdtKW+tmn5gj3JNF7ki0rgCZtJFw4iMayTH862FTUIqCdp70ug0S0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-loader": "^10.1.1",
     "css-loader": "^7.1.5",
     "eslint": "^9.39.2",
+    "eslint-formatter-compact": "^9.0.1",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.7.0",
     "react": "^19.2.6",


### PR DESCRIPTION
## What was wrong

When `do_jslint()` in `dev.py` ran eslint and encountered issues, eslint's default `stylish` formatter emitted multi-line blocks per problem — typically 4-6 lines each — producing ~1000 lines of output for a file with many violations.

## What changed

Added `--format`, `compact` to the eslint command in `do_jslint()` (`dev.py` line 273). The `compact` formatter emits one line per problem in the form `file:line:col: message [rule]`, preserving all issue information while keeping output proportional to the number of problems found.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python -m pytest dev_test.py::test_find_files -p no:timeout` — 1 passed (only test relevant to `dev.py`; full suite conftest.py hits the database during initialization which timed out in this environment even after MariaDB was started)

Fixes #12584

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dc9b4c8b-f55a-476f-a2e6-efa852b117d4)
