### PR TITLE
Extract _season_table_and_where to unify key_cards and key_cards_long (#12566)

### DIFF
--- a/decksite/data/playability.py
+++ b/decksite/data/playability.py
@@ -25,15 +25,15 @@ def preaggregate() -> None:
     preaggregate_season_playability()
     preaggregate_playability()
 
+def _season_table_and_where(season_id: int) -> tuple[str, str]:
+    if season_id:
+        return '_season_archetype_playability', f'p.season_id = {season_id}'
+    return '_archetype_playability', 'TRUE'
+
 # Map of archetype_id => cardname where cardname is the key card for that archetype for the supplied season, or all time if 0 supplied as season_id.
 @retry_after_calling(preaggregate)
 def key_cards(season_id: int) -> dict[int, str]:
-    if season_id:
-        table = '_season_archetype_playability'
-        where = f'p.season_id = {season_id}'
-    else:
-        table = '_archetype_playability'
-        where = 'TRUE'
+    table, where = _season_table_and_where(season_id)
     sql = f"""
         SELECT
             p.archetype_id,
@@ -60,12 +60,7 @@ def key_cards(season_id: int) -> dict[int, str]:
 
 @retry_after_calling(preaggregate)
 def key_cards_long(season_id: int) -> dict[int, list[str]]:
-    if season_id:
-        table = '_season_archetype_playability'
-        where = f'p.season_id = {season_id}'
-    else:
-        table = '_archetype_playability'
-        where = 'TRUE'
+    table, where = _season_table_and_where(season_id)
     where = f'({where}) AND p.playability > {USEFUL_PLAYABILITY_THRESHOLD}'
     sql = f"""
         SELECT


### PR DESCRIPTION
## What was wrong

`key_cards()` and `key_cards_long()` in `decksite/data/playability.py` contained identical `if season_id: ... else: ...` blocks to select the appropriate table (`_season_archetype_playability` vs `_archetype_playability`) and corresponding `WHERE` clause fragment. Any future change to this logic would need to be applied in two places.

## What changed

Extracted the duplicated block into a private helper `_season_table_and_where(season_id: int) -> tuple[str, str]`. Both `key_cards()` and `key_cards_long()` now call this helper and unpack the returned `(table, where)` tuple. No behavior change.

## Validation

- `uv run --frozen python dev.py lint` — passed (exit code 0)
- Unit tests require a live MariaDB database which was not available in the cloud sandbox environment; tests were env-blocked. The change is a pure refactor with no logic change, only moving identical code into a shared helper.

Fixes #12566