### PR TITLE
Explain Quality sort via descriptive tooltip on /metagame (#12555)

### DIFF
--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -9,6 +9,13 @@ const n = (num) => {
     return Number(Math.round(num)).toLocaleString();
 };
 
+const sortExplanations = {
+    quality: "Quality is the 99% confidence lower bound for win rate. It rewards a strong record, but discounts decks with fewer matches.",
+    qualityOptimistic: "Quality (Optimistic) is the 50% confidence lower bound for win rate. It discounts decks with fewer matches less heavily.",
+    qualityStrict: "Quality (Strict) is the 99.999% confidence lower bound for win rate. It discounts decks with fewer matches more heavily.",
+    potential: "Potential is the 99% confidence upper bound for win rate. It highlights decks that could be strong despite having fewer matches."
+};
+
 //  once everything is in place mouseover everything and makes ure the titles are right
 const renderItem = (grid, archetype) => (
     <a className="archetype" href={archetype.url} key={archetype.id}>
@@ -52,7 +59,7 @@ const renderItem = (grid, archetype) => (
             </div>
             {typeof archetype.qualityScore === "number" && (
                 <div className="cell r quality">
-                    <span title="Quality">
+                    <span title={sortExplanations.quality}>
                         <span className="quality-star">★</span>{Number(archetype.qualityScore * 100).toFixed(0)}
                     </span>
                 </div>
@@ -89,7 +96,12 @@ const renderSort = (grid) => (
     <React.Fragment>
         {"Sorted by "}
         <form className="inline">
-            <select value={grid.state.sortBy} onChange={(e) => { grid.sort(e.target.value, grid.state.sortOrder); }}>
+            <select
+                key={grid.state.sortBy}
+                onChange={(e) => { grid.sort(e.target.value, grid.state.sortOrder); }}
+                title={sortExplanations[grid.state.sortBy]}
+                value={grid.state.sortBy}
+            >
                 <option value="quality">Quality</option>
                 <option value="qualityOptimistic">Quality (Optimistic)</option>
                 <option value="qualityStrict">Quality (Strict)</option>


### PR DESCRIPTION
## What was wrong

The Quality score and sort on `/metagame` did not explain what the metric means. The original implementation attached the explanation to a native `<option>`, whose tooltip behavior is inconsistent across browsers.

## What changed

- Adds accurate explanations for Quality, Quality (Optimistic), Quality (Strict), and Potential.
- Shows the relevant tooltip when the user hovers the sort selector itself, without adding a separate icon or changing the layout.
- Uses the standard Quality explanation for the score shown on each metagame tile.

## Validation

- `npm run dev-build`
- `uv run --frozen python dev.py jslint`
- `uv run --frozen python dev.py lint`
- Live browser validation of all four explanations and Meta Share's no-tooltip state.
- Confirmed the direction selector remains at the same horizontal position through every sort change.

Fixes #12555
