### PR TITLE
Reject ungrounded archetype evidence

### DIFF
--- a/decksite/data/archetype_classifier.py
+++ b/decksite/data/archetype_classifier.py
@@ -23,8 +23,10 @@ The structured answer makes the model identify the primary plan, intended castab
 literal decklist evidence, competing candidates, and whether the chosen name's qualifiers fit.
 These are judgment aids rather than mechanical color rules: reanimation targets, alternate
 costs, narrow sideboard splashes, and incidental activations can all be deliberately off-color.
-They are logged with the candidates and final choice so a bad suggestion can be investigated;
-confidence and the chosen archetype remain the only values stored in the database.
+They are logged with the candidates and final choice so a bad suggestion can be investigated.
+If cited evidence is not in the literal list, the answer is discarded and the nearest-deck
+fallback is used; this avoids both saving a hallucinated answer and paying to retry it hourly.
+Confidence and the chosen archetype remain the only values stored in the database.
 
 Playability and archetype card profiles are database-preaggregated, and load_decks can reuse
 Redis-cached deck objects. Similarity scores are still recomputed for every nonempty run; the
@@ -195,10 +197,12 @@ def _classify_one(api_key: str, model: str, d: Deck, meta: Metadata, new_cards: 
     unsupported_evidence = [name for name in evidence_cards if name not in listed_cards]
     if unsupported_evidence:
         logger.warning(
-            'archetype_classifier: deck %s cited cards absent from submitted decklist: %s',
+            'archetype_classifier: deck %s cited cards absent from submitted decklist: %s; using nearest-deck fallback',
             d.id,
             unsupported_evidence,
         )
+        _fallback_one(d)
+        return
     if chosen.upper() == NONE_ANSWER or chosen.lower() not in name_to_id:
         # Nothing fit: leave for a human. A future novelty pass can use this + possible_new_variant.
         return
@@ -384,9 +388,13 @@ def _base_root_ids() -> list[int]:
 
 def _fallback(decks: list[Deck]) -> None:
     for d in decks:
-        for s in getattr(d, 'similar_decks', []):
-            if s.reviewed and s.archetype_id is not None:
-                sim = int(100 * deck.similarity_score(d, s))
-                if d.archetype_id != s.archetype_id:
-                    archetype.assign(d.id, s.archetype_id, None, False, sim)
-                break
+        _fallback_one(d)
+
+
+def _fallback_one(d: Deck) -> None:
+    for s in getattr(d, 'similar_decks', []):
+        if s.reviewed and s.archetype_id is not None:
+            sim = int(100 * deck.similarity_score(d, s))
+            if d.archetype_id != s.archetype_id:
+                archetype.assign(d.id, s.archetype_id, None, False, sim)
+            break

--- a/decksite/data/archetype_classifier_test.py
+++ b/decksite/data/archetype_classifier_test.py
@@ -141,7 +141,7 @@ def test_classify_one_clamps_confidence(monkeypatch: pytest.MonkeyPatch, reporte
     assign.assert_called_once_with(1, 7, None, False, stored)
 
 
-def test_classify_one_logs_decision_context_and_unsupported_evidence(
+def test_classify_one_rejects_unsupported_evidence(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -168,20 +168,24 @@ def test_classify_one_logs_decision_context_and_unsupported_evidence(
         },
     )
     monkeypatch.setattr(archetype_classifier.archetype, 'assign', assign)
+    monkeypatch.setattr(archetype_classifier.deck, 'similarity_score', lambda _d, _s: 0.72)
     caplog.set_level('INFO', logger=archetype_classifier.__name__)
+    similar = Container(id=2, reviewed=True, archetype_id=7)
     source = Container(
         id=1,
+        archetype_id=None,
         maindeck=[CardRef('Priest of Fell Rites', 4)],
         sideboard=[],
+        similar_decks=[similar],
     )
 
     archetype_classifier._classify_one('secret', 'model', source, {}, set())
 
-    assign.assert_called_once_with(1, 8, None, False, 96)
+    assign.assert_called_once_with(1, 7, None, False, 72)
     assert "candidates=['Rakdos Reanimator', 'Traditional Reanimator']" in caplog.text
     assert "plan='reanimate large creatures'" in caplog.text
     assert "colors=['White', 'Black', 'Red']" in caplog.text
-    assert "cited cards absent from submitted decklist: ['Card From Candidate Profile']" in caplog.text
+    assert "cited cards absent from submitted decklist: ['Card From Candidate Profile']; using nearest-deck fallback" in caplog.text
 
 
 def test_call_logs_anthropic_error_response(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary
- reject classifier answers that cite cards absent from the submitted decklist
- use the existing nearest-deck fallback instead of saving the ungrounded answer or retrying it hourly
- retain decision logging and document the behavior alongside the classifier design

## Testing
- `uv run --frozen pytest decksite/data/archetype_classifier_test.py decksite/data/archetype_test.py`
- `uv run --frozen ruff check decksite/data/archetype_classifier.py decksite/data/archetype_classifier_test.py`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/2638355e-b4ee-46a8-b32b-4557c7425736)
