### PR TITLE
Read base_chars from pd.css instead of hardcoding (#12546)

### DIFF
--- a/maintenance/fonts.py
+++ b/maintenance/fonts.py
@@ -201,7 +201,15 @@ def subset_font(font: TTFont, graphemes: set[str]) -> TTFont:
 
 
 def find_base_graphemes() -> set[str]:
-    return set('①②③④⑤⑥⑦⑧⑯Ⓣ⇅⊕⸺▪🐞🚫🏆📰💻▾△🛈✅☐☑⚔🏅☰🏠☼🌙✨✕')
+    css_path = os.path.join('shared_web', 'static', 'css', 'pd.css')
+    with open(css_path, encoding='utf-8') as f:
+        content = f.read()
+    start = content.index('The characters included in our subsetted fonts are:')
+    end = content.index('*/', start)
+    section = content[start:end]
+    # Take only the first U+XXXX per line to avoid picking up alternate code points mentioned in comments
+    code_points = (matches[0] for line in section.splitlines() for matches in [regex.findall(r'U\+([0-9A-F]{4,5})', line)] if matches)
+    return {chr(int(cp, 16)) for cp in code_points}
 
 def encode(font: TTFont) -> str:
     _, tmp_in = tempfile.mkstemp()

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -265,12 +265,14 @@ The characters included in our subsetted fonts are:
     ☐ U+2610 BALLOT BOX (uncheck all checkboxes in this table)
     ☑ U+2611 BALLOT BOX WITH CHECK (check all checkboxes in this table)
     ⚔ U+2694 CROSSED SWORDS (represents number of matches)
-    🏅 U+2059 SPORTS MEDAL (achievement earned)
+    🏅 U+1F3C5 SPORTS MEDAL (achievement earned)
     ☰ U+2630 TRIGRAM FOR HEAVEN (hamburger menu)
     ☼ U+263C WHITE SUN WITH RAYS (light mode toggle)
     🌙 U+1F319 CRESCENT MOON (dark mode toggle)
+    ✨ U+2728 SPARKLES (magic sparkle effect)
+    ✕ U+2715 MULTIPLICATION X (close/remove button)
 
-    (Please note: anything added here needs to be added to base_chars in the fonts maintenance task.)
+    (Please note: the fonts maintenance task reads these U+XXXX entries automatically; adding them here is sufficient.)
 
 as well as many, many characters used only in deck names.
 


### PR DESCRIPTION
## What was wrong

`find_base_graphemes()` in `maintenance/fonts.py` returned a hardcoded string of 33 Unicode characters. Whenever a new symbol was added to the site, it had to be added in two places: the `pd.css` comment block (as a `U+XXXX` annotation) **and** the hardcoded Python string — an easy sync error to make.

Additionally, `pd.css` contained a wrong code-point annotation: `🏅` (SPORTS MEDAL) was listed as `U+2059` (FIVE DOT PUNCTUATION) instead of the correct `U+1F3C5`. Two characters present in the hardcoded set — `✨` (U+2728) and `✕` (U+2715) — were also absent from the `pd.css` comment entirely.

## What changed

**`shared_web/static/css/pd.css`**
- Fixed `🏅` annotation from `U+2059` → `U+1F3C5` (SPORTS MEDAL)
- Added `✨ U+2728 SPARKLES` and `✕ U+2715 MULTIPLICATION X` entries to the comment block
- Updated the note to reflect that `fonts.py` now reads from this file automatically

**`maintenance/fonts.py`**
- Replaced the hardcoded `find_base_graphemes()` with logic that opens `shared_web/static/css/pd.css`, slices the section between `"The characters included in our subsetted fonts are:"` and the closing `*/`, then extracts the first `U+XXXX` code point per line (skipping secondary code points mentioned in inline comments like `could use U+2014`) and converts them via `chr(int(cp, 16))`.

The new function produces an identical 33-character set to the old hardcoded one.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped, 89 deselected
- Manual verification: the new function was tested inline to confirm it returns exactly the same set as the original hardcoded string

Fixes #12546