### PR TITLE
Make deck ordering deterministic by appending d.id to ORDER BY (#12571)

### DIFF
--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -85,7 +85,7 @@ def load_decks_query(columns: str,
                      season_id: str | int | None = None,
                      ) -> str:
     if order_by is None:
-        order_by = 'active_date DESC, d.finish IS NULL, d.finish'
+        order_by = 'active_date DESC, d.finish IS NULL, d.finish, d.id'
     if group_by is None:
         group_by = ''
     else:
@@ -156,7 +156,7 @@ def load_decks_heavy(where: str = 'TRUE',
                      season_id: str | int | None = None,
                      ) -> tuple[list[Deck], int]:
     if order_by is None:
-        order_by = 'active_date DESC, d.finish IS NULL, d.finish'
+        order_by = 'active_date DESC, d.finish IS NULL, d.finish, d.id'
 
     sql = """
         SELECT


### PR DESCRIPTION
## Problem

The competition detail page shows losing decks (those with a `finish` value) in an unstable order. When multiple decks share the same `active_date` and `finish` value (e.g. several decks that all lost in the same round), MySQL/MariaDB does not guarantee a consistent tie-breaking order, so the ordering could vary between page loads or database restarts.

## Fix

Appended `, d.id` to the default `ORDER BY` clause in two places in `decksite/data/deck.py`:

- `load_decks_query` (line 88) — used for the lightweight deck list query
- `load_decks_heavy` (line 159) — used for the heavy deck list query with win/loss counts

Both defaulted to `active_date DESC, d.finish IS NULL, d.finish`. Adding `d.id` as a final tiebreaker makes the sort fully deterministic since `d.id` is a unique primary key.

## Validation

- `uv run --frozen python dev.py lint` — passed (All checks passed)
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped, 89 deselected in 17.90s

Fixes #12571