### PR TITLE
Add explain for sideboarding down to 59 cards (#12512)

### DIFF
--- a/discordbot/commands/explain.py
+++ b/discordbot/commands/explain.py
@@ -164,6 +164,15 @@ explanations: dict[str, tuple[str, dict[str, str]]] = {
         """,
         {},
     ),
+    'sideboard': (
+        """
+        If you sideboard down to less than 60 cards (quite possible due to a known Magic Online bug) and either player notices before the end of turn 2 and the player with a legal deck wants to restart the game, the game will be restarted.
+        The result of any game played beyond turn 2 with less than 60 cards in maindeck will stand.
+        """,
+        {
+            'Tournament Rules': fetcher.decksite_url('/tournaments/'),
+        },
+    ),
     'spectating': (
         """
         Spectating tournament and league matches is allowed and encouraged.
@@ -222,6 +231,7 @@ keys = sorted(explanations.keys())
 
 explanations['drop'] = explanations['retire']
 explanations['legality'] = explanations['rotation']
+explanations['sideboards'] = explanations['sideboard']
 explanations['spectate'] = explanations['spectating']
 explanations['tournaments'] = explanations['tournament']
 explanations['watching'] = explanations['spectating']


### PR DESCRIPTION
## What was missing

`!explain sideboard` (and `/explain sideboard`) had no entry. Players asking about the PD tournament rule for sideboarding down to less than 60 cards had no quick Discord answer.

## What changed

Added a `'sideboard'` key to the `explanations` dict in `discordbot/commands/explain.py` with the tournament rule text sourced directly from the tournaments page template (`decksite/templates/tournaments.mustache`): if a player starts a sideboarded game with less than 60 cards and either player notices before the end of turn 2, the game is restarted; games beyond turn 2 stand. Included a link to the Tournament Rules page. Also added `'sideboards'` as an explicit alias (the existing `rstrip('s')` logic already handles the plural, but the alias keeps it consistent with other alias entries).

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit discordbot` — 845 passed, 1 skipped

Fixes #12512