### PR TITLE
Guard against already-tz-aware datetimes from PyGithub (#12557)

### DIFF
--- a/decksite/data/news.py
+++ b/decksite/data/news.py
@@ -62,7 +62,7 @@ def code_merges(start_date: datetime.datetime, end_date: datetime.datetime, max_
             merged_at = pull.merged_at
             if merged_at is None or 'Not News' in [label.name for label in pull.as_issue().labels]:
                 continue
-            merges.append(Container({'date': dtutil.UTC_TZ.localize(merged_at), 'title': pull.title, 'url': pull.html_url, 'type': 'code-release'}))
+            merges.append(Container({'date': merged_at if merged_at.tzinfo is not None else dtutil.UTC_TZ.localize(merged_at), 'title': pull.title, 'url': pull.html_url, 'type': 'code-release'}))
         redis.store('decksite:news:merges', merges, ex=7200)
         return merges
     except ConnectionError:

--- a/shared/repo.py
+++ b/shared/repo.py
@@ -140,8 +140,8 @@ def get_pull_requests(start_date: datetime.datetime,
             updated_at = pull.updated_at
             if merged_at is None or updated_at is None:
                 continue
-            merged_dt = dtutil.UTC_TZ.localize(merged_at)
-            updated_dt = dtutil.UTC_TZ.localize(updated_at)
+            merged_dt = merged_at if merged_at.tzinfo is not None else dtutil.UTC_TZ.localize(merged_at)
+            updated_dt = updated_at if updated_at.tzinfo is not None else dtutil.UTC_TZ.localize(updated_at)
             if merged_dt > end_date:
                 continue
             if updated_dt < start_date:


### PR DESCRIPTION
## What was wrong

PyGithub updated to return timezone-aware `datetime` objects for `pull.merged_at` and `pull.updated_at`. The existing code unconditionally called `dtutil.UTC_TZ.localize()` (a pytz method) on these values, which raises `ValueError: Not naive datetime (tzinfo is already set)` when the datetime already carries timezone info. This caused `get_pull_requests()` to throw, so no PRs were fetched and the news feed appeared empty.

## What changed

- `shared/repo.py` lines 143–144: guard each `localize()` call with `if merged_at.tzinfo is not None` so already-aware datetimes are used directly.
- `decksite/data/news.py` line 65: same guard applied to the `merged_at` datetime used when building the merges list.

No schema changes, no new dependencies.

## How it was validated

- `uv run --frozen python dev.py lint` — passed on both touched files.
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped (functional test intentionally excluded by marker) on a live MariaDB instance in the CI environment.

Fixes #12557