### PR TITLE
Fix metagame grid ragged end by using factor-of-24 column counts (#12563)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2848,20 +2848,49 @@ Metagame
 
 /* This is the containing grid from the page HTML. */
 .metagamegrid {
+    container-type: inline-size;
     width: 100%;
 }
 
-/* This is the grid of tiles inside the component. */
+/* This is the grid of tiles inside the component. The standard view contains
+   24 archetypes, so factor-of-24 column counts avoid a short final row. A zero
+   minimum keeps every track the same width regardless of its tile's content.
+   Container queries make the breakpoints follow the grid's available space,
+   which changes independently of the viewport when sidebars appear. */
 .metagame-grid {
     display: grid;
     gap: 0.422rem;
-    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     margin-bottom: 1rem;
 }
 
-@media only screen and (max-width: 500px) {
+@container (min-width: 16rem) {
     .metagame-grid {
-        grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@container (min-width: 24.5rem) {
+    .metagame-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+}
+
+@container (min-width: 33rem) {
+    .metagame-grid {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+}
+
+@container (min-width: 50rem) {
+    .metagame-grid {
+        grid-template-columns: repeat(6, minmax(0, 1fr));
+    }
+}
+
+@container (min-width: 67rem) {
+    .metagame-grid {
+        grid-template-columns: repeat(8, minmax(0, 1fr));
     }
 }
 


### PR DESCRIPTION
## What was wrong

The standard metagame view contains 24 archetypes. Its responsive `auto-fill` grid could choose five or seven columns at intermediate widths, leaving a short final row even though 24 divides evenly into several nearby column counts.

## What changed

The grid now uses container queries to select factor-of-24 column counts: one, two, three, four, six, or eight columns according to the space actually available to the grid. Using the grid container rather than viewport breakpoints keeps the layout correct when the site's sidebars appear or disappear. The breakpoints use the existing mobile-friendly `8rem` practical minimum, so a width that would previously produce five columns advances to six equal columns instead of falling back to four oversized ones.

Each track is `minmax(0, 1fr)`, so every tile in a row remains exactly the same width even when a tile contains a long archetype name or other intrinsically wide content.

## Validation

- Browser-rendered all 24 tiles at 390, 500, 699, 700, 999, 1000, 1100, 1200, 1300, 1400, 1500, 1600, 1800, and 2048 px viewport widths.
- At every tested width, the rendered column count matched the intended factor of 24 and the first-row tile-width spread was 0 px.
- `uv run --frozen python dev.py lint` passed.

Fixes #12563
