### PR TITLE
Add description to every bot slash command (#12553)

### DIFF
--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -1,12 +1,33 @@
 import datetime
+import glob
+import importlib
+import inspect
+import os
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from interactions.models.internal.application_commands import SlashCommand
 
 from discordbot import command, commands
 from discordbot.commands import CardConverter, resources
 from magic.models import Card, Printing
+
+
+def test_all_slash_commands_have_descriptions() -> None:
+    commands_dir = os.path.join(os.path.dirname(__file__), 'commands')
+    paths = glob.glob(os.path.join(commands_dir, '*.py'))
+    missing = []
+    for path in sorted(paths):
+        name = os.path.basename(path)[:-3]
+        if name.startswith('_') or name.endswith('_test'):
+            continue
+        module = importlib.import_module(f'discordbot.commands.{name}')
+        for _cls_name, cls in inspect.getmembers(module, inspect.isclass):
+            for _attr_name, obj in inspect.getmembers_static(cls):
+                if isinstance(obj, SlashCommand) and str(obj.description) == 'No Description Set':
+                    missing.append(f'{name}.{obj.name}')
+    assert missing == [], f'Slash commands missing descriptions: {missing}'
 
 
 def test_command_setup_does_not_load_test_modules(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/discordbot/commands/art.py
+++ b/discordbot/commands/art.py
@@ -10,7 +10,7 @@ from magic.models import Card
 
 
 class Art(Extension):
-    @slash_command()
+    @slash_command(description='Display the artwork of the requested card.')
     @command.slash_card_option()
     async def art(self, ctx: MtgInteractionContext, card: Card) -> None:
         """Display the artwork of the requested card."""

--- a/discordbot/commands/barbs.py
+++ b/discordbot/commands/barbs.py
@@ -4,7 +4,7 @@ from discordbot.command import MtgMessageContext
 
 
 class Barbs(Extension):
-    @slash_command()
+    @slash_command(description="Volvary's advice for when to board in Aura Barbs.")
     async def barbs(self, ctx: MtgMessageContext) -> None:
         """Volvary's advice for when to board in Aura Barbs."""
         msg = "Heroic doesn't get that affected by Barbs. Bogles though. Kills their creature, kills their face."

--- a/discordbot/commands/bug.py
+++ b/discordbot/commands/bug.py
@@ -6,7 +6,7 @@ from shared import repo
 
 
 class Bug(Extension):
-    @slash_command()
+    @slash_command(description='Report a bug or task for the Penny Dreadful Tools team.')
     @slash_option('title', 'One sentence description of the issue', OptionType.STRING, required=True)
     @slash_option('body', 'More info', OptionType.STRING)
     async def bug(self, ctx: MtgContext, title: str, body: str | None = None) -> None:
@@ -21,7 +21,7 @@ class Bug(Extension):
         else:
             await ctx.send(f'Issue has been reported at <{issue.html_url}>')
 
-    @slash_command('gbug')
+    @slash_command('gbug', description='Report a Gatherling bug.')
     @slash_option('title', 'One sentence description of the issue', OptionType.STRING, required=True)
     @slash_option('body', 'More info', OptionType.STRING)
     async def gatherlingbug(self, ctx: MtgContext, title: str, body: str | None = None) -> None:

--- a/discordbot/commands/burningofxinye.py
+++ b/discordbot/commands/burningofxinye.py
@@ -4,7 +4,7 @@ from discordbot.command import MtgContext
 
 
 class BurningOfXinye(Extension):
-    @slash_command()
+    @slash_command(description="Information about Burning of Xinye's rules.")
     async def burningofxinye(self, ctx: MtgContext) -> None:
         """Information about Burning of Xinye's rules."""
         await ctx.send('https://katelyngigante.tumblr.com/post/163849688389/why-the-mtgo-bug-that-burning-of-xinye-allows')

--- a/discordbot/commands/clearimagecache.py
+++ b/discordbot/commands/clearimagecache.py
@@ -9,7 +9,7 @@ from shared import configuration
 
 
 class ClearImageCache(Extension):
-    @slash_command('clear-image-cache')
+    @slash_command('clear-image-cache', description='Deletes all the cached images.')
     @check(is_owner())
     async def clearimagecache(self, ctx: MtgContext) -> None:
         """Deletes all the cached images.  Use sparingly"""

--- a/discordbot/commands/configure.py
+++ b/discordbot/commands/configure.py
@@ -15,7 +15,7 @@ class ConfigError(CommandException):
         self.scope = scope
 
 class Configure(Extension):
-    @slash_command()
+    @slash_command(description='Configure bot settings for this server or channel.')
     @slash_option('scope', "'channel' or 'server'", OptionType.STRING, True)
     @slash_option('setting', 'key=value', OptionType.STRING, True)
     @check(is_owner())

--- a/discordbot/commands/debug.py
+++ b/discordbot/commands/debug.py
@@ -12,7 +12,7 @@ from discordbot.command import MtgContext
 
 
 class PDDebug(Extension):
-    @slash_command()
+    @slash_command(description='Reload a bot extension.')
     @check(is_owner())
     async def regrow(self, ctx: MtgContext, module: str) -> None:
         try:
@@ -39,7 +39,7 @@ class PDDebug(Extension):
             return
         raise
 
-    @slash_command()
+    @slash_command(description='Enable the debug extension.')
     @check(is_owner())
     async def enable_debugger(self, ctx: MtgContext) -> None:
         self.bot.load_extension('interactions.ext.debug_extension')

--- a/discordbot/commands/downtimes.py
+++ b/discordbot/commands/downtimes.py
@@ -6,7 +6,7 @@ from shared import fetch_tools
 
 
 class Downtimes(Extension):
-    @slash_command()
+    @slash_command(description='Show Magic Online scheduled downtime information.')
     async def downtimes(self, ctx: MtgInteractionContext) -> None:
         await ctx.defer()
         await ctx.send(await fetch_tools.fetch_async('https://pennydreadfulmtg.github.io/modo-bugs/downtimes.txt'))

--- a/discordbot/commands/echo.py
+++ b/discordbot/commands/echo.py
@@ -5,7 +5,7 @@ from discordbot.command import MtgContext
 
 
 class Echo(Extension):
-    @slash_command()
+    @slash_command(description='Repeat after me…')
     @slash_option('message', 'Thing to say', OptionType.STRING, True)
     async def echo(self, ctx: MtgContext, message: str) -> None:
         """Repeat after me…"""

--- a/discordbot/commands/flavor.py
+++ b/discordbot/commands/flavor.py
@@ -7,7 +7,7 @@ from magic.models import Card
 
 
 class Flavour(Extension):
-    @slash_command('flavor')
+    @slash_command('flavor', description='Flavor text of a card.')
     @slash_card_option()
     async def flavor(self, ctx: MtgInteractionContext, card: Card) -> None:
         """Flavor text of a card"""

--- a/discordbot/commands/google.py
+++ b/discordbot/commands/google.py
@@ -9,7 +9,7 @@ from shared import configuration
 
 
 class Google(Extension):
-    @slash_command('google')
+    @slash_command('google', description='Google search.')
     @slash_option('query', 'Search terms', OptionType.STRING, required=True)
     async def google(self, ctx: MtgContext, query: str) -> None:
         """Google search"""

--- a/discordbot/commands/history.py
+++ b/discordbot/commands/history.py
@@ -9,7 +9,7 @@ from shared import fetch_tools
 
 
 class History(Extension):
-    @slash_command()
+    @slash_command(description='Show the legality history of the specified card.')
     @command.slash_card_option()
     async def history(self, ctx: MtgContext, card: Card) -> None:
         """Show the legality history of the specified card and a link to its all time page."""

--- a/discordbot/commands/hype.py
+++ b/discordbot/commands/hype.py
@@ -6,7 +6,7 @@ from magic import rotation
 
 
 class Hype(Extension):
-    @slash_command('hype')
+    @slash_command('hype', description='Display the latest rotation hype message.')
     async def hype(self, ctx: MtgContext) -> None:
         """Display the latest rotation hype message."""
         if rotation.in_rotation() and rotation.last_run_time() is not None:

--- a/discordbot/commands/invite.py
+++ b/discordbot/commands/invite.py
@@ -4,7 +4,7 @@ from discordbot.command import MtgContext
 
 
 class Invite(Extension):
-    @slash_command()
+    @slash_command(description='Invite me to your server.')
     async def invite(self, ctx: MtgContext) -> None:
         """Invite me to your server."""
         await ctx.send('Invite me to your discord server by clicking this link: <https://discordapp.com/oauth2/authorize?client_id=224755717767299072&scope=bot&permissions=268757056>')

--- a/discordbot/commands/kickoff.py
+++ b/discordbot/commands/kickoff.py
@@ -6,7 +6,7 @@ from magic import fetcher
 
 
 class KickOff(Extension):
-    @slash_command('kickoff')
+    @slash_command('kickoff', description='Display a link to the Season Kick Off information page.')
     async def kickoff(self, ctx: MtgContext) -> None:
         """Display a link to the Season Kick Off information page."""
         await ctx.send(fetcher.decksite_url('/tournaments/kickoff/'))

--- a/discordbot/commands/legal.py
+++ b/discordbot/commands/legal.py
@@ -7,7 +7,7 @@ from magic.models import Card
 
 
 class Legal(Extension):
-    @slash_command('legal')
+    @slash_command('legal', description='Announce whether the specified card is legal or not.')
     @command.slash_card_option()
     async def legal(self, ctx: MtgContext, card: Card) -> None:
         """Announce whether the specified card is legal or not."""

--- a/discordbot/commands/mana.py
+++ b/discordbot/commands/mana.py
@@ -8,7 +8,7 @@ from discordbot.command import MtgContext
 
 
 class Mana(Extension):
-    @slash_command('mana')
+    @slash_command('mana', description="Get Dr. Karsten's advice on colored mana sources required.")
     async def mana(self, ctx: MtgContext) -> None:
         """Get Dr. Karsten's advice on number of colored sources of mana required."""
         await ctx.send_image_with_retry(os.path.join(pathlib.Path(__file__).parent.absolute(), 'img/mana-frank.png'))

--- a/discordbot/commands/modobug.py
+++ b/discordbot/commands/modobug.py
@@ -19,7 +19,7 @@ class ModoBugs(Extension):
     """Commands for interacting with the modo-bugs repository."""
     blacklist: set[tuple[str, str]] = set()
 
-    @slash_command('modo-bug')
+    @slash_command('modo-bug', description='Our Magic Online Bug Tracker.')
     async def modobug(self, _ctx: MtgInteractionContext) -> None:
         """Our Magic Online Bug Tracker."""
 

--- a/discordbot/commands/modofail.py
+++ b/discordbot/commands/modofail.py
@@ -6,7 +6,7 @@ from shared import redis_wrapper as redis
 
 
 class ModoFail(Extension):
-    @slash_command('modofail')
+    @slash_command('modofail', description='Ding!')
     async def modofail(self, ctx: MtgContext) -> None:
         """Ding!"""
         n = redis.increment(f'modofail:{ctx.guild}')

--- a/discordbot/commands/mos_league.py
+++ b/discordbot/commands/mos_league.py
@@ -14,7 +14,7 @@ TTL = 30 * 60
 class MosLeague(Extension):
     queues: defaultdict[int, list[TTLItem[int]]] = defaultdict(list)
 
-    @slash_command(scopes=[711238742270017547])
+    @slash_command(description='Manage the league queue.', scopes=[711238742270017547])
     async def queue(self, ctx: MtgContext) -> None:
         pass
 

--- a/discordbot/commands/odds.py
+++ b/discordbot/commands/odds.py
@@ -10,7 +10,7 @@ class Odds(Extension):
         self.bot = bot
         super().__init__()
 
-    @slash_command('odds')
+    @slash_command('odds', description='Determine the odds of drawing a card.')
     @slash_option(
         name='copies',
         description='How many copies are you running? (Default 4)',

--- a/discordbot/commands/oracle.py
+++ b/discordbot/commands/oracle.py
@@ -6,7 +6,7 @@ from magic.models import Card
 
 
 class Oracle(Extension):
-    @slash_command()
+    @slash_command(description='Oracle text of a card.')
     @slash_card_option()
     async def oracle(self, ctx: MtgContext, card: Card) -> None:
         """Oracle text of a card."""

--- a/discordbot/commands/p1p1.py
+++ b/discordbot/commands/p1p1.py
@@ -8,7 +8,7 @@ from magic import image_fetcher, oracle
 
 
 class P1P1(Extension):
-    @slash_command()
+    @slash_command(description='Pack 1, pick 1 game.')
     @max_concurrency(Buckets.GUILD, 1)
     async def p1p1(self, ctx: MtgInteractionContext) -> None:
         """`!p1p1` Summon a pack 1, pick 1 game."""

--- a/discordbot/commands/patreon.py
+++ b/discordbot/commands/patreon.py
@@ -5,7 +5,7 @@ from discordbot.command import MtgContext
 
 
 class Patreon(Extension):
-    @slash_command('patreon')
+    @slash_command('patreon', description='Link to the PD Patreon.')
     async def patreon(self, ctx: MtgContext) -> None:
         """Link to the PD Patreon."""
         await ctx.send('<https://www.patreon.com/silasary/>')

--- a/discordbot/commands/pd500.py
+++ b/discordbot/commands/pd500.py
@@ -6,7 +6,7 @@ from magic import fetcher
 
 
 class PD500(Extension):
-    @slash_command()
+    @slash_command(description='Display a link to the PD 500 information page.')
     async def pd500(self, ctx: MtgContext) -> None:
         """Display a link to the PD 500 information page."""
         await ctx.send(fetcher.decksite_url('/tournaments/pd500/'))

--- a/discordbot/commands/price.py
+++ b/discordbot/commands/price.py
@@ -7,7 +7,7 @@ from magic.models import Card
 
 
 class Price(Extension):
-    @slash_command()
+    @slash_command(description='Price information for a card.')
     @slash_card_option()
     async def price(self, ctx: MtgContext, card: Card) -> None:
         """Price information for a card."""

--- a/discordbot/commands/quality.py
+++ b/discordbot/commands/quality.py
@@ -4,7 +4,7 @@ from discordbot.command import MtgContext
 
 
 class Quality(Extension):
-    @slash_command()
+    @slash_command(description="A reminder about everyone's favorite way to play digital Magic.")
     @slash_option('product', 'Product (if not MTGO)', OptionType.STRING)
     async def quality(self, ctx: MtgContext, product: str | None = None) -> None:
         """A reminder about everyone's favorite way to play digital Magic"""

--- a/discordbot/commands/randomcard.py
+++ b/discordbot/commands/randomcard.py
@@ -8,7 +8,7 @@ from magic import oracle
 
 
 class RandomCard(Extension):
-    @slash_command('random-card')
+    @slash_command('random-card', description='A random PD legal card.')
     @slash_option('number', 'How many cards?', OptionType.INTEGER)
     async def randomcard(self, ctx: MtgInteractionContext, number: int = 1) -> None:
         """A random PD legal card.

--- a/discordbot/commands/randomdeck.py
+++ b/discordbot/commands/randomdeck.py
@@ -7,7 +7,7 @@ from shared import fetch_tools
 
 
 class RandomDeck(Extension):
-    @slash_command('random-deck')
+    @slash_command('random-deck', description='A random deck from the current season.')
     async def randomdeck(self, ctx: MtgInteractionContext) -> None:
         """A random deck from the current season."""
         await ctx.defer()

--- a/discordbot/commands/reboot.py
+++ b/discordbot/commands/reboot.py
@@ -8,7 +8,7 @@ from shared import redis_wrapper
 
 
 class Reboot(Extension):
-    @slash_command()
+    @slash_command(description='Restart the bot.')
     @check(is_owner())
     async def reboot(self, ctx: MtgContext) -> None:
         """Restart the bot."""

--- a/discordbot/commands/resources.py
+++ b/discordbot/commands/resources.py
@@ -10,7 +10,7 @@ from shared import fetch_tools
 
 
 class Resources(Extension):
-    @slash_command()
+    @slash_command(description='Useful pages related to your query.')
     @slash_option('resource', 'Your query', OptionType.STRING)
     @auto_defer()
     async def resources(self, ctx: MtgInteractionContext, resource: str | None = None) -> None:

--- a/discordbot/commands/rhinos.py
+++ b/discordbot/commands/rhinos.py
@@ -10,7 +10,7 @@ from magic.models import Card
 
 
 class Rhinos(Extension):
-    @slash_command()
+    @slash_command(description='Anything can be a rhino if you try hard enough.')
     async def rhinos(self, ctx: MtgInteractionContext) -> None:
         """Anything can be a rhino if you try hard enough"""
         await ctx.defer()

--- a/discordbot/commands/rotation.py
+++ b/discordbot/commands/rotation.py
@@ -6,7 +6,7 @@ from magic import seasons
 
 
 class Rotation(Extension):
-    @slash_command()
+    @slash_command(description='Date of the next Penny Dreadful rotation.')
     async def rotation(self, ctx: MtgContext) -> None:
         """Date of the next Penny Dreadful rotation."""
         await ctx.send(seasons.message())

--- a/discordbot/commands/rulings.py
+++ b/discordbot/commands/rulings.py
@@ -10,7 +10,7 @@ from shared import fetch_tools
 
 
 class Rulings(Extension):
-    @slash_command()
+    @slash_command(description='Rulings for a card.')
     @slash_card_option()
     @auto_defer()
     async def rulings(self, ctx: MtgContext, card: Card) -> None:

--- a/discordbot/commands/scry.py
+++ b/discordbot/commands/scry.py
@@ -9,7 +9,7 @@ from shared import fetch_tools
 
 
 class Scry(Extension):
-    @slash_command()
+    @slash_command(description='Card search using Scryfall.')
     @slash_option('query', 'A scryfall query', OptionType.STRING, required=True)
     @auto_defer()
     async def scry(self, ctx: MtgContext, query: str) -> None:

--- a/discordbot/commands/spoiler.py
+++ b/discordbot/commands/spoiler.py
@@ -12,7 +12,7 @@ from shared.fetch_tools import FetchException
 
 
 class Spoiler(Extension):
-    @slash_command()
+    @slash_command(description='Request a card from an upcoming set.')
     @slash_card_option()
     async def spoiler(self, ctx: MtgInteractionContext, card: str) -> None:
         """Request a card from an upcoming set."""

--- a/discordbot/commands/status.py
+++ b/discordbot/commands/status.py
@@ -6,7 +6,7 @@ from magic import fetcher
 
 
 class Status(Extension):
-    @slash_command()
+    @slash_command(description='Status of Magic Online.')
     async def status(self, ctx: MtgInteractionContext) -> None:
         """Status of Magic Online."""
         await ctx.defer()

--- a/discordbot/commands/supersaturday.py
+++ b/discordbot/commands/supersaturday.py
@@ -6,7 +6,7 @@ from magic import fetcher
 
 
 class SuperSaturday(Extension):
-    @slash_command()
+    @slash_command(description='Display a link to the Super Saturday information page.')
     async def supersaturday(self, ctx: MtgContext) -> None:
         """Display a link to the Super Saturday information page."""
         await ctx.send(fetcher.decksite_url('/tournaments/super-saturday/'))

--- a/discordbot/commands/swiss.py
+++ b/discordbot/commands/swiss.py
@@ -12,7 +12,7 @@ class Swiss(Extension):
         self.bot = bot
         super().__init__()
 
-    @slash_command()
+    @slash_command(description='Display the record needed to reach the elimination rounds.')
     @slash_option(
         name='num_players',
         description='number of players in the event',

--- a/discordbot/commands/sync.py
+++ b/discordbot/commands/sync.py
@@ -5,7 +5,7 @@ from shared import configuration, redis_wrapper
 
 
 class Sync(Extension):
-    @slash_command('sync', scopes=[configuration.pd_server_id.value])
+    @slash_command('sync', description='Sync your achievements.', scopes=[configuration.pd_server_id.value])
     async def sync(self, ctx: MtgInteractionContext) -> None:
         """Sync your achievements"""
         key = f'discordbot:achievements:players:{ctx.author.id}'

--- a/discordbot/commands/time.py
+++ b/discordbot/commands/time.py
@@ -14,7 +14,7 @@ from shared.settings import with_config_file
 
 
 class Time(Extension):
-    @slash_command('time')
+    @slash_command('time', description='Current time in a location.')
     @slash_option('place', 'Where are you checking the time?', OptionType.STRING, required=True)
     async def time(self, ctx: MtgInteractionContext, place: str) -> None:
         """Current time in location."""

--- a/discordbot/commands/tournament.py
+++ b/discordbot/commands/tournament.py
@@ -6,7 +6,7 @@ from magic import fetcher, tournaments
 
 
 class Tournament(Extension):
-    @slash_command()
+    @slash_command(description='Information about the next tournament.')
     async def tournament(self, ctx: MtgContext) -> None:
         """Information about the next tournament."""
         t = tournaments.next_tournament_info()

--- a/discordbot/commands/update.py
+++ b/discordbot/commands/update.py
@@ -7,7 +7,7 @@ from shared import configuration
 
 
 class Update(Extension):
-    @slash_command()
+    @slash_command(description='Forces an update to legal cards and bugs.')
     @check(is_owner())
     async def update(self, ctx: MtgContext) -> None:
         """Forces an update to legal cards and bugs."""

--- a/discordbot/commands/version.py
+++ b/discordbot/commands/version.py
@@ -13,7 +13,7 @@ from shared.pd_exception import DatabaseException
 
 
 class Version(Extension):
-    @slash_command('version')
+    @slash_command('version', description='Display the current version numbers.')
     async def version(self, ctx: MtgContext) -> None:
         """Display the current version numbers"""
         embed = Embed(title='Version')

--- a/discordbot/commands/welcome.py
+++ b/discordbot/commands/welcome.py
@@ -7,7 +7,7 @@ from magic.models import Card
 
 
 class Welcome(Extension):
-    @slash_command()
+    @slash_command(description='Welcome a newcomer to PD.')
     async def welcome(self, ctx: MtgInteractionContext) -> None:
         """Welcome a newcomer to PD."""
         await ctx.defer()
@@ -15,7 +15,7 @@ class Welcome(Extension):
         card = oracle.cards_by_name()['Welcome to the Fold']
         await greeting(ctx, card, text)
 
-    @slash_command('back-for-more')
+    @slash_command('back-for-more', description='Greet someone returning to PD.')
     async def back_for_more(self, ctx: MtgInteractionContext) -> None:
         """Greet someone returning to PD."""
         await ctx.defer()

--- a/discordbot/commands/whois.py
+++ b/discordbot/commands/whois.py
@@ -8,7 +8,7 @@ from magic import fetcher
 
 
 class Whois(Extension):
-    @slash_command('whois', sub_cmd_name='mtgo', sub_cmd_description='Info about a MTGO player')
+    @slash_command('whois', description='Look up who someone is on MTGO or Discord.', sub_cmd_name='mtgo', sub_cmd_description='Info about a MTGO player')
     @slash_option('username', 'The username of the MTGO player', OptionType.STRING, required=True)
     async def whois_mtgo(self, ctx: MtgInteractionContext, username: str) -> None:
         await ctx.defer()


### PR DESCRIPTION
## What was wrong

Every `@slash_command()` decorator in `discordbot/commands/` was missing the `description=` parameter. Discord requires a description for each slash command to display in the UI. Without it, commands showed the default placeholder `'No Description Set'`.

Two files already had descriptions (`dreadrise.py` and `explain.py`); all others were missing them.

## What changed

- Added `description='...'` to 49 `@slash_command()` calls across 46 command files, using text derived from each method's docstring.
- Added `test_all_slash_commands_have_descriptions` to `discordbot/command_test.py` that imports every command module, finds all `SlashCommand` class attributes, and asserts none have the default `'No Description Set'` value.

## Validation

- `uv run --frozen python dev.py lint` — passed (all files)
- `uv run --frozen python dev.py unit discordbot` — 846 passed, 1 skipped (the new test is included and passes)

Fixes #12553