### PR TITLE
Fix meta share bar width calculation (#12585)

### DIFF
--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -20,9 +20,9 @@ const renderItem = (grid, archetype) => (
                 <div className="card" data-name={archetype.keyCards[0].name} style={{background: `url(${archetype.keyCards[0].url}) center top / cover no-repeat`}}></div>
             )}
         </div>
-        <div className="row flex-row">
+        <div className="row flex-row" style={{gap: "8px"}}>
             <div title="Meta Share" className="stacked-bar stacked-bar-highlight" style={{width: `${archetype.metaShare * 100}%`}}></div>
-            <div className="percentage-with-additional" style={{marginLeft: "8px", width: `${100 - archetype.metaShare}%`}}>
+            <div className="percentage-with-additional" style={{width: `${(1 - archetype.metaShare) * 100}%`}}>
                 <span title="Meta Share" className="percentage">
                     {n(archetype.metaShare * 100)}%
                 </span>


### PR DESCRIPTION
## What was wrong

`archetype.metaShare` is a decimal fraction (e.g. `0.15` for 15%). On line 25, the remaining-width for the label div was calculated as `100 - archetype.metaShare`, which evaluated to `99.85%` instead of `85%`. This made the label div almost always overflow its container regardless of the actual meta-share value.

## What changed

In `shared_web/static/js/metagamegrid.jsx`:

- Changed the label div width from `` `${100 - archetype.metaShare}%` `` to `` `${(1 - archetype.metaShare) * 100}%` `` so it correctly occupies the remaining portion of the row.
- Moved the 8 px spacing from an inline `marginLeft` on the label div to a `gap: "8px"` on the parent `flex-row` div, so the two children' widths can honestly sum to 100% without overflowing.

## Validation

`uv run --frozen python dev.py lint` — **passed**. The unit test suite requires a live MariaDB instance which was not provisioned; `metagamegrid.jsx` is a React component with no Python unit tests, so no relevant tests were skipped.

Fixes #12585