### PR TITLE
Fix /all/people person links to point to all-time detail page (#12472)

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -273,7 +273,7 @@ def people_api() -> Response:
     q = request.args.get('q', '').strip()
     where = clauses.text_where(query.person_query(), q) if q else 'TRUE'
     people, total = ps.load_people(where=where, order_by=order_by, limit=limit, season_id=season_id)
-    prepare_people(people)
+    prepare_people(people, season_id)
     r = {'page': page, 'total': total, 'objects': people}
     resp = return_camelized_json(r)
     resp.set_cookie('page_size', str(page_size))

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -139,9 +139,14 @@ def prepare_deck(d: Deck) -> None:
             total += c['n'] * c.card.cmc
     d.average_cmc = round(total / max(1, num_cards), 2)
 
-def prepare_people(ps: Sequence[Person]) -> None:
+def prepare_people(ps: Sequence[Person], season_id: int | str | None = None) -> None:
     for p in ps:
-        if p.get('mtgo_username'):
+        if season_id == 0:
+            if p.get('mtgo_username'):
+                p.url = f'/seasons/all/people/{p.mtgo_username.lower()}/'
+            else:
+                p.url = f'/seasons/all/people/id/{p.id}/'
+        elif p.get('mtgo_username'):
             p.url = f'/people/{p.mtgo_username.lower()}/'
         else:
             p.url = f'/people/id/{p.id}/'

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -235,7 +235,7 @@ class View(BaseView):
             c.league = c.type == 'League'
 
     def prepare_people(self) -> None:
-        prepare.prepare_people(getattr(self, 'people', []))
+        prepare.prepare_people(getattr(self, 'people', []), self.season_id())
 
     def prepare_archetypes(self) -> None:
         prepare.prepare_archetypes(getattr(self, 'archetypes', []), getattr(self, 'archetype', {}).get('id', None), getattr(self, 'tournament_only', False), self.season_id())


### PR DESCRIPTION
## What was wrong

On `/seasons/all/people`, each person's row linked to `/people/{username}/` — the **current season** detail page — instead of `/seasons/all/people/{username}/`, the **all-time** detail page.

The root cause: `prepare_people()` in `decksite/prepare.py` unconditionally generated base `/people/` URLs with no awareness of which season context it was being called for.

## What changed

- **`decksite/prepare.py`**: Added `season_id: int | str | None = None` parameter to `prepare_people`. When `season_id == 0` (the internal representation of "all seasons", as returned by `get_season_id()` when the path segment is `all`), person URLs are generated as `/seasons/all/people/{username}/` or `/seasons/all/people/id/{id}/` instead of the bare `/people/` forms.
- **`decksite/controllers/api.py`**: Passed the already-computed `season_id` to `prepare_people(people, season_id)` in `people_api()`. The `seasonId=0` query parameter sent by the JS client on the all-seasons page maps to `season_id=0` here.
- **`decksite/view.py`**: Updated the `View.prepare_people()` method to pass `self.season_id()` to `prepare.prepare_people`, matching the existing pattern used by `prepare_archetypes`.

## How it was validated

- `uv run --frozen python dev.py lint` — passed (all checks)
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped
- Manual trace: on `/seasons/all/people`, the JS table sends `?seasonId=0` to `/api/people/`; `seasons.season_id("0", None)` returns `0`; `prepare_people(people, 0)` now generates `/seasons/all/people/{username}/` URLs.

Fixes #12472