### PR TITLE
Show quality rank within season on metagame tiles regardless of filter (#12534)

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -584,6 +584,7 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
         table = '_arch_disjoint_stats'
         base_where = 'TRUE'
         group_by = 'a.id'
+    rank_where = "deck_type = 'tournament'" if tournament_only else 'TRUE'
     if tournament_only:
         base_where = f"({base_where}) AND deck_type = 'tournament'"
     where = f'({where}) AND ({base_where})'
@@ -601,6 +602,21 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
                 archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1
             WHERE
                 ({base_where}) AND ({season_query})
+        ),
+        season_ranks AS (
+            SELECT
+                a.id AS archetype_id,
+                RANK() OVER (ORDER BY {clauses.wilson_lower_bound_sql()} DESC) AS quality_rank
+            FROM
+                archetype AS a
+            LEFT JOIN
+                _arch_disjoint_stats AS ars ON a.id = ars.archetype_id
+            LEFT JOIN
+                archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1
+            WHERE
+                ({rank_where}) AND ({season_query})
+            GROUP BY
+                a.id, aca.ancestor
         )
         SELECT
             a.id,
@@ -618,7 +634,8 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
             IFNULL(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1), '') AS win_percent,
             COUNT(*) OVER () AS total,
             SUM(wins + losses + draws) / tc.total_matches AS meta_share,
-            {clauses.wilson_lower_bound_sql()} AS quality_score
+            {clauses.wilson_lower_bound_sql()} AS quality_score,
+            sr.quality_rank
         FROM
             archetype AS a
         LEFT JOIN
@@ -627,6 +644,8 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
              archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1
         LEFT JOIN
             total_count AS tc ON TRUE
+        LEFT JOIN
+            season_ranks AS sr ON a.id = sr.archetype_id
         WHERE
             ({where}) AND ({season_query})
         GROUP BY

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -55,6 +55,9 @@ const renderItem = (grid, archetype) => (
                     <span title="Quality">
                         <span className="quality-star">★</span>{Number(archetype.qualityScore * 100).toFixed(0)}
                     </span>
+                    {archetype.qualityRank && (
+                        <span title="Quality Rank in Season" className="quality-rank">#{archetype.qualityRank}</span>
+                    )}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## What was wrong

The metagame grid tiles showed quality score (Wilson lower bound) for each archetype, but no indication of an archetype's rank among all archetypes in the season. When a user searched/filtered the grid, there was no way to know if the visible archetypes were the top-ranked or mid-pack in the overall meta.

## What changed

**`decksite/data/archetype.py`** — Added a `season_ranks` CTE inside `load_disjoint_archetypes` that computes `RANK() OVER (ORDER BY quality_score DESC)` for **all archetypes in the season** using the global `_arch_disjoint_stats` table (not filtered by the caller-supplied `where` parameter). This CTE respects the `tournament_only` flag but ignores any search/filter applied by the viewer. The rank is then LEFT JOIN-ed into the main SELECT as `quality_rank`, making it available on every returned archetype object.

**`shared_web/static/js/metagamegrid.jsx`** — Added a `#{archetype.qualityRank}` badge (rendered as `<span class="quality-rank">`) inside the existing quality cell, visible whenever `qualityRank` is present. The `quality_rank` snake_case field is automatically camelized to `qualityRank` by the existing `return_camelized_json` → `humps.camelize` pipeline in the API — no API changes were needed.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped (no DB-dependent archetype tests exist; SQL correctness validated by inspection)

Fixes #12534