### PR TITLE
Markdown-escape card names in MtgMixin send paths (#12612)

### DIFF
--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -256,11 +256,12 @@ async def autocomplete_card(ctx: AutocompleteContext) -> None:
 
 class MtgMixin:
     async def send_image_with_retry(self: 'MtgContext', image_file: str, text: str = '') -> None:  # type: ignore
-        message = await self.send(file=File(image_file), content=text)
+        escaped = escape_underscores(text)
+        message = await self.send(file=File(image_file), content=escaped)
         if message and message.attachments and message.attachments[0].size == 0:
             logging.warning('Message size is zero so resending')
             await message.delete()
-            await self.send(file=File(image_file), content=text)
+            await self.send(file=File(image_file), content=escaped)
 
     async def single_card_text(self: 'MtgContext', c: Card, f: Callable, show_legality: bool = True) -> None:  # type: ignore
         if c is None:
@@ -278,7 +279,7 @@ class MtgMixin:
         info_emoji = emoji.info_emoji(c, show_legality=show_legality)
         text = await emoji.replace_emoji(f(c), self.bot)
         message = f'**{name}** {info_emoji} {text}{stale_card_information_warning()}'
-        await self.send(message)
+        await self.send(escape_underscores(message))
 
     async def post_cards(self: 'MtgContext', cards: list[Card], replying_to: User | Member | None = None, additional_text: str = '') -> None:  # type: ignore
         if len(cards) == 0:


### PR DESCRIPTION
## What was wrong

The `MtgMixin` class methods `single_card_text` and `send_image_with_retry` called `self.send()` (the raw Discord library send) directly, bypassing the module-level `send()` wrapper that applies `escape_underscores()`. Card names containing underscores (e.g. names that resolve to oracle text with underscores) would render as Discord markdown formatting rather than literal underscores.

The module-level `send()` at line 165 already escapes underscores correctly; the class methods were a gap.

## What changed

- `MtgMixin.single_card_text` (`command.py:282`): wrap the composed message with `escape_underscores()` before passing to `self.send()`.
- `MtgMixin.send_image_with_retry` (`command.py:259,263`): escape the `text` parameter once up front and reuse the escaped string for both the initial send and the retry, avoiding double-escaping.

Only `discordbot/command.py` was modified; 4 lines changed (+4, -3 net +1).

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit discordbot` — 845 passed, 1 skipped (functional test explicitly skipped by the repo)
- `discordbot/command_test.py::test_escape_underscores` confirms the escaping logic itself is correct

Fixes #12612