### PR TITLE
Raise InvalidSearchException for empty search expressions like () (#10105)

### DIFF
--- a/find/find_test.py
+++ b/find/find_test.py
@@ -345,6 +345,10 @@ def test_oracle_and_fulloracle() -> None:
     do_functional_test('o:"That enchantment gains"', ['Balduvian Shaman'], ['Echoing Calm', 'Plains'])
     do_functional_test('fo:"That enchantment gains"', ['Balduvian Shaman'], ['Echoing Calm', 'Plains'])
 
+def test_empty_parentheses() -> None:
+    with pytest.raises(search.InvalidSearchException):
+        do_test('()', '')
+
 @pytest.mark.functional
 def test_parentheses_functional() -> None:
     with pytest.raises(search.InvalidSearchException):

--- a/find/search.py
+++ b/find/search.py
@@ -154,7 +154,10 @@ def parse(expression: Expression) -> str:
         elif next_cls != BooleanOperator or next_token.value() == 'NOT':  # type: ignore
             s += ' AND '
         i += 1
-    return s[:-len(' AND ')].replace('    ', ' ').strip()
+    result = s[:-len(' AND ')].replace('    ', ' ').strip()
+    if not result:
+        raise InvalidSearchException('Empty search expression')
+    return result
 
 # Parse key, operator and term tokens into a SQL boolean or raise if the tokens are invalid in combination.
 def parse_criterion(key: Token, operator: Token, term: Token) -> str:


### PR DESCRIPTION
## What was wrong

Searching for `()` or another empty parenthesized expression produced an empty SQL fragment. That fragment reached a `WHERE` clause as invalid SQL, causing a server error and leaving the search UI stuck on “Unable to load.”

## What changed

`parse()` now rejects an empty parsed expression with `InvalidSearchException`. The existing card-search error handling converts that into a safe, user-visible search error instead of executing invalid SQL. Nested and whitespace-only empty parentheses follow the same path.

A focused regression test covers `()`.

## Validation

- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py unit find` — 61 passed

Fixes #10105
