### PR TITLE
Show top archetypes by deck count on home page (#12568)

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import InternalServerError
 
 from decksite import APP, SEASONS, auth, deck_name, get_season_id
 from decksite.cache import cached
+from decksite.data import archetype as archs
 from decksite.data import card as cs
 from decksite.data import deck as ds
 from decksite.data import match as ms
@@ -25,10 +26,12 @@ from shared.pd_exception import TooFewItemsException
 @APP.route('/')
 @cached()
 def home() -> str:
-    decks = ds.latest_decks(season_id=get_season_id())
+    season_id = get_season_id()
+    decks = ds.latest_decks(season_id=season_id)
     top_8_plus_basics = 'LIMIT 13'
-    cards, total = cs.load_cards(limit=top_8_plus_basics, season_id=get_season_id())
-    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats())
+    cards, total = cs.load_cards(limit=top_8_plus_basics, season_id=season_id)
+    all_archetypes = archs.load_archetypes(order_by='num_decks DESC', season_id=season_id)
+    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats(), all_archetypes)
     return view.page()
 
 @APP.route('/export/<int:deck_id>/')

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -5,6 +5,30 @@
         <p><a href="{{url}}">{{link_text}}</a></p>
     </section>
 {{/deck_tables}}
+{{#has_top_archetypes}}
+    <section>
+        <h2>{{_ Top Archetypes}}</h2>
+        <table>
+            <thead>
+                <th>Archetype</th>
+                <th># Decks</th>
+                <th>Record</th>
+                <th>Win %</th>
+            </thead>
+            <tbody>
+                {{#archetypes}}
+                    <tr data-href="{{url}}" class="clickable">
+                        <td><a href="{{url}}">{{name}}</a></td>
+                        <td class="n">{{num_decks}}</td>
+                        <td class="n">{{#show_record}}{{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}{{/show_record}}</td>
+                        <td class="n">{{#show_record}}{{win_percent}}{{/show_record}}</td>
+                    </tr>
+                {{/archetypes}}
+            </tbody>
+        </table>
+        <p><a href="{{archetypes_url}}">{{_ More archetypes…}}</a></p>
+    </section>
+{{/has_top_archetypes}}
 {{#has_top_cards}}
     <section>
         <h2>{{_ Top Cards}}</h2>

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -1,6 +1,7 @@
 from flask import url_for
 from flask_babel import gettext
 
+from decksite.data.archetype import Archetype
 from decksite.view import View
 from magic import rotation, seasons, tournaments
 from magic.models import Card, Deck
@@ -9,11 +10,12 @@ from shared.container import Container
 
 
 class Home(View):
-    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int]) -> None:
+    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int], all_archetypes: list[Archetype]) -> None:
         super().__init__()
         self.setup_news(news)
         self.setup_decks(decks)
         self.setup_cards(cards)
+        self.setup_archetypes(all_archetypes)
         self.setup_rotation()
         self.setup_stats(matches_stats)
         self.setup_tournaments()
@@ -92,6 +94,12 @@ class Home(View):
         self.has_top_cards = len(cards) > 0
         self.cards = self.top_cards  # To get prepare_card treatment
         self.cards_url = url_for('.cards')
+
+    def setup_archetypes(self, all_archetypes: list[Archetype]) -> None:
+        top = [a for a in all_archetypes if a.get('num_decks')][:8]
+        self.archetypes = top
+        self.has_top_archetypes = len(top) > 0
+        self.archetypes_url = url_for('.archetypes')
 
     def setup_rotation(self) -> None:
         self.season_start_display = dtutil.display_date(seasons.last_rotation())


### PR DESCRIPTION
## What was wrong

The home page showed recent decks, top cards, tournament calendar, news, and community stats, but no metagame context — visitors had no quick sense of what archetypes are dominating the current season without navigating away.

## What changed

- `decksite/main.py`: imports the archetype data module and loads all archetypes ordered by `num_decks DESC` for the current season, then passes them to the `Home` view.
- `decksite/views/home.py`: adds a `setup_archetypes` method that selects the top 8 archetypes with at least one deck and sets `self.archetypes` (triggering the existing `prepare_archetypes` pipeline that adds URLs and `show_record` flags), plus `has_top_archetypes` and `archetypes_url` for the template.
- `decksite/templates/home.mustache`: adds a "Top Archetypes" table section (name, # decks, record, win %) immediately after the recent-deck tables, styled consistently with the existing Top Cards section, with a link to the full archetypes page.

## How it was validated

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped (the single skip is a pre-existing functional test skip unrelated to this change)

Fixes #12568