### PR TITLE
Replace # with 🃏 as deck count icon on /metagame (#12572)

### DIFF
--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -28,7 +28,7 @@ const renderItem = (grid, archetype) => (
                 </span>
                 <span className="additional">
                     <span title="Number of Decks">
-                        #{n(archetype.numDecks)}
+                        🃏{n(archetype.numDecks)}
                     </span>
                     <span title="Number of Matches">
                         ⚔{n(archetype.numMatches)}


### PR DESCRIPTION
## What was wrong

On the `/metagame` grid, the number of decks was prefixed with `#` (e.g. `#42`). The `#` symbol is ambiguous — it reads as "rank" (as in #1) rather than "count of decks", which was confusing.

## What changed

In `shared_web/static/js/metagamegrid.jsx` line 31, replaced `#` with `🃏` (playing card joker emoji). This matches the style of all other stats in the grid which use Unicode/emoji icons: ⚔ for matches, ① for tournament wins, ⑧ for top 8s, and 🏆 for 5-0 league runs. The bundle was rebuilt locally to confirm webpack compiles cleanly.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `npm run build` — compiled successfully with 0 errors (3 pre-existing asset-size warnings, unchanged)
- Bundle confirmed to contain the `🃏` character

Fixes #12572