### PR TITLE
Fix quoted card names not matching in whoosh search (#12527)

### DIFF
--- a/magic/whoosh_constants.py
+++ b/magic/whoosh_constants.py
@@ -6,5 +6,5 @@ from shared import configuration
 class WhooshConstants:
     index_dir = configuration.get_str('whoosh_index_dir')
     tokenized_analyzer = StandardAnalyzer(stoplist=None)
-    normalized_analyzer = IDTokenizer() | SubstitutionFilter(r"[\s/,_'-]", '') | LowercaseFilter()
-    stem_analyzer = StemmingAnalyzer(r"[\s/,_'-]", gaps=True, stoplist=None)
+    normalized_analyzer = IDTokenizer() | SubstitutionFilter('[\\s/,_\'"“”-]', '') | LowercaseFilter()
+    stem_analyzer = StemmingAnalyzer('[\\s/,_\'"“”-]', gaps=True, stoplist=None)

--- a/magic/whoosh_search_test.py
+++ b/magic/whoosh_search_test.py
@@ -183,5 +183,26 @@ def test_refresh_picks_up_an_index_rebuilt_by_another_process(monkeypatch: pytes
     assert searcher.search('Black Lo').get_best_match() == 'Black Lotus'
     assert searcher.search('Ancestral Re').get_best_match() == 'Ancestral Recall'
 
+def test_quoted_card_name_is_searchable(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(WhooshConstants, 'index_dir', str(tmp_path))
+    ix = create_in(tmp_path, whoosh_write.WhooshWriter().schema)
+    card = Card({
+        'id': 1,
+        'name': '"Name Sticker" Goblin',
+        'names': '"Name Sticker" Goblin',
+        'flavor_names': None,
+        'layout': 'normal',
+    })
+    whoosh_write.update_index(ix, [card])
+
+    searcher = WhooshSearcher()
+
+    result = searcher.search('"Name Sticker" Goblin')
+    assert result.get_best_match() == '"Name Sticker" Goblin'
+
+    result = searcher.search('Name Sticker Goblin')
+    assert result.get_best_match() == '"Name Sticker" Goblin'
+
+
 def indexable_card(card_id: int, name: str) -> Card:
     return Card({'id': card_id, 'name': name, 'names': name, 'flavor_names': None, 'layout': 'normal'})


### PR DESCRIPTION
## What was wrong

The whoosh `SubstitutionFilter` and `StemmingAnalyzer` patterns in `magic/whoosh_constants.py` used `r"[\s/,_'-]"` to strip/split on separators during indexing and search. This pattern did not include ASCII double-quotes (`"`, U+0022), left curly quotes (`\u201c`), or right curly quotes (`\u201d`). As a result, card names like `"Name Sticker" Goblin` — which contain double-quotes as part of the printed name — could not be normalized to a matchable form, so the bot failed to find them even though the card exists in the database.

## What changed

In `magic/whoosh_constants.py`, the separator pattern was updated to `'[\\s/,_\'"\u201c\u201d-]'`, adding ASCII double-quote and both curly quote variants. This allows the normalized and stemmed analyzers to treat quotes as separators/stripped characters, so `"Name Sticker" Goblin` indexes as `namestickergoblin` and can be matched by queries with or without the quotes.

A regression test `test_quoted_card_name_is_searchable` was added to `magic/whoosh_search_test.py` to verify that searching for `"Name Sticker" Goblin` both with and without the quote characters finds the card.

## Validation

Lint (`uv run --frozen python dev.py lint`): passed. Unit tests (`uv run --frozen python dev.py unit`): 846 passed, 1 skipped. The new test is among the passing tests.

Fixes #12527