### PR TITLE
Add 'screw' variants to profanity whitelist (#12495)

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -54,6 +54,9 @@ PROFANITY_WHITELIST = [
     'lesbians',
     'queer',
     'queers',
+    'screw',
+    'screwed',
+    'screwing',
 ]
 
 PROFANITY_BLACKLIST = [


### PR DESCRIPTION
## What was wrong

Deck names containing the word "screw" (e.g. "screw it we ball") were being censored by the `better_profanity` library's filter, replacing the word with spaces. The word is not profane in context — it's common Magic slang and a legitimate deck name component.

## What changed

Added `'screw'`, `'screwed'`, and `'screwing'` to `PROFANITY_WHITELIST` in `decksite/deck_name.py` (line 57–59). This whitelist is passed to `better_profanity`'s `load_censor_words()` so these words are excluded from censorship.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit decksite/deck_name_test.py` — 845 passed, 1 skipped in 15.19s

Fixes #12495