### PR TITLE
Scope key_cards_long to current page's archetypes in /api/archetypes2 (#12554)

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -446,7 +446,7 @@ def archetypes2_api() -> Response:
     tournament_only = request.args.get('deckType') == 'tournament'
     season_id = seasons.season_id(str(request.args.get('seasonId')), None)
     results, total = archs.load_disjoint_archetypes(where=where, order_by=order_by, limit=limit, season_id=season_id, tournament_only=tournament_only)
-    archetype_key_cards = playability.key_cards_long(season_id)
+    archetype_key_cards = playability.key_cards_long(season_id, [r.id for r in results])
     cards = oracle.cards_by_name()
     prepare_archetypes_for_api(results, archetype_key_cards, cards, tournament_only, season_id)
     # Remove infinite loops from the results

--- a/decksite/data/playability.py
+++ b/decksite/data/playability.py
@@ -59,9 +59,14 @@ def key_cards(season_id: int) -> dict[int, str]:
 
 
 @retry_after_calling(preaggregate)
-def key_cards_long(season_id: int) -> dict[int, list[str]]:
+def key_cards_long(season_id: int, archetype_ids: list[int] | None = None) -> dict[int, list[str]]:
     table, where = _season_table_and_where(season_id)
     where = f'({where}) AND p.playability > {USEFUL_PLAYABILITY_THRESHOLD}'
+    if archetype_ids is not None:
+        if not archetype_ids:
+            return {}
+        ids = ', '.join(str(i) for i in archetype_ids)
+        where = f'({where}) AND p.archetype_id IN ({ids})'
     sql = f"""
         SELECT
             p.archetype_id,


### PR DESCRIPTION
## What was wrong

`/api/archetypes2` called `playability.key_cards_long(season_id)` which fetched key cards for **every archetype** in the season, even though only the archetypes on the current page (typically ~20) were needed. This was wasteful: each page load scanned all archetypes in the precomputed playability table.

## What changed

- `decksite/data/playability.py`: Added an optional `archetype_ids: list[int] | None = None` parameter to `key_cards_long()`. When provided (and non-empty), appends `AND p.archetype_id IN (<ids>)` to the WHERE clause, limiting the query to only the requested archetypes. An empty list returns `{}` immediately to avoid invalid `IN ()` SQL.
- `decksite/controllers/api.py`: Passes `[r.id for r in results]` as `archetype_ids` so only the current page's archetypes are fetched.

The parameter defaults to `None` so all existing callers (e.g. the `/api/key_cards` route) are unaffected.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped

Fixes #12554