### PR TITLE
Strip leading ¿ before titlecasing deck names (#12484)

### DIFF
--- a/decksite/deck_name.py
+++ b/decksite/deck_name.py
@@ -86,6 +86,7 @@ def normalize(d: Deck) -> str:
         name = d.original_name
         if whitelisted(name):
             return name
+        name = name.lstrip('¿')
         name = titlecase.titlecase(name)
         if whitelisted(name):
             return name.replace('#General', '#general')

--- a/decksite/deck_name_test.py
+++ b/decksite/deck_name_test.py
@@ -320,6 +320,7 @@ TESTDATA: list[tuple[str, str, list[str] | None, str | None, int]] = [
     ('🏴\u200d☠️', '🏴\u200d☠', ['U', 'R'], 'Pirates', 33),  # Pirate flag without force color
     ('👨\u200d👩\u200d👧\u200d👦', '👨\u200d👩\u200d👧\u200d👦', None, None, 1),  # Family
     ('👨\ufe0f\u200d💻\ufe0f', '👨\u200d💻', None, None, 1),  # Person at computer
+    ('¿Red Deck Wins?', 'Red Deck Wins?', ['R'], 'Red Deck Wins', 1),
 ]
 
 def test_replace_space_alternatives() -> None:


### PR DESCRIPTION
## What was wrong

Deck names beginning with the Spanish inverted question mark (`¿`) were not handled correctly. The `titlecase` library sees `¿` as the first character and does not capitalize the following word properly, resulting in mangled deck names like `¿red Deck Wins?` instead of the expected `Red Deck Wins?`.

## What changed

In `decksite/deck_name.py`, added `name = name.lstrip('¿')` immediately before the first `titlecase.titlecase(name)` call in `normalize()`. This strips any leading inverted question marks before titlecasing, so the rest of the pipeline processes the name correctly.

Added a corresponding parametrized test case `('¿Red Deck Wins?', 'Red Deck Wins?', ['R'], 'Red Deck Wins', 1)` in `decksite/deck_name_test.py`.

## Validation

- `uv run --frozen python dev.py lint` — passed (all checks)
- `uv run --frozen python dev.py unit decksite/deck_name_test.py` — 846 passed, 1 skipped, 89 deselected

Fixes #12484