### PR TITLE
Persist metagame sort selection in localStorage (#12579)

### DIFF
--- a/shared_web/static/js/grid.jsx
+++ b/shared_web/static/js/grid.jsx
@@ -23,13 +23,13 @@ export class Grid extends DataManager {
                 if (stored.sortBy) this.state.sortBy = stored.sortBy;
                 if (stored.sortOrder) this.state.sortOrder = stored.sortOrder;
             }
-        } catch (e) { /* ignore corrupt storage */ }
+        } catch { /* ignore corrupt storage */ }
     }
 
     sort(sortBy, sortOrder = "AUTO") {
         try {
             localStorage.setItem(STORAGE_KEY, JSON.stringify({ sortBy, sortOrder }));
-        } catch (e) { /* ignore storage errors */ }
+        } catch { /* ignore storage errors */ }
         this.setState({ sortBy, sortOrder, "page": 0 });
     }
 

--- a/shared_web/static/js/grid.jsx
+++ b/shared_web/static/js/grid.jsx
@@ -12,8 +12,24 @@ For properties see concrete uses in metagamegrid.
 
 */
 
+const STORAGE_KEY = "metagame-sort";
+
 export class Grid extends DataManager {
+    constructor(props) {
+        super(props);
+        try {
+            const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) || "null");
+            if (stored) {
+                if (stored.sortBy) this.state.sortBy = stored.sortBy;
+                if (stored.sortOrder) this.state.sortOrder = stored.sortOrder;
+            }
+        } catch (e) { /* ignore corrupt storage */ }
+    }
+
     sort(sortBy, sortOrder = "AUTO") {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({ sortBy, sortOrder }));
+        } catch (e) { /* ignore storage errors */ }
         this.setState({ sortBy, sortOrder, "page": 0 });
     }
 

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -89,7 +89,7 @@ const renderSort = (grid) => (
     <React.Fragment>
         {"Sorted by "}
         <form className="inline">
-            <select onChange={(e) => { grid.sort(e.target.value, grid.state.sortOrder); }}>
+            <select value={grid.state.sortBy} onChange={(e) => { grid.sort(e.target.value, grid.state.sortOrder); }}>
                 <option value="quality">Quality</option>
                 <option value="metaShare">Meta Share</option>
                 <option value="winPercent">Win %</option>
@@ -99,7 +99,7 @@ const renderSort = (grid) => (
                 <option value="name">Name</option>
             </select>
             {" : "}
-            <select onChange={(e) => { grid.sort(grid.state.sortBy, e.target.value); }}>
+            <select value={grid.state.sortOrder} onChange={(e) => { grid.sort(grid.state.sortBy, e.target.value); }}>
                 <option value="AUTO">Auto</option>
                 <option value="ASC">Asc</option>
                 <option value="DESC">Desc</option>


### PR DESCRIPTION
## What was wrong

The `/metagame` sort selection (sort field and direction) was not persisted between page loads or when switching seasons/toggling tournament-only mode. Every visit reset to the default `quality / AUTO` sort.

## What changed

**`shared_web/static/js/grid.jsx`**
- Added a `constructor` that reads `{ sortBy, sortOrder }` from `localStorage` under the key `metagame-sort` and uses those values as the initial state, overriding the prop-supplied defaults.
- Overrode `sort()` to write `{ sortBy, sortOrder }` to `localStorage` before calling `setState`, so the selection is saved on every user change.

**`shared_web/static/js/metagamegrid.jsx`**
- Made both sort `<select>` elements controlled by adding `value={grid.state.sortBy}` and `value={grid.state.sortOrder}` so they visually reflect whichever sort was loaded from localStorage (not just the prop-supplied default).

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped (pre-existing skip, unrelated to this change)
- The changed files are JSX (frontend only); there are no Python unit tests for this component, but the full unit suite covers the rest of the codebase.

Fixes #12579

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/48644e05-5eb9-4973-808b-93d0130fa607)
