### PR TITLE
Replace inline style with CSS class in /manabase output (#12467)

### DIFF
--- a/decksite/templates/manabase.mustache
+++ b/decksite/templates/manabase.mustache
@@ -7,6 +7,6 @@
         {{> decklistinput}}
         <button type="submit">Generate</button>
     </form>
-    {{#output}}<pre style="font-family: monospace; overflow: scroll">{{output}}</pre>{{/output}}
+    {{#output}}<pre class="manabase-output">{{output}}</pre>{{/output}}
     {{> deckerrors}}
 </section>

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -3729,6 +3729,11 @@ A reasonable amount has been cut which we'll need to restore if we ever want dif
     color: #ccc;
 }
 
+.manabase-output {
+    font-family: monospace;
+    overflow: scroll;
+}
+
 .tpd-skin-dark a:hover {
     color: #c0c0c0;
 }


### PR DESCRIPTION
## What was wrong

The `<pre>` element in `decksite/templates/manabase.mustache` used an inline `style` attribute (`font-family: monospace; overflow: scroll`) instead of a CSS class, violating the project's convention of keeping styles in stylesheets.

## What changed

- `decksite/templates/manabase.mustache`: replaced `style="font-family: monospace; overflow: scroll"` with `class="manabase-output"` on the `<pre>` element
- `shared_web/static/css/pd.css`: added `.manabase-output { font-family: monospace; overflow: scroll; }` near the end of the file

## Validation

- `uv run --frozen python dev.py lint` — passed
- `uv run --frozen python dev.py unit` — 845 passed, 1 skipped in 18.08s

Fixes #12467