### PR TITLE
Add quality optimistic, quality strict, and potential sort options to /metagame (#12578)

### DIFF
--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -71,3 +71,25 @@ def test_load_disjoint_archetypes_returns_float_or_none_for_win_percent() -> Non
     assert win_percent_by_id[1] == 66.7
     assert isinstance(win_percent_by_id[1], float)
     assert win_percent_by_id[2] is None
+
+
+@with_test_db
+@pytest.mark.functional
+@pytest.mark.parametrize('sort_by', ['quality', 'qualityOptimistic', 'qualityStrict', 'potential'])
+def test_archetype_quality_sorts_put_no_match_archetypes_last(sort_by: str) -> None:
+    archetype.preaggregate_disjoint_archetypes()
+    db().execute("""
+        INSERT INTO _arch_disjoint_stats
+            (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
+        VALUES
+            (1, 1, 3, 2, 1, 0, 0, 0, 0, 'league'),
+            (2, 1, 1, 0, 0, 1, 0, 0, 0, 'league'),
+            (3, 1, 4, 1, 3, 0, 0, 0, 0, 'league'),
+            (4, 1, 4, 3, 1, 0, 0, 0, 0, 'league')
+    """)
+
+    ascending, _ = archetype.load_disjoint_archetypes(order_by=clauses.archetype_order_by(sort_by, 'ASC'), season_id=1)
+    descending, _ = archetype.load_disjoint_archetypes(order_by=clauses.archetype_order_by(sort_by, 'DESC'), season_id=1)
+
+    assert ascending[-1].id == 2
+    assert descending[-1].id == 2

--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -193,6 +193,9 @@ def archetype_order_by(sort_by: str | None, sort_order: str | None) -> str:
         'name': ('name', 'ASC'),
         'metaShare': ('SUM(wins + losses + draws) / SUM(SUM(wins + losses + draws)) OVER ()', 'DESC'),
         'quality': (wilson_lower_bound_sql(), 'DESC'),
+        'qualityOptimistic': (wilson_lower_bound_sql(confidence_level=0.5), 'DESC'),
+        'qualityStrict': (wilson_lower_bound_sql(confidence_level=0.99999), 'DESC'),
+        'potential': (wilson_upper_bound_sql(), 'DESC'),
         'winPercent': (win_rate, 'DESC'),
         'tournamentWins': ('tournament_wins', 'DESC'),
         'tournamentTop8s': ('tournament_top8s', 'DESC'),
@@ -202,7 +205,8 @@ def archetype_order_by(sort_by: str | None, sort_order: str | None) -> str:
     if sort_order == 'AUTO':
         sort_order = default_order
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
-    primary_order = order_by_nulls_last(col, sort_order) if sort_by == 'winPercent' else f'{col} {sort_order}'
+    nullable_sorts = {'quality', 'qualityOptimistic', 'qualityStrict', 'potential', 'winPercent'}
+    primary_order = order_by_nulls_last(col, sort_order) if sort_by in nullable_sorts else f'{col} {sort_order}'
     return f'{primary_order}, {wilson_lower_bound_sql()} DESC, num_decks DESC, {order_by_nulls_last(win_percent, "DESC")}, name ASC'
 
 def exclude_active_league_runs(except_person_id: int | None) -> str:
@@ -314,6 +318,10 @@ HIGH_CONFIDENCE = 0.95
 def wilson_lower_bound_sql(phat: str = 'SUM(wins) / SUM(wins + losses)', n: str = 'SUM(wins + losses)', confidence_level: float = VERY_HIGH_CONFIDENCE) -> str:
     z = z_value(confidence_level)
     return f'({phat} + {z} * {z} / (2 * {n}) - {z} * SQRT(({phat} * (1 - {phat}) + {z} * {z} / (4 * {n})) / {n})) / (1 + {z} * {z} / {n})'
+
+def wilson_upper_bound_sql(phat: str = 'SUM(wins) / SUM(wins + losses)', n: str = 'SUM(wins + losses)', confidence_level: float = VERY_HIGH_CONFIDENCE) -> str:
+    z = z_value(confidence_level)
+    return f'({phat} + {z} * {z} / (2 * {n}) + {z} * SQRT(({phat} * (1 - {phat}) + {z} * {z} / (4 * {n})) / {n})) / (1 + {z} * {z} / {n})'
 
 def z_value(confidence_level: float) -> float:
     return norm.ppf((1 + confidence_level) / 2)

--- a/decksite/data/clauses_test.py
+++ b/decksite/data/clauses_test.py
@@ -35,6 +35,15 @@ def test_archetype_win_percent_auto_order_remains_descending() -> None:
     assert ordered.startswith(f'{expression} DESC')
 
 
+@pytest.mark.parametrize('sort_by', ['quality', 'qualityOptimistic', 'qualityStrict', 'potential'])
+@pytest.mark.parametrize('sort_order', ['ASC', 'DESC'])
+def test_archetype_quality_ordering_puts_nulls_last(sort_by: str, sort_order: str) -> None:
+    sql = clauses.archetype_order_by(sort_by, sort_order)
+    expression, ordered = sql.split(' IS NULL ASC, ', 1)
+
+    assert ordered.startswith(f'{expression} {sort_order}')
+
+
 def test_decks_where() -> None:
     args = {'deckType': DeckType.LEAGUE.value}
     assert "= 'League'" in clauses.decks_where(args, False, 1)

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -91,6 +91,9 @@ const renderSort = (grid) => (
         <form className="inline">
             <select value={grid.state.sortBy} onChange={(e) => { grid.sort(e.target.value, grid.state.sortOrder); }}>
                 <option value="quality">Quality</option>
+                <option value="qualityOptimistic">Quality (Optimistic)</option>
+                <option value="qualityStrict">Quality (Strict)</option>
+                <option value="potential">Potential</option>
                 <option value="metaShare">Meta Share</option>
                 <option value="winPercent">Win %</option>
                 <option value="tournamentWins">Tournament Wins</option>


### PR DESCRIPTION
## What was wrong

The `/metagame` grid offered only its standard 99%-confidence Quality sort. There was no way to explore promising smaller archetypes, demand much stronger evidence, or rank by the upper end of an archetype's plausible performance.

## What changed

- Added **Quality (Optimistic)**: Wilson lower bound at 50% confidence.
- Added **Quality (Strict)**: Wilson lower bound at 99.999% confidence.
- Added **Potential**: Wilson upper bound at 99% confidence.
- Preserved the existing **Quality** sort at its current 99% confidence.
- Put archetypes without matches last for all four Wilson-based metrics in both ascending and descending order.
- Rebased onto #15064, so these new selections are remembered across reloads, season changes, and tournament-only toggling.

## Validation

- 30 focused tests pass, including MariaDB-backed null-last checks for every quality mode in both directions.
- Python lint passes.
- mypy passes.
- JavaScript lint passes.
- Frontend bundle builds successfully.
- All four quality modes returned 200 and the complete 121-archetype result set in both ascending and descending order against the live local database.
- The rendered browser page contains all three new options and updates the grid when selected.

Fixes #12578
