### PR TITLE
Replace hub with gh in do_pull_request and update README (#12469)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you plan on running things outside of the containers (eg: dev.py or logsite):
 - Reset the token, use it to fill out `token` in `.env`
 - Optionally, add the bot to your server with `https://discordapp.com/oauth2/authorize?client_id=<your client id here>&scope=bot`
 - Optionally, take a look at shared/configuration.py and enter any required non-default information into `.env`
-- You will want to investigate the various targets in dev.py that acts as a Makefile. Some of these utilities use GitHub's commandline git-enchancer, hub: <https://github.com/github/hub>
+- You will want to investigate the various targets in dev.py that acts as a Makefile. Some of these utilities use GitHub's official CLI, gh: <https://cli.github.com/>
 
 ## Manual Development Environment Setup (Non-docker instructions)
 

--- a/dev.py
+++ b/dev.py
@@ -257,10 +257,7 @@ def push() -> None:
 
 def do_pull_request(argv: list[str]) -> None:
     print('>>>> Pull request')
-    try:
-        subprocess.check_call(['hub', 'pull-request', *argv])
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        subprocess.check_call(['gh', 'pr', 'create'])
+    subprocess.check_call(['gh', 'pr', 'create', *argv])
 
 @cli.command()
 @click.argument('argv', nargs=-1)


### PR DESCRIPTION
## What was wrong

`do_pull_request()` in `dev.py` (lines 258–264) tried `hub pull-request` first and only fell back to `gh pr create` on failure. `hub` is a deprecated tool that has been superseded by the official GitHub CLI (`gh`). The fallback also silently dropped the `argv` arguments when falling back to `gh`.

README.md line 95 still linked to the old `hub` project at github.com/github/hub.

## What changed

- **dev.py**: Removed the try/except wrapper; `do_pull_request` now calls `['gh', 'pr', 'create', *argv]` directly, correctly forwarding any extra arguments.
- **README.md**: Updated the sentence to reference the official GitHub CLI (`gh`) and link to <https://cli.github.com/>.

## Validation

`uv run --frozen python dev.py lint` passes on the modified files. Unit tests require a live database which was not provisioned in this environment; the change is limited to a four-line simplification with no logic changes beyond removing the dead `hub` code path.

Fixes #12469