### PR TITLE
Fix archetype URLs with // in name not matching routes (#12494)

### DIFF
--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -122,15 +122,15 @@ def archetypes(deck_type: str | None = None) -> str:
     view = Archetypes(all_archetypes, tournament_only=tournament_only)
     return view.page()
 
-@APP.route('/archetypes/<archetype_id>/')
-@APP.route('/archetypes/<archetype_id>/<any(tournament,league):deck_type>/')
-@SEASONS.route('/archetypes/<archetype_id>/')
-@SEASONS.route('/archetypes/<archetype_id>/<any(tournament,league):deck_type>/')
+@APP.route('/archetypes/<path:archetype_id>/')
+@APP.route('/archetypes/<path:archetype_id>/<any(tournament,league):deck_type>/')
+@SEASONS.route('/archetypes/<path:archetype_id>/')
+@SEASONS.route('/archetypes/<path:archetype_id>/<any(tournament,league):deck_type>/')
 @cached()
 def archetype(archetype_id: str, deck_type: str | None = None) -> str:
     tournament_only = validate_deck_type(deck_type, [DeckType.ALL, DeckType.TOURNAMENT]) == DeckType.TOURNAMENT
     season_id = get_season_id()
-    a = archs.load_archetype(archetype_id.replace('+', ' '))
+    a = archs.load_archetype(merge_slashes(archetype_id.replace('+', ' ')))
     all_archetypes = archs.load_archetypes(season_id=season_id, tournament_only=tournament_only)
     archetype_matchups = archs.load_matchups(archetype_id=a.id, season_id=season_id, tournament_only=tournament_only)
     seasons_active = archs.seasons_active(a.id)

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -30,7 +30,7 @@ def load_archetype(archetype: int | str) -> Archetype:
     except ValueError as c:
         name = titlecase.titlecase(archetype)
         name_without_dashes = name.replace('-', ' ')
-        archetype_id = db().value("SELECT id FROM archetype WHERE REPLACE(name, '-', ' ') = %s", [name_without_dashes])
+        archetype_id = db().value("SELECT id FROM archetype WHERE REPLACE(REPLACE(name, ' // ', ' / '), '-', ' ') = %s", [name_without_dashes])
         if not archetype_id:
             raise DoesNotExistException(f'Did not find archetype with name of `{name}`') from c
     arch = Archetype()


### PR DESCRIPTION
## What was wrong

Archetype names containing `//` (like "Leave // Chance Midrange") failed to load via `/archetypes/<name>/` URLs for two reasons:

1. The route pattern `<archetype_id>` does not match path segments containing `/`, so Flask returned 404 for any archetype whose URL slug included a slash.
2. Reverse proxies in front of the app collapse repeated slashes, so `/archetypes/Leave // Chance Midrange/` arrives as `/archetypes/Leave / Chance Midrange/` (single slash). The `load_archetype()` SQL then compared that against DB rows where the name still has `//`, so no row was found.

## What changed

**`decksite/controllers/metagame.py`** (4 route decorators + 1 handler call):
- Changed all four `<archetype_id>` route parameters to `<path:archetype_id>`, mirroring the existing card handler, so Flask accepts slashes in the archetype segment.
- Applied the already-present `merge_slashes()` helper to the captured `archetype_id` before passing it to `load_archetype()`, normalising any proxy-collapsed single-slash to the canonical form used in the DB lookup.

**`decksite/data/archetype.py`** (`load_archetype()` SQL):
- Changed `REPLACE(name, '-', ' ')` to `REPLACE(REPLACE(name, ' // ', ' / '), '-', ' ')` so the DB-side name is also normalised to single-slash before comparison. This lets `Leave / Chance Midrange` (from the proxy-collapsed URL) match `Leave // Chance Midrange` (stored in DB).

## Validation

- `uv run --frozen python dev.py lint` — **passed** (all checks)
- `uv run --frozen python dev.py unit` — **845 passed**, 1 skipped, 89 deselected

Fixes #12494