### PR TITLE
Exclude bakert from automatic Mergify queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -53,6 +53,7 @@ pull_request_rules:
       when CI passes and trusted comitter
     conditions:
       - author=@PennyDreadfulMTG/automerge
+      - author!=bakert
     actions:
       queue:
 priority_rules:


### PR DESCRIPTION
## Summary

- exclude `bakert` from the trusted-author rule that automatically queues pull requests
- leave automatic queuing unchanged for the other members of `@PennyDreadfulMTG/automerge`
- retain the ability for `bakert` pull requests to be queued explicitly with `@mergifyio queue`

## Validation

- parsed `.mergify.yml` with `js-yaml`
- `git diff --check`

This pull request will itself be automatically queued by the existing rule. Once merged, future pull requests authored by `bakert` will remain open until explicitly queued.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2638355e-b4ee-46a8-b32b-4557c7425736)
