### PR TITLE
Clear cached decks after archetype assignment

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -19,7 +19,6 @@ from decksite.views.archetype_search import ArchetypeSearch
 from magic import oracle
 from magic.models import Deck
 from shared import dtutil
-from shared import redis_wrapper as redis
 from shared.pd_exception import InvalidArgumentException, InvalidDataException
 from shared_web.decorators import fill_form
 from shared_web.menu import Menu, MenuItem
@@ -92,7 +91,6 @@ def post_archetypes() -> wrappers.Response:
             archetype_id = archetype_ids.pop(0)
             if archetype_id:
                 archs.assign(int(deck_id), int(archetype_id), auth.person_id())
-                redis.clear(f'decksite:deck:{deck_id}')
     elif request.form.get('q') is not None and request.form.get('notq') is not None:
         q = cast(str, request.form.get('q'))
         notq = cast(str, request.form.get('notq'))

--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -23,7 +23,6 @@ from magic import image_fetcher, layout, oracle, seasons, tournaments
 from magic.colors import find_colors
 from magic.models import Card, Deck
 from shared import configuration, dtutil, guarantee
-from shared import redis_wrapper as redis
 from shared.container import Container
 from shared.pd_exception import DoesNotExistException, InvalidArgumentException, TooManyItemsException
 from shared_web import template
@@ -662,7 +661,6 @@ def card_api(card: str) -> Response:
 @fill_form('deck_id', 'archetype_id')
 def post_reassign(deck_id: int, archetype_id: int) -> Response:
     archs.assign(deck_id, archetype_id, auth.person_id())
-    redis.clear(f'decksite:deck:{deck_id}')
     return return_json({'success': True, 'deck_id': deck_id})
 
 @APP.route('/api/rule/update', methods=['POST'])

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -7,6 +7,7 @@ from anytree.iterators import PreOrderIter
 from decksite.data import clauses, deck, preaggregation, query
 from decksite.database import db
 from magic.models import Competition
+from shared import redis_wrapper as redis
 from shared.container import Container
 from shared.database import sqlescape
 from shared.decorators import retry_after_calling
@@ -132,6 +133,7 @@ def assign(deck_id: int, archetype_id: int, person_id: int | None, reviewed: boo
     if not reviewed and similarity is not None:
         db().execute('UPDATE deck_cache SET similarity = %s WHERE deck_id = %s', [similarity, deck_id])
     db().commit('assign_archetype')
+    redis.clear(f'decksite:deck:{deck_id}')
 
 def move(archetype_id: int, parent_id: int) -> None:
     db().begin('move_archetype')

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -31,3 +32,15 @@ def test_season_stats(monkeypatch: pytest.MonkeyPatch, tournament_only: bool, wh
     ]
     assert database.args == [42]
     assert f'AND {where}' in database.sql
+
+
+def test_assign_clears_cached_deck_after_committing(monkeypatch: pytest.MonkeyPatch) -> None:
+    database = mock.Mock()
+    clear = mock.Mock()
+    monkeypatch.setattr(archetype, 'db', lambda: database)
+    monkeypatch.setattr(archetype.redis, 'clear', clear)
+
+    archetype.assign(42, 7, None, False, 72)
+
+    database.commit.assert_called_once_with('assign_archetype')
+    clear.assert_called_once_with('decksite:deck:42')


### PR DESCRIPTION
## Summary

- invalidate the cached deck object after every archetype assignment
- centralize invalidation in `archetype.assign` so classifier, fallback, scraper, admin, and API assignments cannot omit it
- remove duplicate invalidation from the two HTTP callers that already handled it

This fixes the archetype queue showing a freshly written similarity while leaving Current blank until the deck cache expired.

## Validation

- `uv run --frozen pytest decksite/data/archetype_test.py decksite/data/archetype_classifier_test.py decksite/controllers/admin_test.py` — 30 passed
- `uv run --frozen ruff check decksite/data/archetype.py decksite/data/archetype_test.py decksite/controllers/admin.py decksite/controllers/api.py`
- `uv run --frozen mypy decksite/data/archetype.py decksite/controllers/admin.py decksite/controllers/api.py`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2638355e-b4ee-46a8-b32b-4557c7425736)
