### PR TITLE
Remove flask-babel DeprecationWarning suppression (#12521)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -10,5 +10,3 @@ markers =
 filterwarnings =
     # https://github.com/python-restx/flask-restx/issues/553
     ignore:.*RefResolver.*:DeprecationWarning:flask_restx
-    # https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/issues/12521
-    ignore:.*'locked_cached_property' is deprecated.*:DeprecationWarning:flask_babel


### PR DESCRIPTION
## What was wrong

`pytest.ini` contained a `filterwarnings` entry suppressing a `DeprecationWarning` about `locked_cached_property` emitted by `flask_babel`. This suppression was needed when the project was pinned to flask-babel 2.0.0.

## What changed

Removed the two-line block (the `# https://github.com/...issues/12521` comment and the accompanying `ignore:` filter) from `pytest.ini`. flask-babel was already upgraded to 4.0.0 as part of the Pipenv→uv migration, so the warning no longer occurs and the suppression is dead code.

## Validation

- `uv run --frozen python dev.py lint` — passed
- Full unit suite was not run due to environment constraints (no database bootstrapped), but the change is a two-line deletion in a config file with no logic impact.

Fixes #12521