### PR TITLE
Fix admin/unlink to only load linked people (#12492)

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -220,7 +220,7 @@ def post_player_note(person_id: int, note: str) -> wrappers.Response:
 @APP.route('/admin/unlink/')
 @auth.admin_required
 def unlink(num_affected_people: int | None = None, errors: list[str] | None = None) -> str:
-    all_people, _ = ps.load_people(order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
+    all_people, _ = ps.load_people(where='p.discord_id IS NOT NULL', order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
     view = Unlink(all_people, num_affected_people, errors)
     return view.page()
 


### PR DESCRIPTION
## What was wrong

The `/admin/unlink/` page called `ps.load_people()` without any filter, loading **all** people from the database — including those who have no Discord account linked. The purpose of the unlink page is specifically to remove Discord links, so showing people who have no `discord_id` is misleading and wastes the dropdown space. Since `load_people` uses a `LEFT JOIN` to Discord accounts, people without a link are silently included but can never be unlinked.

## What changed

Added `where='p.discord_id IS NOT NULL'` to the `ps.load_people()` call in `decksite/controllers/admin.py:223` (the `unlink()` controller). This is a 1-line change scoped entirely to the unlink page — other admin pages (`player_notes`, `ban`, `edit_aliases`) that legitimately need the full people list are left unchanged.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped (full suite, with live MariaDB)

Fixes #12492