### PR TITLE
Use highlight color for mobile menu hover state (#12560)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1091,7 +1091,7 @@ html.dark-mode .icon.dark-mode-toggle::before {
 }
 
 .menu .item:hover .icon, .submenu .item:hover {
-    background-color: var(--tertiary-background);
+    background-color: var(--highlight);
 }
 
 .menu .current .icon, .submenu .current {


### PR DESCRIPTION
## What was wrong

In `shared_web/static/css/pd.css` line 1093–1095, the `.menu .item:hover .icon` and `.submenu .item:hover` selectors used `background-color: var(--tertiary-background)` (a dark gray / light-gray depending on theme). This looked ugly — especially in dark mode — as the hover highlight was an unrelated gray color.

## What changed

Changed the hover `background-color` from `var(--tertiary-background)` to `var(--highlight)` (soft tangerine orange), matching the color already used for the active/current menu item (`.menu .current .icon` / `.submenu .current`). Now hovering over a menu item shows the same highlight color as the selected state, giving a consistent and intentional visual affordance.

## How it was validated

- `uv run --frozen python dev.py lint` passed.
- Visual inspection of the diff: exactly one line changed in one file, replacing `--tertiary-background` with `--highlight`.
- No unit tests exist for CSS; this is a pure visual change.

Fixes #12560