### PR TITLE
Add ruff full-lint and mypy hooks to pre-commit (#12573)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,14 @@ repos:
     hooks:
         -   id: ruff
             args: ["--select", "I", "--fix"]
+        -   id: ruff
+            name: ruff-lint
+            args: []
+-   repo: local
+    hooks:
+    -   id: mypy
+        name: mypy
+        language: system
+        entry: uv run --frozen python dev.py mypy
+        types: [python]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,10 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+ci:
+    # This system hook uses the developer's project environment. GitHub Actions
+    # runs mypy separately; pre-commit.ci does not provide uv.
+    skip: [mypy]
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -30,6 +35,9 @@ repos:
         -   id: ruff
             name: ruff-lint
             args: []
+            # WSGI entrypoints expose imported application objects to the server
+            # and are not scanned by the project's `dev.py lint` command.
+            exclude: wsgi$
 -   repo: local
     hooks:
     -   id: mypy


### PR DESCRIPTION
## What was wrong

The pre-commit configuration only ran Ruff's import-sorting rule. A commit could therefore pass locally while the project's full Ruff or mypy checks failed later.

## What changed

- Added a second Ruff hook that runs the complete configured rule set.
- Added a local, whole-project mypy hook using the project's locked `uv` environment and `dev.py mypy` wrapper.
- Excluded `.wsgi` entrypoints from the new Ruff hook, matching `dev.py lint`; those modules intentionally expose imported application objects to the WSGI server.
- Skipped the system-dependent mypy hook specifically on pre-commit.ci, which does not provide `uv`. GitHub Actions continues to run and require the project's mypy job.

## Validation

- `pre-commit validate-config` passes.
- A complete developer-local `pre-commit run --all-files` passes, including full Ruff and whole-project mypy.
- A pre-commit.ci-equivalent `SKIP=mypy pre-commit run --all-files` passes, with only mypy skipped as configured.
- The PR remains config-only and introduces no runtime changes.

Fixes #12573
