### PR TITLE
Fix badge z-index hack using DOM order and li as containing block (#12593)

### DIFF
--- a/decksite/templates/menu.mustache
+++ b/decksite/templates/menu.mustache
@@ -2,15 +2,15 @@
 <ul class="menu badges">
     {{#menu}}
         <li class="{{#admin_only}}admin{{/admin_only}} {{#demimod_only}}demimod{{/demimod_only}}">
+            <a class="item {{#current}}current{{/current}}" href="{{url}}">
+                <div class="icon {{endpoint}}"></div>
+                {{name}}
+            </a>
             {{#badge}}
                 <div class="badge-holder">
                     <a class="badge {{class_name}}" href="{{url}}">{{text}}</a>
                 </div>
             {{/badge}}
-            <a class="item {{#current}}current{{/current}}" href="{{url}}">
-                <div class="icon {{endpoint}}"></div>
-                {{name}}
-            </a>
             {{#has_submenu}}
                 <div class="submenu">
                     <ul>

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -862,7 +862,7 @@ nav, .menu, .submenu {
     padding: 12px 8px;
 }
 
-nav li:hover > .item + .submenu {
+nav li:hover > .item ~ .submenu {
     display: block;
     width: var(--submenu-width);
     z-index: 5;
@@ -885,7 +885,7 @@ When you are in a middle width the main menu is always shown but the submenu is 
 */
 @media only screen and (max-width: 900px), only screen and (min-width: 1601px) {
     /* Expand nav width when hovering over a menu item with a submenu */
-    nav:has(li:hover > .item + .submenu), nav:has(li.submenu-open > .item + .submenu) {
+    nav:has(li:hover > .item ~ .submenu), nav:has(li.submenu-open > .item ~ .submenu) {
         width: var(--full-menu-width);
         z-index: 4;
     }
@@ -913,13 +913,13 @@ When you are in a middle width the main menu is always shown but the submenu is 
         overflow: visible;
         position: relative
     }
-    nav:has(li:hover > .item + .submenu) {
+    nav:has(li:hover > .item ~ .submenu) {
         width: var(--main-menu-width);
     }
 }
 
 /* Fade hover submenus at every width. Touch navigation does not sustain this hover state. */
-nav li > .item + .submenu {
+nav li > .item ~ .submenu {
     display: block;
     opacity: 0;
     transition:
@@ -928,7 +928,7 @@ nav li > .item + .submenu {
     visibility: hidden;
     width: var(--submenu-width);
 }
-nav li.submenu-open > .item + .submenu {
+nav li.submenu-open > .item ~ .submenu {
     opacity: 1;
     transition-delay: 0s;
     visibility: visible;
@@ -940,7 +940,7 @@ nav li.submenu-open > .item + .submenu {
     nav:has(.current ~ .submenu) {
         width: var(--full-menu-width);
     }
-    nav li > .current + .submenu {
+    nav li > .current ~ .submenu {
         display: block;
         opacity: 1;
         visibility: visible;
@@ -981,7 +981,7 @@ nav.showing .menu {
     width: var(--main-menu-width);
 }
 
-nav.showing .current + .submenu {
+nav.showing .current ~ .submenu {
     display: block;
     opacity: 1;
     visibility: visible;
@@ -1606,17 +1606,6 @@ header, nav, main, footer {
 .status-bar {
     z-index: 2;
     box-shadow: var(--elevation-2);
-}
-
-/*
-
-This is a bit of a hack to have the badge appear "above" the menu item so that clicking it works.
-Ideally they're at the same level but this appears later in the HTML so it's still clickable.
-
-*/
-.badge-holder {
-    z-index: 3;
-    /* This is just a div containing the floating number/link to the admin archetypes page and doesn't need a box shadow. */
 }
 
 .scrim {
@@ -2661,9 +2650,8 @@ Notification Badges
 
 */
 
-/* Menu items needed to be positioned statically for dropdowns to work, but the badge needs a relatively-positioned parent in the menu item. */
-.badge-holder {
-    position: relative;
+ul.menu > li {
+    position: relative; /* Establishes containing block for the absolutely-positioned badge. */
 }
 
 /*


### PR DESCRIPTION
## What was wrong

The archetype-sort badge in the nav menu relied on a `z-index: 3` hack on `.badge-holder` to paint above the `<a class="item">` link and remain clickable. The badge appeared *before* the item in the HTML, so without the elevated z-index the item link (which came later in the DOM) would paint over it. The z-index value (3) conflicted with the intentional z-index design table in `pd.css`, where level 3 was explicitly reserved as empty.

## What changed

**`decksite/templates/menu.mustache`** — Moved the `{{#badge}}…{{/badge}}` block to *after* the `<a class="item">` element. The badge now appears later in the DOM, so it naturally paints above the item link in the same stacking context — no z-index needed.

**`shared_web/static/css/pd.css`**:
- Replaced the old `.badge-holder { position: relative }` rule with `ul.menu > li { position: relative }`, making the `<li>` the containing block for the absolutely-positioned `.badge`. The badge's `top: 13px; right: 1.5rem` values are unchanged and remain visually correct (the badge-holder had zero height and sat at `<li>`'s top anyway, so the coordinate origin is the same).
- Removed the `z-index: 3` hack block on `.badge-holder` (and its explanatory comment).
- Updated all six `> .item + .submenu` / `> .current + .submenu` adjacent-sibling selectors to general-sibling `~` selectors, since the badge-holder `<div>` can now appear between `.item` and `.submenu` in the DOM.

## How it was validated

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python -m pytest decksite/ -x -m 'not functional and not perf'` — 426 passed, 6 deselected
- The existing `test_menu_badge_is_entirely_linked` test continues to pass; it verifies the badge link renders correctly in the template.

Fixes #12593