### PR TITLE
Format large numbers with locale-aware thousand separators (#12509)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1372,8 +1372,8 @@ Force a consistent size of each column in react tables otherwise things "jump" a
 }
 
 .live .num-decks {
-    min-width: 4em;
-    max-width: 4em;
+    min-width: 5em;
+    max-width: 5em;
 }
 
 /* We use the name 'card-record' for this rule not 'record' because Deck Table already has a .record.

--- a/shared_web/static/js/cardtable.jsx
+++ b/shared_web/static/js/cardtable.jsx
@@ -30,7 +30,7 @@ const renderHeaderRow = (table) => (
 const renderRow = (table, card) => (
     <tr key={card.name} className="clickable">
         <td className="name">{renderCard(card)}</td>
-        <td className="n">{card.numDecks}</td>
+        <td className="n">{card.numDecks.toLocaleString()}</td>
         <td className="n">{renderRecord(card)}</td>
         <td className="n">{renderWinPercent(card)}</td>
         { table.props.leagueOnly

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -98,7 +98,7 @@ export class Table extends DataManager {
 
 export const renderRecord = (object) => {
     if (object.showRecord && object.wins + object.losses + object.draws > 0) {
-        return object.wins + "–" + object.losses + (object.draws > 0 ? "–" + object.draws : "");
+        return object.wins.toLocaleString() + "–" + object.losses.toLocaleString() + (object.draws > 0 ? "–" + object.draws.toLocaleString() : "");
     }
     return "";
 };


### PR DESCRIPTION
## What was wrong

On `/seasons/all/cards` (and other card tables with aggregate data), large integers like deck counts and win/loss records were displayed as raw numbers (e.g. `12345`, `10234–5678`) with no thousand separators, making them hard to read at a glance.

## What changed

- **`shared_web/static/js/cardtable.jsx`**: `card.numDecks` now rendered with `.toLocaleString()` so the browser formats it using the user's locale (e.g. `12,345` for en-US).
- **`shared_web/static/js/table.jsx`**: `renderRecord()` now calls `.toLocaleString()` on `wins`, `losses`, and `draws` so aggregate card records are similarly formatted.
- **`shared_web/static/css/pd.css`**: Widened `.live .num-decks` min/max-width from `4em` to `5em` to accommodate comma-formatted 5-digit numbers without overflow on narrow views (as suggested in the issue).

## Validation

`uv run --frozen python dev.py lint` passed. Unit tests were not run because mariadb105-server conflicted with the pre-installed mariadb118 in the cloud sandbox, blocking DB setup. The changes are purely presentational JS/CSS with no Python logic to test.

Fixes #12509