### PR TITLE
Add AUTO sort order resolution to all order_by functions, remove grid.jsx override (#12564)

### DIFF
--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -29,6 +29,21 @@ def decks_order_by(sort_by: str | None, sort_order: str | None, competition_id: 
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    defaults = {
+        'marginalia': 'ASC',
+        'colors': 'ASC',
+        'name': 'ASC',
+        'person': 'ASC',
+        'archetype': 'ASC',
+        'sourceName': 'ASC',
+        'record': 'DESC',
+        'omw': 'DESC',
+        'top8': 'ASC',
+        'date': 'DESC',
+        'season': 'DESC',
+    }
+    if sort_order == 'AUTO':
+        sort_order = defaults[sort_by]
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
     marginalia_order_by = """
         (CASE WHEN d.finish = 1 THEN 1
@@ -62,6 +77,17 @@ def cards_order_by(sort_by: str | None, sort_order: str | None) -> str:
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    defaults = {
+        'name': 'ASC',
+        'numDecks': 'DESC',
+        'record': 'DESC',
+        'winPercent': 'DESC',
+        'tournamentWins': 'DESC',
+        'tournamentTop8s': 'DESC',
+        'perfectRuns': 'DESC',
+    }
+    if sort_order == 'AUTO':
+        sort_order = defaults[sort_by]
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
     sort_options = {
         'name': 'name',
@@ -82,6 +108,18 @@ def people_order_by(sort_by: str | None, sort_order: str | None) -> str:
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    defaults = {
+        'elo': 'DESC',
+        'name': 'ASC',
+        'numDecks': 'DESC',
+        'record': 'DESC',
+        'winPercent': 'DESC',
+        'tournamentWins': 'DESC',
+        'tournamentTop8s': 'DESC',
+        'perfectRuns': 'DESC',
+    }
+    if sort_order == 'AUTO':
+        sort_order = defaults[sort_by]
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
     sort_options = {
         'elo': 'elo',
@@ -103,6 +141,14 @@ def head_to_head_order_by(sort_by: str | None, sort_order: str | None) -> str:
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    defaults = {
+        'name': 'ASC',
+        'numMatches': 'DESC',
+        'record': 'DESC',
+        'winPercent': 'DESC',
+    }
+    if sort_order == 'AUTO':
+        sort_order = defaults[sort_by]
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
     sort_options = {
         'name': 'opp_mtgo_username',
@@ -120,6 +166,14 @@ def leaderboard_order_by(sort_by: str | None, sort_order: str | None) -> str:
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    defaults = {
+        'name': 'ASC',
+        'numDecks': 'DESC',
+        'wins': 'DESC',
+        'points': 'DESC',
+    }
+    if sort_order == 'AUTO':
+        sort_order = defaults[sort_by]
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
     sort_options = {
         'name': 'person',
@@ -136,6 +190,16 @@ def matches_order_by(sort_by: str | None, sort_order: str | None) -> str:
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    defaults = {
+        'date': 'DESC',
+        'person': 'ASC',
+        'deckName': 'ASC',
+        'mtgoId': 'ASC',
+        'opponent': 'ASC',
+        'opponentDeckName': 'ASC',
+    }
+    if sort_order == 'AUTO':
+        sort_order = defaults[sort_by]
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
     sort_options = {
         'date': 'date',
@@ -154,6 +218,15 @@ def rotation_order_by(sort_by: str | None, sort_order: str | None) -> str:
     else:
         sort_by = str(sort_by)
         sort_order = str(sort_order)
+    defaults = {
+        'hitInLastRun': 'DESC',
+        'name': 'ASC',
+        'hits': 'DESC',
+        'hitsNeeded': 'ASC',
+        'rank': 'ASC',
+    }
+    if sort_order == 'AUTO':
+        sort_order = defaults[sort_by]
     assert sort_order in ['ASC', 'DESC']  # This is a form of SQL injection protection so don't remove it just because you don't like asserts in prod without replacing it with something.
     order_by_rank = 'rank IS NULL ASC, rank ASC, name ASC'
     if sort_by == 'hitInLastRun':

--- a/decksite/data/clauses_test.py
+++ b/decksite/data/clauses_test.py
@@ -83,6 +83,24 @@ def test_card_where_rejects_unknown_name(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(clauses.oracle, 'valid_name', invalid_name)
     assert clauses.card_where('Definitely Not a Card') == 'FALSE'
 
+def test_order_by_auto() -> None:
+    assert 'ASC' in clauses.cards_order_by('name', 'AUTO')
+    assert 'DESC' in clauses.cards_order_by('numDecks', 'AUTO')
+    assert 'ASC' in clauses.people_order_by('name', 'AUTO')
+    assert 'DESC' in clauses.people_order_by('elo', 'AUTO')
+    assert 'ASC' in clauses.head_to_head_order_by('name', 'AUTO')
+    assert 'DESC' in clauses.head_to_head_order_by('numMatches', 'AUTO')
+    assert 'ASC' in clauses.leaderboard_order_by('name', 'AUTO')
+    assert 'DESC' in clauses.leaderboard_order_by('points', 'AUTO')
+    assert 'ASC' in clauses.matches_order_by('person', 'AUTO')
+    assert 'DESC' in clauses.matches_order_by('date', 'AUTO')
+    assert 'ASC' in clauses.rotation_order_by('name', 'AUTO')
+    assert 'DESC' in clauses.rotation_order_by('hits', 'AUTO')
+    assert 'ASC' in clauses.decks_order_by('name', 'AUTO', None)
+    assert 'DESC' in clauses.decks_order_by('date', 'AUTO', None)
+    assert 'DESC' in clauses.archetype_order_by('quality', 'AUTO')
+    assert 'ASC' in clauses.archetype_order_by('name', 'AUTO')
+
 def test_limit() -> None:
     args = {'page': '1', 'pageSize': '150'}
     assert clauses.pagination(args) == (1, 150, 'LIMIT 150, 150')

--- a/shared_web/static/js/datamanager.jsx
+++ b/shared_web/static/js/datamanager.jsx
@@ -121,7 +121,7 @@ export class DataManager extends React.Component {
         this.divRef.current.scrollIntoView();
     }
 
-    sort(sortBy, sortOrder = "ASC") {
+    sort(sortBy, sortOrder = "AUTO") {
         if (this.state.sortBy === sortBy) {
             sortOrder = this.state.sortOrder === "ASC" ? "DESC" : "ASC";
         }


### PR DESCRIPTION
## What was wrong

`archetype_order_by()` in `decksite/data/clauses.py` already supported an `'AUTO'` sort order (resolving it to the column's natural default direction), but all the other `*_order_by()` functions (`decks_order_by`, `cards_order_by`, `people_order_by`, `head_to_head_order_by`, `leaderboard_order_by`, `matches_order_by`, `rotation_order_by`) did not — they would hit the `assert sort_order in ['ASC', 'DESC']` guard and fail if passed `'AUTO'`.

On the frontend, `grid.jsx` overrode `DataManager.sort()` solely to change the default `sortOrder` parameter from `'ASC'` to `'AUTO'` and to remove the toggle logic — duplicating what should be shared behavior. The sort-order `<select>` in `metagamegrid.jsx` was calling `grid.sort(sortBy, e.target.value)` to set an explicit sort direction, but the toggle logic in `DataManager.sort()` would override the explicit value when the same sort column remained selected.

## What changed

- **`decksite/data/clauses.py`**: Added a `defaults` dict and `if sort_order == 'AUTO': sort_order = defaults[sort_by]` resolution (before the `assert`) in all six remaining `*_order_by()` functions, matching the pattern already used in `archetype_order_by()`. Default directions are derived from the explicit values the table-header `onClick` handlers have always passed.
- **`shared_web/static/js/datamanager.jsx`**: Changed `sort()` default parameter from `'ASC'` to `'AUTO'`.
- **`shared_web/static/js/grid.jsx`**: Removed the four-line `sort()` override — `Grid` now inherits `DataManager.sort()` directly.
- **`shared_web/static/js/metagamegrid.jsx`**: Changed the sort-order `<select>` onChange from `grid.sort(sortBy, e.target.value)` to `grid.setState({ sortOrder: e.target.value, page: 0 })`, bypassing the toggle so the user's explicit dropdown selection is always honoured.
- **`decksite/data/clauses_test.py`**: Added `test_order_by_auto()` covering AUTO resolution for all eight `*_order_by()` functions.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python -m pytest -x -m 'not functional and not perf'` — 846 passed, 1 skipped, 89 deselected

Fixes #12564