### PR TITLE
Show help cursor on elements with title attribute that are not links (#12537)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -3234,6 +3234,10 @@ A reasonable amount has been cut which we'll need to restore if we ever want dif
     cursor: help;
 }
 
+[title]:not(a) {
+    cursor: help;
+}
+
 .tpd-tooltip {
     white-space: pre-line;
 }


### PR DESCRIPTION
## What was wrong

Elements with a `title` attribute (which causes browsers to show a tooltip on hover) that were not `<a>` links were showing the default text cursor (I-beam) or arrow cursor. This gave users no indication that hovering would reveal additional information. The issue specifically called out achievements on the player detail page (`<li class="button" title="...">` and `<span class="earned" title="...">`) as examples.

## What changed

Added `[title]:not(a) { cursor: help; }` to `shared_web/static/css/pd.css` near the existing cursor rules section (around line 3233). This makes all non-link elements with a `title` attribute show the help cursor (❓), signalling to users that hovering will reveal a tooltip. Links (`<a>`) are excluded since they already show the pointer cursor and their primary action is navigation, not tooltip display.

## How it was validated

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped
- Manual review of `git diff origin/master...` confirmed only 4 lines added, all serving #12537

Fixes #12537