### PR TITLE
Separate load_decks/load_people/etc from their paginated _with_total variants (#12490)

### DIFF
--- a/decksite/controllers/about.py
+++ b/decksite/controllers/about.py
@@ -21,7 +21,7 @@ def about_gp() -> Response:
 @cached()
 def about() -> str:
     season_id = max(get_season_id() - 1, 0)
-    last_season_tournament_winners, _ = deck.load_decks('d.finish = 1', season_id=season_id)
+    last_season_tournament_winners = deck.load_decks('d.finish = 1', season_id=season_id)
     view = About(request.args.get('src'), last_season_tournament_winners)
     return view.page()
 

--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -47,7 +47,7 @@ def admin_home() -> wrappers.Response:
 @auth.admin_required
 def edit_aliases() -> str:
     aliases = ps.load_aliases()
-    all_people, _ = ps.load_people(order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
+    all_people = ps.load_people(order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
     view = EditAliases(aliases, all_people)
     return view.page()
 
@@ -201,7 +201,7 @@ def rotation_checklist() -> str:
 @auth.admin_required
 def player_notes() -> str:
     notes = ps.load_notes()
-    all_people, _ = ps.load_people(order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
+    all_people = ps.load_people(order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
     view = PlayerNotes(notes, all_people)
     return view.page()
 
@@ -218,7 +218,7 @@ def post_player_note(person_id: int, note: str) -> wrappers.Response:
 @APP.route('/admin/unlink/')
 @auth.admin_required
 def unlink(num_affected_people: int | None = None, errors: list[str] | None = None) -> str:
-    all_people, _ = ps.load_people(where='p.discord_id IS NOT NULL', order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
+    all_people = ps.load_people(where='p.discord_id IS NOT NULL', order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
     view = Unlink(all_people, num_affected_people, errors)
     return view.page()
 
@@ -240,7 +240,7 @@ def post_unlink() -> str:
 @APP.route('/admin/ban/')
 @auth.admin_required
 def ban(success: bool | None = None) -> str:
-    all_people, _ = ps.load_people(order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
+    all_people = ps.load_people(order_by='ISNULL(p.mtgo_username), p.mtgo_username, p.name')
     view = Ban(all_people, success)
     return view.page()
 

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -25,7 +25,7 @@ def test_post_archetypes_reports_invalid_card_names(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(admin.oracle, 'valid_name', valid_name)
     monkeypatch.setattr(admin.ds, 'load_decks_by_cards', load_decks_by_cards)
     monkeypatch.setattr(admin, 'edit_archetypes', edit_archetypes)
-    monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: ([], 0))
+    monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: [])
     monkeypatch.setattr(deck, 'load_queue_similarity', lambda decks: None)
     with APP.test_request_context('/admin/archetypes/', method='POST', data={'q': 'Dark Ritual\nNot a Card', 'notq': 'Also Not a Card'}):
         response = cast(Any, admin.post_archetypes).__wrapped__()

--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -140,7 +140,7 @@ def decks_api() -> Response:
     # Don't restrict by season if we're loading something with a date by its id.
     season_id = 'all' if request.args.get('competitionId') else seasons.season_id(str(request.args.get('seasonId')), None)
     where = clauses.decks_where(request.args, cast(bool, session.get('admin')), cast(int, session.get('person_id')))
-    ds, total = deck.load_decks(where=where, order_by=order_by, limit=limit, season_id=season_id)
+    ds, total = deck.load_decks_with_total(where=where, order_by=order_by, limit=limit, season_id=season_id)
     prepare_decks(ds)
     r = {'page': page, 'total': total, 'objects': ds}
     resp = return_camelized_json(r)
@@ -176,7 +176,7 @@ class UpdatedDecks(Resource):
             raise InvalidArgumentException('Invalid timestamp!')
         page, page_size, limit = pagination(request.args)
         where = '(' + clauses.decks_where(request.args, False, None) + ') AND ' + clauses.decks_updated_since(timestamp)
-        ds, total = deck.load_decks(where=where, order_by='d.id DESC', limit=limit, season_id=season)
+        ds, total = deck.load_decks_with_total(where=where, order_by='d.id DESC', limit=limit, season_id=season)
         prepare_decks(ds)
         return {'page': page, 'total': total, 'objects': ds}
 
@@ -218,7 +218,7 @@ def cards2_api() -> Response:
     q = request.args.get('q', '').strip()
     additional_where, message = clauses.card_search_where(q, base_query, 'cs.name') if q or base_query else ('TRUE', '')
     all_legal = request.args.get('allLegal', False)
-    cs, total = card.load_cards(additional_where=additional_where, order_by=order_by, limit=limit, archetype_id=archetype_id, competition_id=competition_id, person_id=person_id, tournament_only=tournament_only, season_id=season_id, all_legal=all_legal)
+    cs, total = card.load_cards_with_total(additional_where=additional_where, order_by=order_by, limit=limit, archetype_id=archetype_id, competition_id=competition_id, person_id=person_id, tournament_only=tournament_only, season_id=season_id, all_legal=all_legal)
     prepare_cards(cs, tournament_only=tournament_only, season_id=season_id)
     r = {'page': page, 'total': total, 'objects': cs, 'message': message}
     resp = return_camelized_json(r)
@@ -270,7 +270,7 @@ def people_api() -> Response:
     season_id = seasons.season_id(str(request.args.get('seasonId')), None)
     q = request.args.get('q', '').strip()
     where = clauses.text_where(query.person_query(), q) if q else 'TRUE'
-    people, total = ps.load_people(where=where, order_by=order_by, limit=limit, season_id=season_id)
+    people, total = ps.load_people_with_total(where=where, order_by=order_by, limit=limit, season_id=season_id)
     prepare_people(people, season_id)
     r = {'page': page, 'total': total, 'objects': people}
     resp = return_camelized_json(r)
@@ -392,7 +392,7 @@ def matches_api() -> Response:
         season_id = None
     except ValueError:
         season_id = seasons.season_id(str(request.args.get('seasonId')), None)
-    entries, total = match.load_matches(where=where, order_by=order_by, limit=limit, season_id=season_id, show_active_deck_names=session.get('admin', False))
+    entries, total = match.load_matches_with_total(where=where, order_by=order_by, limit=limit, season_id=season_id, show_active_deck_names=session.get('admin', False))
     prepare_matches(entries)
     r = {'page': page, 'total': total, 'objects': entries}
     resp = return_camelized_json(r)
@@ -480,7 +480,7 @@ def rotation_cards_api() -> Response:
     if not session.get('admin', False):
         where += " AND status <> 'Undecided'"
     order_by = clauses.rotation_order_by(request.args.get('sortBy'), request.args.get('sortOrder'))
-    cs, total = rot.load_rotation(where=where, order_by=order_by, limit=limit)
+    cs, total = rot.load_rotation_with_total(where=where, order_by=order_by, limit=limit)
     prepare_cards(cs)
     r = {'page': page, 'total': total, 'objects': cs, 'message': message}
     resp = return_camelized_json(r)
@@ -638,7 +638,7 @@ def rotation_clear_cache() -> Response:
 @APP.route('/api/cards')
 @APP.route('/api/cards/')
 def cards_api() -> Response:
-    cs, _ = card.load_cards()
+    cs = card.load_cards()
     return return_json({'cards': cs})
 
 @APP.route('/api/card/<card>')
@@ -702,7 +702,7 @@ def person_status() -> Response:
         if d is not None:
             r['deck'] = {'name': d.name, 'url': url_for('deck', deck_id=d.id), 'wins': d.get('wins', 0), 'losses': d.get('losses', 0)}
     if r['admin'] or r['demimod']:
-        _, total = deck.load_decks('NOT d.reviewed', limit='LIMIT 1')
+        _, total = deck.load_decks_with_total('NOT d.reviewed', limit='LIMIT 1')
         r['archetypes_to_tag'] = total
     active_league = league.active_league()
     if active_league:

--- a/decksite/controllers/competitions.py
+++ b/decksite/controllers/competitions.py
@@ -51,7 +51,7 @@ def tournament_leaderboards() -> str:
 @APP.route('/tournaments/pd500/')
 @cached()
 def pd500() -> str:
-    tournament_winning_decks, _ = ds.load_decks(where='d.finish = 1', season_id=get_season_id())
+    tournament_winning_decks = ds.load_decks(where='d.finish = 1', season_id=get_season_id())
     view = PD500(tournament_winning_decks)
     return view.page()
 

--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -155,10 +155,9 @@ def matchups() -> str:
     results = mus.matchup(hero, enemy, season_id=season_id) if 'hero_person_id' in request.args else None
     matchup_archetypes = archs.load_archetypes()
     matchup_archetypes.sort(key=lambda a: a.name)
-    matchup_people, _ = ps.load_people(where='p.mtgo_username IS NOT NULL')
-    matchup_people = list(matchup_people)
+    matchup_people = ps.load_people(where='p.mtgo_username IS NOT NULL')
     matchup_people.sort(key=lambda p: p.name)
-    matchup_cards, _ = cs.load_cards()
+    matchup_cards = cs.load_cards()
     matchup_cards.sort(key=lambda c: c.name)
     view = Matchups(hero, enemy, season_id, matchup_archetypes, matchup_people, matchup_cards, results)
     return view.page()

--- a/decksite/data/achievements.py
+++ b/decksite/data/achievements.py
@@ -210,7 +210,7 @@ class Achievement:
         ids = db().value(sql)
         result = Container()
         if ids:
-            ds, _ = deck.load_decks(where=f'd.id IN ({ids})')
+            ds = deck.load_decks(where=f'd.id IN ({ids})')
         else:
             ds = []
         result.decks = ds

--- a/decksite/data/archetype_classifier.py
+++ b/decksite/data/archetype_classifier.py
@@ -146,7 +146,7 @@ OUTPUT_SCHEMA = {
 
 
 def run(limit: int = 100) -> None:
-    decks, _ = deck.load_decks('NOT reviewed AND d.archetype_id IS NULL', order_by='d.created_date DESC', limit=f'LIMIT {int(limit)}')
+    decks = deck.load_decks('NOT reviewed AND d.archetype_id IS NULL', order_by='d.created_date DESC', limit=f'LIMIT {int(limit)}')
     if not decks:
         return
     deck.calculate_similar_decks(decks)

--- a/decksite/data/archetype_classifier_test.py
+++ b/decksite/data/archetype_classifier_test.py
@@ -10,7 +10,7 @@ from shared.container import Container
 
 def test_run_does_no_expensive_work_for_an_empty_queue(monkeypatch: pytest.MonkeyPatch) -> None:
     calculate_similar_decks = mock.Mock()
-    monkeypatch.setattr(archetype_classifier.deck, 'load_decks', lambda *args, **kwargs: ([], 0))
+    monkeypatch.setattr(archetype_classifier.deck, 'load_decks', lambda *args, **kwargs: [])
     monkeypatch.setattr(archetype_classifier.deck, 'calculate_similar_decks', calculate_similar_decks)
 
     archetype_classifier.run()
@@ -26,7 +26,7 @@ def test_run_without_an_api_key_preserves_the_old_guesser(monkeypatch: pytest.Mo
     def calculate_similar_decks(decks: list[Container]) -> None:
         decks[0].similar_decks = [similar]
 
-    monkeypatch.setattr(archetype_classifier.deck, 'load_decks', lambda *args, **kwargs: ([source], 1))
+    monkeypatch.setattr(archetype_classifier.deck, 'load_decks', lambda *args, **kwargs: [source])
     monkeypatch.setattr(archetype_classifier.deck, 'calculate_similar_decks', calculate_similar_decks)
     monkeypatch.setattr(archetype_classifier.configuration, 'get_optional_str', lambda _key: None)
     monkeypatch.setattr(archetype_classifier.archetype, 'assign', assign)

--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -263,7 +263,21 @@ def load_cards(
         archetype_id: int | None = None,
         competition_id: int | None = None,
         person_id: int | None = None,
-        season_id: int | None = None,
+        season_id: str | int | None = None,
+        tournament_only: bool = False,
+        all_legal: bool = False,
+) -> list[Card]:
+    cs, _ = load_cards_with_total(additional_where, order_by, limit, archetype_id, competition_id, person_id, season_id, tournament_only, all_legal)
+    return cs
+
+def load_cards_with_total(
+        additional_where: str = 'TRUE',
+        order_by: str = 'num_decks DESC, record, name',
+        limit: str = '',
+        archetype_id: int | None = None,
+        competition_id: int | None = None,
+        person_id: int | None = None,
+        season_id: str | int | None = None,
         tournament_only: bool = False,
         all_legal: bool = False,
 ) -> tuple[list[Card], int]:
@@ -321,7 +335,7 @@ def load_cards(
 
 @retry_after_calling(preaggregate_card)
 def load_card(name: str, tournament_only: bool = False, season_id: int | None = None) -> Card:
-    cs, _ = load_cards(additional_where=f'name = {sqlescape(name)}', order_by='NULL', season_id=season_id, tournament_only=tournament_only)
+    cs = load_cards(additional_where=f'name = {sqlescape(name)}', order_by='NULL', season_id=season_id, tournament_only=tournament_only)
     c = guarantee.at_most_one(cs)
     if c:
         return c

--- a/decksite/data/competition.py
+++ b/decksite/data/competition.py
@@ -97,7 +97,7 @@ def load_decks(competitions: list[Competition]) -> None:
         return
     competitions_by_id = {c.id: c for c in competitions}
     where = 'd.competition_id IN ({ids})'.format(ids=', '.join(str(k) for k in competitions_by_id.keys()))
-    decks, _ = deck.load_decks(where)
+    decks = deck.load_decks(where)
     for c in competitions:
         c.decks = []
     for d in decks:

--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -19,23 +19,29 @@ from shared_web import fonts
 
 
 def latest_decks(season_id: str | int | None = None) -> list[Deck]:
-    ds, _ = load_decks(where='d.created_date > UNIX_TIMESTAMP(NOW() - INTERVAL 30 DAY)', limit='LIMIT 500', season_id=season_id)
-    return ds
+    return load_decks(where='d.created_date > UNIX_TIMESTAMP(NOW() - INTERVAL 30 DAY)', limit='LIMIT 500', season_id=season_id)
 
 def recent_decks_for_person(person_id: int) -> list[Deck]:
-    ds, _ = load_decks(where=f'd.person_id = {sqlescape(person_id)}', order_by='active_date DESC', limit='LIMIT 10', season_id=seasons.current_season_num())
-    return ds
+    return load_decks(where=f'd.person_id = {sqlescape(person_id)}', order_by='active_date DESC', limit='LIMIT 10', season_id=seasons.current_season_num())
 
 def load_deck(deck_id: int) -> Deck:
-    ds, _ = load_decks(f'd.id = {sqlescape(deck_id)}')
-    return guarantee.exactly_one(ds)
+    return guarantee.exactly_one(load_decks(f'd.id = {sqlescape(deck_id)}'))
 
 def load_decks(where: str = 'TRUE',
                having: str = 'TRUE',
                order_by: str | None = None,
                limit: str = '',
                season_id: str | int | None = None,
-               ) -> tuple[list[Deck], int]:
+               ) -> list[Deck]:
+    ds, _ = load_decks_with_total(where, having, order_by, limit, season_id)
+    return ds
+
+def load_decks_with_total(where: str = 'TRUE',
+                          having: str = 'TRUE',
+                          order_by: str | None = None,
+                          limit: str = '',
+                          season_id: str | int | None = None,
+                          ) -> tuple[list[Deck], int]:
     if not redis.enabled():
         return load_decks_heavy(where, having, order_by, limit, season_id)
     columns = """
@@ -477,7 +483,7 @@ def calculate_similar_decks(ds: list[Deck]) -> None:
             d.similar_decks = []
         return
     plays = playability.playability()
-    potentially_similar, _ = load_decks(f'd.id IN (SELECT deck_id FROM deck_card WHERE card IN ({cards_escaped}))')
+    potentially_similar = load_decks(f'd.id IN (SELECT deck_id FROM deck_card WHERE card IN ({cards_escaped}))')
     for d in ds:
         for psd in potentially_similar:
             psd.similarity_score = round(similarity_score(d, psd, plays) * 100)
@@ -516,8 +522,7 @@ def load_decks_by_cards(names: list[str], not_names: list[str]) -> list[Deck]:
         sql += ' AND '
     if not_names:
         sql += contains_cards_clause(not_names, True)
-    ds, _ = load_decks(sql)
-    return ds
+    return load_decks(sql)
 
 def contains_cards_clause(names: list[str], negate: bool = False) -> str:
     negation = ' NOT' if negate else ''
@@ -560,7 +565,7 @@ def load_conflicted_decks() -> list[Deck]:
             GROUP BY
                 d1.decklist_hash
         )"""
-    ds, _ = load_decks(where, order_by='d.decklist_hash')
+    ds = load_decks(where, order_by='d.decklist_hash')
     return ds
 
 def load_queue_similarity(decks: list[Deck]) -> None:

--- a/decksite/data/deck_test.py
+++ b/decksite/data/deck_test.py
@@ -160,7 +160,7 @@ def test_calculate_similar_decks_ranks_rare_shared_cards_above_common_ones() -> 
 
     with (
         mock.patch.object(deck.playability, 'playability', return_value=plays) as get_playability,
-        mock.patch.object(deck, 'load_decks', return_value=([common_match, rare_match, no_match], 3)),
+        mock.patch.object(deck, 'load_decks', return_value=[common_match, rare_match, no_match]),
         mock.patch.object(deck.redis, 'store') as store,
     ):
         deck.calculate_similar_decks([source])

--- a/decksite/data/elo.py
+++ b/decksite/data/elo.py
@@ -25,9 +25,9 @@ def expected(elo1: int, elo2: int) -> float:
 def adjust_elo(winning_deck_id: int, losing_deck_id: int) -> None:
     if not losing_deck_id:
         return  # Intentional draws do not affect Elo.
-    ps, _ = person.load_people(f'p.id IN (SELECT person_id FROM deck WHERE id = {sqlescape(winning_deck_id)})')
+    ps = person.load_people(f'p.id IN (SELECT person_id FROM deck WHERE id = {sqlescape(winning_deck_id)})')
     winner = guarantee.exactly_one(ps)
-    ps, _ = person.load_people(f'p.id IN (SELECT person_id FROM deck WHERE id = {sqlescape(losing_deck_id)})')
+    ps = person.load_people(f'p.id IN (SELECT person_id FROM deck WHERE id = {sqlescape(losing_deck_id)})')
     loser = guarantee.exactly_one(ps)
     adj = adjustment(winner.elo or STARTING_ELO, loser.elo or STARTING_ELO)
     sql = f'UPDATE person SET elo = IFNULL(elo, {sqlescape(STARTING_ELO)}) + %s WHERE id = %s'

--- a/decksite/data/match.py
+++ b/decksite/data/match.py
@@ -41,20 +41,19 @@ def insert_match(dt: datetime.datetime,
     return match_id
 
 def load_match(match_id: int, deck_id: int) -> Container:
-    ms, _ = load_matches(where=f'm.id = {match_id} AND d.id = {deck_id}')
-    return guarantee.exactly_one(ms)
+    return guarantee.exactly_one(load_matches(where=f'm.id = {match_id} AND d.id = {deck_id}'))
 
 def load_matches_by_deck(d: deck.Deck) -> list[Container]:
-    where = f'd.id = {d.id}'
-    ms, _ = load_matches(where=where, season_id=None)
-    return ms
+    return load_matches(where=f'd.id = {d.id}', season_id=None)
 
 def load_matches_by_person(person_id: int, season_id: int | None = None) -> list[Container]:
-    where = f'd.person_id = {person_id}'
-    ms, _ = load_matches(where=where, season_id=season_id)
+    return load_matches(where=f'd.person_id = {person_id}', season_id=season_id)
+
+def load_matches(where: str = 'TRUE', order_by: str = 'm.`date`, m.`round`', limit: str = '', season_id: int | str | None = None, show_active_deck_names: bool = False) -> list[Container]:
+    ms, _ = load_matches_with_total(where, order_by, limit, season_id, show_active_deck_names)
     return ms
 
-def load_matches(where: str = 'TRUE', order_by: str = 'm.`date`, m.`round`', limit: str = '', season_id: int | str | None = None, show_active_deck_names: bool = False) -> tuple[list[Container], int]:
+def load_matches_with_total(where: str = 'TRUE', order_by: str = 'm.`date`, m.`round`', limit: str = '', season_id: int | str | None = None, show_active_deck_names: bool = False) -> tuple[list[Container], int]:
     person_query = query.person_query()
     opponent_person_query = query.person_query(table='o')
     competition_join = query.competition_join()

--- a/decksite/data/matchup.py
+++ b/decksite/data/matchup.py
@@ -71,13 +71,13 @@ def matchup(hero: dict[str, str], enemy: dict[str, str], season_id: int | None =
 
     hero_deck_ids = rs['hero_deck_ids'].split(',') if rs['hero_deck_ids'] else []
     if hero_deck_ids:
-        hero_decks, _ = deck.load_decks('d.id IN (' + ', '.join(hero_deck_ids) + ')')
+        hero_decks = deck.load_decks('d.id IN (' + ', '.join(hero_deck_ids) + ')')
     else:
         hero_decks = []
     enemy_deck_ids = rs['enemy_deck_ids'].split(',') if rs['enemy_deck_ids'] else []
     match_ids = rs['match_ids'].split(',') if rs['match_ids'] else []
     if match_ids:
-        ms, _ = match.load_matches(where='m.id IN (' + ', '.join(match_ids) + ')', order_by='m.date DESC, m.round DESC')
+        ms = match.load_matches(where='m.id IN (' + ', '.join(match_ids) + ')', order_by='m.date DESC, m.round DESC')
     else:
         ms = []
     return MatchupResults(

--- a/decksite/data/models/person.py
+++ b/decksite/data/models/person.py
@@ -8,6 +8,6 @@ class Person(Container):
     @property
     def decks(self) -> list[deck.Deck]:
         if self.__decks is None:
-            ds, _ = deck.load_decks(f'd.person_id = {self.id}', season_id=self.season_id)
+            ds = deck.load_decks(f'd.person_id = {self.id}', season_id=self.season_id)
             self.__decks = ds
         return self.__decks

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -47,19 +47,19 @@ def load_person_by_discord_id_or_username(person: str, season_id: int = 0) -> Pe
 def maybe_load_person_by_discord_id(discord_id: int | None) -> Person | None:
     if discord_id is None:
         return None
-    ps, _ = load_people(f'p.discord_id = {discord_id}')
+    ps = load_people(f'p.discord_id = {discord_id}')
     return guarantee.at_most_one(ps)
 
 def maybe_load_person_by_tappedout_name(username: str) -> Person | None:
-    ps, _ = load_people(f'p.tappedout_username = {sqlescape(username)}')
+    ps = load_people(f'p.tappedout_username = {sqlescape(username)}')
     return guarantee.at_most_one(ps)
 
 def maybe_load_person_by_mtggoldfish_name(username: str) -> Person | None:
-    ps, _ = load_people(f'p.mtggoldfish_username = {sqlescape(username)}')
+    ps = load_people(f'p.mtggoldfish_username = {sqlescape(username)}')
     return guarantee.at_most_one(ps)
 
 def load_person(where: str, season_id: int | None = None) -> Person:
-    people, _ = load_people(where, season_id=season_id)
+    people = load_people(where, season_id=season_id)
     if len(people) == 0:  # We didn't find an entry for that person with decks, what about without?
         person = load_person_statless(where, season_id)
     else:
@@ -94,7 +94,14 @@ def load_person_statless(where: str = 'TRUE', season_id: int | None = None) -> P
 def load_people(where: str = 'TRUE',
                 order_by: str = 'num_decks DESC, p.name',
                 limit: str = '',
-                season_id: str | int | None = None) -> tuple[Sequence[Person], int]:
+                season_id: str | int | None = None) -> list[Person]:
+    people, _ = load_people_with_total(where, order_by, limit, season_id)
+    return people
+
+def load_people_with_total(where: str = 'TRUE',
+                           order_by: str = 'num_decks DESC, p.name',
+                           limit: str = '',
+                           season_id: str | int | None = None) -> tuple[list[Person], int]:
     person_query = query.person_query()
     season_join = query.season_join() if season_id else ''
     season_query = query.season_query(season_id, 'season.season_id')

--- a/decksite/data/rotation.py
+++ b/decksite/data/rotation.py
@@ -10,7 +10,11 @@ from shared.pd_exception import DatabaseException, OperationalException
 
 # A decksite-level cache of rotation information, primarily to make /rotation much faster.
 
-def load_rotation(where: str = 'TRUE', order_by: str = 'hits', limit: str = '') -> tuple[list[Card], int]:
+def load_rotation(where: str = 'TRUE', order_by: str = 'hits', limit: str = '') -> list[Card]:
+    cs, _ = load_rotation_with_total(where, order_by, limit)
+    return cs
+
+def load_rotation_with_total(where: str = 'TRUE', order_by: str = 'hits', limit: str = '') -> tuple[list[Card], int]:
     sql = f"""
         SELECT
             name,

--- a/decksite/data/rule.py
+++ b/decksite/data/rule.py
@@ -112,7 +112,7 @@ def mistagged_decks() -> list[Deck]:
     if not rule_archetypes:
         return []
     ids_list = ', '.join(str(deck_id) for deck_id in rule_archetypes)
-    result, _ = deck.load_decks(where=f'd.id IN ({ids_list})')
+    result = deck.load_decks(where=f'd.id IN ({ids_list})')
     for d in result:
         d.rule_id, d.rule_archetype_id, d.rule_archetype_name = rule_archetypes[d.id]
     return result
@@ -139,7 +139,7 @@ def doubled_decks() -> list[Deck]:
     if not archetypes_from_rules:
         return []
     ids_list = ', '.join(str(deck_id) for deck_id in archetypes_from_rules)
-    result, _ = deck.load_decks(where=f'd.id IN ({ids_list})')
+    result = deck.load_decks(where=f'd.id IN ({ids_list})')
     for d in result:
         d.archetypes_from_rules = archetypes_from_rules[d.id]
         d.archetypes_from_rules_names = ', '.join(f'{a.archetype_name} ({a.rule_id})' for a in archetypes_from_rules[d.id])
@@ -171,7 +171,7 @@ def overlooked_decks() -> list[Deck]:
     if not deck_ids:
         return []
     ids_list = ', '.join(deck_ids)
-    ds, _ = deck.load_decks(where=f'd.id IN ({ids_list})')
+    ds = deck.load_decks(where=f'd.id IN ({ids_list})')
     return ds
 
 @retry_after_calling(cache_all_rules)

--- a/decksite/league.py
+++ b/decksite/league.py
@@ -194,7 +194,7 @@ def active_decks(additional_where: str = 'TRUE') -> list[deck.Deck]:
         AND
             ({additional_where})
     """
-    decks, _ = deck.load_decks(where)
+    decks = deck.load_decks(where)
     return sorted(decks, key=lambda d: f'{d.person.ljust(100)}{d.name}')
 
 def active_decks_by(mtgo_username: str) -> list[deck.Deck]:
@@ -218,7 +218,7 @@ def report(form: ReportForm) -> bool:
         entry_deck_id = int(form.entry)
         opponent_deck_id = int(form.opponent)
 
-        ds, _ = deck.load_decks(f'd.id IN ({entry_deck_id}, {opponent_deck_id})')
+        ds = deck.load_decks(f'd.id IN ({entry_deck_id}, {opponent_deck_id})')
         ds_by_id = {d.id: d for d in ds}
         entry_deck = ds_by_id.get(entry_deck_id)
         opponent_deck = ds_by_id.get(opponent_deck_id)
@@ -350,7 +350,7 @@ def retire_deck(d: Deck) -> None:
 def random_legal_deck() -> Deck | None:
     where = f'd.reviewed AND d.created_date > (SELECT start_date FROM season WHERE number = {seasons.current_season_num()})'
     having = f'(d.competition_id NOT IN ({active_competition_id_query()}) OR SUM(cache.wins + cache.draws + cache.losses) >= 5)'
-    ds, _ = deck.load_decks(where=where, having=having, order_by='RAND()', limit='LIMIT 1')
+    ds = deck.load_decks(where=where, having=having, order_by='RAND()', limit='LIMIT 1')
     try:
         return ds[0]
     except IndexError:

--- a/decksite/league_test.py
+++ b/decksite/league_test.py
@@ -81,6 +81,6 @@ def test_determine_league_name() -> None:
 def test_random_legal_deck(monkeypatch: pytest.MonkeyPatch, decks: list[Deck]) -> None:
     monkeypatch.setattr(league.seasons, 'current_season_num', lambda: 42)
     monkeypatch.setattr(league, 'active_competition_id_query', lambda: '1, 2')
-    monkeypatch.setattr(league.deck, 'load_decks', lambda **kwargs: (decks, len(decks)))
+    monkeypatch.setattr(league.deck, 'load_decks', lambda **kwargs: decks)
 
     assert league.random_legal_deck() is (decks[0] if decks else None)

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -29,7 +29,7 @@ def home() -> str:
     season_id = get_season_id()
     decks = ds.latest_decks(season_id=season_id)
     top_8_plus_basics = 'LIMIT 13'
-    cards, total = cs.load_cards(limit=top_8_plus_basics, season_id=season_id)
+    cards, total = cs.load_cards_with_total(limit=top_8_plus_basics, season_id=season_id)
     all_archetypes = archs.load_archetypes(order_by='num_decks DESC', season_id=season_id)
     view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats(), all_archetypes)
     return view.page()

--- a/decksite/scrapers/gatherling_test.py
+++ b/decksite/scrapers/gatherling_test.py
@@ -42,7 +42,7 @@ def test_process() -> None:
     assert finishes[5] == 4
     for i in range(9, len(c.decks)):
         assert finishes[i] == 1
-    ms, _ = match.load_matches('c.id = ' + str(c.id))
+    ms = match.load_matches('c.id = ' + str(c.id))
     assert len(ms) == len(event.matches)
     for m in ms:
         assert (m.opponent is None) or (2 <= m.game_wins + m.game_losses <= 3)

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -11,7 +11,7 @@ class EditArchetypes(View):
         super().__init__()
         self.archetypes = archetypes
         self.archetypes_preordered = archetype.preorder(archetypes)
-        ds, _ = deck.load_decks(where='NOT d.reviewed', order_by='updated_date DESC', limit='LIMIT 20')
+        ds = deck.load_decks(where='NOT d.reviewed', order_by='updated_date DESC', limit='LIMIT 20')
         self.queue = ds
         deck.load_queue_similarity(self.queue)
         rule.apply_rules_to_decks(self.queue)


### PR DESCRIPTION
## What was wrong

The `load_decks`, `load_people`, `load_cards`, `load_matches`, and `load_rotation` functions all returned `tuple[list[T], int]` (results + total count) because the API needs the total for pagination. However, the vast majority of callers don't need the total, leading to widespread `ds, _ = load_decks(...)` unpacking boilerplate throughout the codebase — and one place that had to cast `list(matchup_people)` because `load_people` returned `Sequence[Person]` instead of `list[Person]`.

## What changed

- Each function (`load_decks`, `load_people`, `load_cards`, `load_matches`, `load_rotation`) now returns `list[T]` directly.
- New `load_decks_with_total`, `load_people_with_total`, `load_cards_with_total`, `load_matches_with_total`, and `load_rotation_with_total` variants are introduced; each wraps the implementation and returns `tuple[list[T], int]`.
- API endpoints and `main.py` (which need the total for pagination) are updated to call the `_with_total` variants.
- All non-paginated callers are simplified to drop the `_, _` unpacking.
- `load_people` return type changed from `Sequence[Person]` to `list[Person]`, eliminating the `list()` cast in `metagame.py`.
- Test mocks for `load_decks` updated to return a plain list instead of a tuple.

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 848 passed, 1 skipped, 89 deselected

Fixes #12490