### PR TITLE
Reduce metagame grid tile min-width so two fit on iPhone (#12613)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2859,6 +2859,12 @@ Metagame
     margin-bottom: 1rem;
 }
 
+@media only screen and (max-width: 500px) {
+    .metagame-grid {
+        grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+    }
+}
+
 .metagame-grid a {
     font-variant-numeric: normal; /* In general an a uses oldstyle-nums as it may be in text. But this is a block. */
 }


### PR DESCRIPTION
## What was wrong

The `/metagame` page displayed one tile per row on a modern iPhone-sized viewport. This site uses a 20px root font size, so the existing `11rem` minimum is 220px and two tracks cannot fit in the 350px content area at a 390px viewport.

## What changed

Desktop keeps the existing `repeat(auto-fill, minmax(11rem, 1fr))` layout. At viewports up to 500px, the minimum becomes `8rem` (160px), allowing two responsive tracks without changing desktop density.

This also preserves master's newer `auto-fill` behavior.

## Validation

- `uv run --frozen python dev.py lint` passed.
- Tested the exact rebased branch in headless Chrome at a 390×844 viewport.
- All 24 tiles rendered in two columns, each 170.8px wide, with no overlap or clipping.
- The media query leaves the desktop rule unchanged.

Fixes #12613
