### PR TITLE
Redirect /seasons/all/decks/ to /decks/ (#12524)

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -83,6 +83,8 @@ def before_request() -> wrappers.Response | None:
         return None  # Let flask do the redirect-routes-not-ending-in-slashes thing before we interfere with routing. Avoids #8277.
     if request.path.startswith('/seasons') and len(request.path) > len('/seasons/') and get_season_id() >= seasons.current_season_num():
         return redirect(re.sub('/seasons/[^/]*', '', request.path))
+    if re.match(r'^/seasons/all/decks(/.*)?$', request.path):
+        return redirect(re.sub(r'^/seasons/all', '', request.path))
     if request.path.startswith('/seasons/0'):
         return redirect(request.path.replace('/seasons/0', '/seasons/all'))
     sentry_sdk.set_user({'id': auth.discord_id(), 'username': auth.mtgo_username(), 'ip_address': '{{auto}}'})


### PR DESCRIPTION
## What was wrong

`/seasons/all/decks/` performed an unbounded SQL query across every deck ever played (no season filter), making the first page load slow. The result was also uninteresting: sorted by date descending, it shows the same recent decks visible on `/decks/` (the current season), just much slower.

## What changed

Added a redirect in `before_request` in `decksite/main.py`: any request matching `/seasons/all/decks/` or `/seasons/all/decks/<deck_type>/` is now redirected to the corresponding seasonless URL (`/decks/` or `/decks/<deck_type>/`). This is consistent with the existing redirect that removes the current-season prefix when navigating via `/seasons/<current_num>/...`.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit decksite/main.py` — 845 passed, 1 skipped

Fixes #12524