### PR TITLE
Serve /metagame tile art from /image/ instead of hotlinking the Scryfall API

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -22,6 +22,11 @@ from magic import image_fetcher, oracle, seasons
 from shared import logger, perf
 from shared.pd_exception import TooFewItemsException
 
+SUPPORTED_IMAGE_VERSIONS = ['', 'art_crop']
+# Card images never change once we've picked a printing, so let browsers and Cloudflare hang on to them.
+# Without this every card on every page is revalidated against us on every pageview.
+IMAGE_MAX_AGE = 60 * 60 * 24 * 7
+
 
 @APP.route('/')
 @cached()
@@ -51,6 +56,11 @@ def discord() -> wrappers.Response:
 @APP.route('/image/<path:c>/')
 def image(c: str = '') -> wrappers.Response:
     names = c.split('|')
+    version = request.args.get('version', '')
+    if version not in SUPPORTED_IMAGE_VERSIONS:
+        return make_response('', 400)
+    if version == 'art_crop' and len(names) > 1:
+        return make_response('', 400)  # There's no such thing as a composite art crop.
     try:
         requested_cards = oracle.load_cards(names)
         preferred_printing = request.args.get('printing')
@@ -62,15 +72,36 @@ def image(c: str = '') -> wrappers.Response:
                     card['preferred_printing'] = preferred_printing
                 if preferred_printing_system_id:
                     card['preferred_printing_system_id'] = preferred_printing_system_id
-        path = image_fetcher.download_image(requested_cards)
+        path = image_fetcher.download_image(requested_cards, version=version)
         if path is None:
+            if len(names) == 1:
+                # Almost always a Scryfall 429 on a cold cache. Let the visitor's browser fetch this one
+                # itself, from its own IP, rather than showing a broken image and paging someone.
+                logger.warning(f'Could not fetch image for {c}, redirecting to Scryfall')
+                return scryfall_fallback(c, version)
             raise InternalServerError(f'Failed to get image for {c}')
-        return send_file(os.path.abspath(path))  # Send abspath to work around monolith root versus web root.
+        response = send_file(os.path.abspath(path))  # Send abspath to work around monolith root versus web root.
+        # send_file defaults to no-cache, which wins over any max-age we add and makes browsers revalidate
+        # every image on every pageview. Clear it. (send_file has a max_age argument but types-flask predates it.)
+        response.cache_control.no_cache = None
+        response.cache_control.public = True
+        response.cache_control.max_age = IMAGE_MAX_AGE
+        return response
     except TooFewItemsException as e:
         logger.info(f'Did not find an image for {c}: {e}')
         if len(names) == 1:
-            return redirect(f'https://api.scryfall.com/cards/named?exact={c}&format=image', code=303)
+            return scryfall_fallback(c, version)
         return make_response('', 400)
+
+def scryfall_fallback(name: str, version: str) -> wrappers.Response:
+    """Redirect the browser to Scryfall for a single card image we can't serve ourselves.
+
+    This is the old behaviour for every image, kept as the fallback. It's uncached, so the next
+    request comes back to us and gets served locally once the fetch succeeds."""
+    url = f'https://api.scryfall.com/cards/named?exact={name}&format=image'
+    if version:
+        url += f'&version={version}'
+    return redirect(url, code=303)
 
 @APP.route('/static/dev-db.sql.gz')
 def dev_db() -> wrappers.Response:
@@ -79,9 +110,12 @@ def dev_db() -> wrappers.Response:
 
 @APP.before_request
 def before_request() -> wrappers.Response | None:
-    simple_paths = [APP.static_url_path, '/banner/', '/favicon.ico', '/robots.txt']
-    if not any(request.path.startswith(prefix) for prefix in simple_paths):
-        auth.check_perms()
+    # These serve identical bytes to everyone. Touching the session would add a Vary: Cookie that stops
+    # them being cached by Cloudflare, so return before anything looks at it.
+    simple_paths = [APP.static_url_path, '/banner/', '/favicon.ico', '/robots.txt', '/image/']
+    if any(request.path.startswith(prefix) for prefix in simple_paths):
+        return None
+    auth.check_perms()
     if not request.path.endswith('/'):
         return None  # Let flask do the redirect-routes-not-ending-in-slashes thing before we interfere with routing. Avoids #8277.
     if request.path.startswith('/seasons') and len(request.path) > len('/seasons/') and get_season_id() >= seasons.current_season_num():

--- a/decksite/main_test.py
+++ b/decksite/main_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from decksite import main
 from magic.models import Card
+from shared.pd_exception import TooFewItemsException
 
 
 def test_image_route_applies_requested_printing_without_mutating_cached_card(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -9,7 +10,7 @@ def test_image_route_applies_requested_printing_without_mutating_cached_card(mon
     captured = []
     monkeypatch.setattr(main.oracle, 'load_cards', lambda _names: [cached_card])
 
-    def download_image(cards: list[Card]) -> str:
+    def download_image(cards: list[Card], version: str = '') -> str:
         captured.extend(cards)
         return 'LICENSE.md'
 
@@ -24,3 +25,85 @@ def test_image_route_applies_requested_printing_without_mutating_cached_card(mon
     assert captured[0].preferred_printing_system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
     assert cached_card.get('preferred_printing') is None
     assert cached_card.get('preferred_printing_system_id') is None
+
+
+def test_image_route_passes_version_through_and_is_cacheable(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = {}
+    monkeypatch.setattr(main.oracle, 'load_cards', lambda _names: [Card({'name': 'Reclaim'})])
+
+    def download_image(cards: list[Card], version: str = '') -> str:
+        captured['version'] = version
+        return 'LICENSE.md'
+
+    monkeypatch.setattr(main.image_fetcher, 'download_image', download_image)
+
+    with main.APP.test_request_context('/image/Reclaim/?version=art_crop'):
+        response = main.image('Reclaim')
+
+    assert response.status_code == 200
+    assert captured['version'] == 'art_crop'
+    # Without these every card on every page is revalidated against us on every pageview. send_file
+    # sets no-cache by default, which silently defeats max_age, so check it is gone.
+    assert response.cache_control.public
+    assert response.cache_control.max_age == main.IMAGE_MAX_AGE
+    assert not response.cache_control.no_cache
+
+
+def test_image_route_rejects_unknown_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main.oracle, 'load_cards', lambda _names: [Card({'name': 'Reclaim'})])
+
+    with main.APP.test_request_context('/image/Reclaim/?version=../../etc/passwd'):
+        response = main.image('Reclaim')
+
+    assert response.status_code == 400
+
+
+def test_image_requests_do_not_touch_the_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anything that reads the session adds a Vary: Cookie, which stops Cloudflare caching /image/ at all."""
+    def fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError('/image/ must not read the session')
+
+    monkeypatch.setattr(main.auth, 'check_perms', fail)
+    monkeypatch.setattr(main.auth, 'discord_id', fail)
+    monkeypatch.setattr(main.auth, 'mtgo_username', fail)
+
+    with main.APP.test_request_context('/image/Reclaim/?version=art_crop'):
+        assert main.before_request() is None
+
+
+def test_image_route_rejects_an_art_crop_of_multiple_cards(monkeypatch: pytest.MonkeyPatch) -> None:
+    """/image/a|b/ composites two card images together, which makes no sense for an art crop."""
+    monkeypatch.setattr(main.oracle, 'load_cards', lambda names: [Card({'name': n}) for n in names])
+
+    with main.APP.test_request_context('/image/Reclaim|Cremate/?version=art_crop'):
+        response = main.image('Reclaim|Cremate')
+
+    assert response.status_code == 400
+
+
+def test_image_route_fallback_keeps_the_requested_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cards we don't have at all still redirect to Scryfall, but should redirect to the right image."""
+    def not_found(_names: list[str]) -> list[Card]:
+        raise TooFewItemsException('nope')
+
+    monkeypatch.setattr(main.oracle, 'load_cards', not_found)
+
+    with main.APP.test_request_context('/image/Nonesuch/?version=art_crop'):
+        response = main.image('Nonesuch')
+
+    assert response.status_code == 303
+    assert response.location is not None
+    assert response.location.endswith('&version=art_crop')
+
+
+def test_image_route_falls_back_to_scryfall_when_the_fetch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cold cache plus a Scryfall 429 used to be a 500 per image. Send the browser to Scryfall for that one instead."""
+    monkeypatch.setattr(main.oracle, 'load_cards', lambda _names: [Card({'name': 'Lovestruck Beast'})])
+    monkeypatch.setattr(main.image_fetcher, 'download_image', lambda cards, version='': None)
+
+    with main.APP.test_request_context('/image/Lovestruck%20Beast/?version=art_crop'):
+        response = main.image('Lovestruck Beast')
+
+    assert response.status_code == 303
+    assert response.location == 'https://api.scryfall.com/cards/named?exact=Lovestruck Beast&format=image&version=art_crop'
+    assert not response.cache_control.max_age  # Must not be cached, or we never get the chance to serve it ourselves.

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -8,7 +8,7 @@ from decksite.data import archetype
 from decksite.data.archetype import Archetype
 from decksite.data.models.person import Person
 from decksite.deck_type import DeckType
-from magic import fetcher, image_fetcher, oracle, seasons
+from magic import fetcher, oracle, seasons
 from magic.colors import find_colors
 from magic.models import Card, Deck
 from shared import dtutil
@@ -60,17 +60,21 @@ def prepare_card_urls(c: Card, tournament_only: bool = False, season_id: int | s
     c.url = url_for_card(c, tournament_only, season_id)
     c.img_url = url_for_image(c.name, c.get('preferred_printing'), c.get('preferred_printing_system_id'))
 
-def url_for_image(name: str, preferred_printing: str | None = None, preferred_printing_system_id: str | None = None) -> str:
+def url_for_image(name: str, preferred_printing: str | None = None, preferred_printing_system_id: str | None = None, version: str | None = None) -> str:
     if g.get('url_cache') is None:
         g.url_cache = {}
     if g.url_cache.get('card_image') is None:
         g.url_cache['card_image'] = url_for('image', c='--cardname--')
-    url = g.url_cache['card_image'].replace('--cardname--', name)
+    # Encode the name. Unencoded spaces are tolerated in an img src but make the URL invalid inside a
+    # CSS url(), which is how /metagame draws its tiles.
+    url = g.url_cache['card_image'].replace('--cardname--', urllib.parse.quote(name))
     query = {}
     if preferred_printing:
         query['printing'] = preferred_printing
     if preferred_printing_system_id:
         query['printing_id'] = preferred_printing_system_id
+    if version:
+        query['version'] = version
     if query:
         return f'{url}?{urllib.parse.urlencode(query)}'
     return url
@@ -200,7 +204,7 @@ def prepare_archetypes_for_api(archetypes: list[Archetype], key_card_names: Mapp
     for a in archetypes:
         key_cards = [cards_by_name[name] for name in key_card_names.get(a.id, [])]
         a.key_cards = [
-            Card({'name': card.name, 'url': image_fetcher.scryfall_image(card, 'art_crop')})
+            Card({'name': card.name, 'url': url_for_image(card.name, version='art_crop')})
             for card in key_cards
             if not is_uninteresting(card)
         ][:5]

--- a/decksite/prepare_test.py
+++ b/decksite/prepare_test.py
@@ -92,7 +92,7 @@ def test_prepare_card_uses_preferred_printing_for_image(monkeypatch: pytest.Monk
     with APP.test_request_context('/'):
         prepare.prepare_card(card)
 
-    assert card.img_url == '/image/Agent Venom/?printing=om1&printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760'
+    assert card.img_url == '/image/Agent%20Venom/?printing=om1&printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760'
 
 
 def test_prepare_archetypes_for_api_adds_grid_fields(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -115,13 +115,12 @@ def test_prepare_archetypes_for_api_adds_grid_fields(monkeypatch: pytest.MonkeyP
         return (['R'], ['R']) if key_cards else ([], [])
 
     monkeypatch.setattr(prepare, 'find_colors', fake_find_colors)
-    monkeypatch.setattr(prepare.image_fetcher, 'scryfall_image', lambda card, version: f'https://images.test/{card.name}/{version}')
 
     with APP.test_request_context('/'):
         prepare.prepare_archetypes_for_api(archetypes, key_card_names, cards, False, 42)
 
     assert [(card.name, card.url) for card in archetypes[0].key_cards] == [
-        (f'Card {n}', f'https://images.test/Card {n}/art_crop') for n in range(1, 6)
+        (f'Card {n}', f'/image/Card%20{n}/?version=art_crop') for n in range(1, 6)
     ]
     assert archetypes[0].num_matches == 5
     assert archetypes[0].colors_safe == '<div class="mana-bar"><span class="stacked-bar mana-R" style="flex-grow: 100"></span></div>'
@@ -129,3 +128,11 @@ def test_prepare_archetypes_for_api_adds_grid_fields(monkeypatch: pytest.MonkeyP
     assert archetypes[1].num_matches == 0
     assert archetypes[1].colors_safe == '<div class="mana-bar"><span class="stacked-bar mana" style="flex-grow: 1"></span></div>'
     assert colors_calls == [list(cards), []]
+
+def test_url_for_image_requests_an_art_crop_from_us_not_scryfall() -> None:
+    """The /metagame tiles used to hotlink api.scryfall.com and get rate limited into 429s."""
+    with APP.test_request_context('/'):
+        url = prepare.url_for_image('Reclaim', version='art_crop')
+
+    assert url == '/image/Reclaim/?version=art_crop'
+    assert 'scryfall' not in url

--- a/decksite/views/card_test.py
+++ b/decksite/views/card_test.py
@@ -29,8 +29,8 @@ def test_alternate_card_page_uses_alternate_name_and_printing(monkeypatch: pytes
     assert '<section class="card-image-block">' in content
     assert '<p class="alternate-printing-note ">Alternate printing of' in content
     assert 'href="/cards/Agent%20Venom/">Agent Venom</a>' in content
-    assert 'src="/image/Agent Venom/?printing=om1&amp;printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760"' in content
-    assert content.index('src="/image/Agent Venom/?printing=om1') < content.index('Alternate printing of')
+    assert 'src="/image/Agent%20Venom/?printing=om1&amp;printing_id=d62cf4f8-36a2-4d9f-9d52-53ea18a52760"' in content
+    assert content.index('src="/image/Agent%20Venom/?printing=om1') < content.index('Alternate printing of')
 
 
 def test_canonical_card_page_links_to_alternate_printing(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/magic/image_fetcher.py
+++ b/magic/image_fetcher.py
@@ -86,8 +86,14 @@ async def download_art_crop(c: Card, hq_data: dict[str, tuple[str, int]]) -> str
             return file_path
     return await download_scryfall_art_crop(c)
 
+def art_crop_filepath(c: Card) -> str:
+    return re.sub('.jpg$', '.art_crop.jpg', determine_filepath([c]))
+
+def art_crop_is_cached(c: Card) -> bool:
+    return fetch_tools.acceptable_file(art_crop_filepath(c))
+
 async def download_scryfall_art_crop(c: Card) -> str | None:
-    file_path = re.sub('.jpg$', '.art_crop.jpg', determine_filepath([c]))
+    file_path = art_crop_filepath(c)
     if not fetch_tools.acceptable_file(file_path):
         await download_scryfall_card_image(c, file_path, version='art_crop')
     if fetch_tools.acceptable_file(file_path):
@@ -135,16 +141,20 @@ def determine_filepath(cards: list[Card], prefix: str = '', ext: str = '.jpg') -
     return f'{directory}/{prefix}{filename}'
 
 
-def download_image(cards: list[Card]) -> str | None:
+def download_image(cards: list[Card], version: str = '') -> str | None:
     event_loop = None
     try:
         event_loop = asyncio.get_event_loop()
     except RuntimeError:
         event_loop = asyncio.new_event_loop()
         asyncio.set_event_loop(event_loop)
-    return event_loop.run_until_complete(download_image_async(cards))
+    return event_loop.run_until_complete(download_image_async(cards, version))
 
-async def download_image_async(cards: list[Card]) -> str | None:
+async def download_image_async(cards: list[Card], version: str = '') -> str | None:
+    if version == 'art_crop':
+        if len(cards) != 1:
+            return None  # There's no such thing as a composite art crop.
+        return await download_scryfall_art_crop(cards[0])
     filepath = determine_filepath(cards)
     if fetch_tools.acceptable_file(filepath):
         return filepath

--- a/maintenance/cache_key_card_art.py
+++ b/maintenance/cache_key_card_art.py
@@ -1,0 +1,52 @@
+import time
+
+from decksite.data import playability
+from decksite.prepare import is_uninteresting
+from magic import image_fetcher, oracle, seasons
+from magic.models import Card
+from shared import logger
+
+DAILY = True
+
+KEY_CARDS_PER_TILE = 5
+# /cards/named is limited to 2 requests a second and nothing is waiting on us, so leave plenty of headroom.
+# See https://scryfall.com/docs/api/rate-limits
+SECONDS_BETWEEN_DOWNLOADS = 1.0
+
+def run() -> None:
+    """Download the art crops /metagame shows on its archetype tiles.
+
+    The tiles used to hotlink api.scryfall.com from the visitor's browser, which meant one pageview fired
+    ~100 requests at an endpoint that allows 2 a second and about half came back 429. They come from
+    /image/ now, so all that's left is making sure a cold cache doesn't leave the first visitor after a
+    deploy waiting on Scryfall. Do that out of band instead.
+    """
+    cards = key_cards()
+    logger.info(f'Checking art crops for {len(cards)} key cards')
+    downloaded, failed = 0, []
+    for card in cards:
+        if image_fetcher.art_crop_is_cached(card):
+            continue
+        if image_fetcher.download_image([card], version='art_crop') is None:
+            failed.append(card.name)
+        else:
+            downloaded += 1
+        time.sleep(SECONDS_BETWEEN_DOWNLOADS)
+    logger.info(f'Downloaded {downloaded} art crops, {len(failed)} failed')
+    if failed:
+        logger.warning(f'Failed to get art crops for: {", ".join(failed)}')
+
+def key_cards() -> list[Card]:
+    """Every card that can appear on a /metagame tile, for any season or all-time.
+
+    That's ~8k cards, so the first run takes a couple of hours. After that it's a no-op apart from whatever
+    became a key card since yesterday. Warming old seasons too matters because a cold season page fires
+    100+ fetches at Scryfall from our server at once and most of them come back 429."""
+    cards_by_name = oracle.cards_by_name()
+    found = {}
+    for season_id in [0, *range(1, seasons.current_season_num() + 1)]:
+        for names in playability.key_cards_long(season_id).values():
+            cards = [card for name in names if (card := cards_by_name.get(name)) is not None]
+            for card in [c for c in cards if not is_uninteresting(c)][0:KEY_CARDS_PER_TILE]:
+                found[card.name] = card
+    return [found[name] for name in sorted(found)]

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -24,7 +24,7 @@ const renderItem = (grid, archetype) => (
         </div>
         <div className="row key-card">
             {archetype.keyCards.length > 0 && (
-                <div className="card" data-name={archetype.keyCards[0].name} style={{background: `url(${archetype.keyCards[0].url}) center top / cover no-repeat`}}></div>
+                <div className="card" data-name={archetype.keyCards[0].name} style={{background: `url("${archetype.keyCards[0].url}") center top / cover no-repeat`}}></div>
             )}
         </div>
         <div className="row flex-row" style={{gap: "8px"}}>
@@ -89,7 +89,7 @@ const renderItem = (grid, archetype) => (
         </div>
         <div className="row key-cards">
             {archetype.keyCards && archetype.keyCards.shift() && archetype.keyCards.map((card) => (
-                <div className="card" data-name={card.name} style={{background: `url(${card.url}) center top / cover no-repeat`}} key={card.name}></div>
+                <div className="card" data-name={card.name} style={{background: `url("${card.url}") center top / cover no-repeat`}} key={card.name}></div>
             ))}
         </div>
     </a>


### PR DESCRIPTION
## The bug

Some or all of the archetype tiles on `/metagame` render blank, and Firefox's console fills with:

```
A resource is blocked by OpaqueResponseBlocking, please check browser console for details. named
```

The tiles hotlinked `https://api.scryfall.com/cards/named?exact=…&format=image&version=art_crop` straight from the visitor's browser, one per key card. Measured on prod with a cold browser profile:

| | prod | this branch |
|---|---|---|
| requests to `api.scryfall.com` per pageview | 111 | **0** |
| HTTP 429 | **55** | **0** |
| tiles rendered with art | ~56/111 | **120/120** |

Scryfall limits `/cards/named` to **2 requests/second** ([docs](https://scryfall.com/docs/api/rate-limits)), so about half the tiles 429 on every cold load, for every visitor, independently. The 429 is JSON with `nosniff`, which is exactly what ORB blocks for an `<img>`/CSS `url()`; that's the console spam. A hard refresh drops the browser cache and makes it worst-case. Every request carries `Referer: https://pennydreadfulmagic.com/`, and the 429 body says *"FAILURE TO ACT WILL RESULT IN A NETWORK BLOCK"*, so the exposure is collective, not just per-user.

## The fix

The tiles now ask **our own** `/image/<name>/?version=art_crop`, which downloads once server-side and caches to disk, the same path every other card image on the site already uses. Scryfall's file CDN is what the server fetches from; visitors never talk to Scryfall.

- `decksite/controllers/api.py` — `url_for_image(name, version='art_crop')` replaces `image_fetcher.scryfall_image(c, 'art_crop')`.
- `decksite/main.py` — `/image/` accepts `?version=art_crop` (single card only; a composite art crop is 400). Responses are `Cache-Control: public, max-age=604800`. `send_file` defaults to `no-cache`, which silently defeats `max-age`, so it's cleared explicitly. `/image/` is added to the paths that skip auth/session in `before_request`: touching the session adds `Vary: Cookie` and Cloudflare then won't cache the image at all (live prod headers today: `cache-control: no-cache`, `vary: Cookie`, `cf-cache-status: DYNAMIC`).
- `magic/image_fetcher.py` — `download_image(cards, version=...)` routes `art_crop` to the existing `download_scryfall_art_crop`.
- `decksite/prepare.py` — `url_for_image` gains `version` and **percent-encodes the card name**. Raw spaces are tolerated in an `<img src>` but make the URL invalid inside a CSS `url()`, which is how the tiles are drawn; only single-word card names rendered until this was fixed. The JSX also quotes the `url()` now.
- If a single card's image can't be fetched (in practice a Scryfall 429 on a cold cache) the route **303s the browser to Scryfall for that one card** instead of 500ing: today's behaviour, from the visitor's own un-rate-limited IP, uncached so the next request comes back to us, and no Sentry noise.
- `maintenance/cache_key_card_art.py` — new daily task that pre-downloads art crops for every key card in every season, throttled to 1 req/s. ~8,285 cards, ~2h once, then a no-op.

## Blast radius, honestly

The URL-encoding is the far-reaching-looking part. I traced every path by which `img_url` reaches a browser: the card page `<img>`, the error page `<img>`, `/api/cards2/`, `/api/rotation/cards/`, and the new tiles. **No JavaScript reads `imgUrl`.** Browsers already percent-encode spaces on the wire, so the server has always received `Agent%20Venom`; only the HTML text changes. The cache-header/session change applies to a route that returns identical bytes to every visitor regardless of login.

## Verification

Against a real stack (dev DB snapshot, 34,250 cards, 110,437 printings, live server), on this branch rebased onto current master:

- **858 tests pass, 0 fail** across every test directory; full-repo mypy, `dev.py lint`, `dev.py jslint` clean.
- **Site-wide image audit**: every card page — including apostrophe, comma, split-card (`Fire // Ice`) and Æ names — references the identical card set as prod; 480 API objects self-consistent; **476 image URLs resolved, 0 broken** (166 cold ones fell back to Scryfall cleanly, exercising the fallback).
- **Live render** of `/metagame/`: 24 tiles, 120/120 backgrounds, 0 Scryfall requests, 0×429.
- Regressions checked by hand: plain card image, `a|b` composite, `art_crop` of two cards → 400, bad version → 400, `before_request` routing (`/seasons/43/decks/`→`/decks/`, `/seasons/0/…`→`/seasons/all/…`), `Vary: Cookie` still on normal pages and gone from `/image/`.
- Pre-warm task: 1,149 + ~6,000 art crops downloaded across two runs, **0 failures**.

Nothing about the art changes visually: it's the same Scryfall art crop as today, just served by us.

## Deploy note

Run `python run.py maintenance cache-key-card-art` once at deploy (~2h, unattended). Without it the first visitors to each season page get some tiles via the Scryfall fallback until the first daily run; with it, `/metagame` is perfect from the first load. `image_dir` is persistent, so this is one-time.

## Follow-ups (not in this PR)

- Server-side fetches still go via `api.scryfall.com/cards/named`. Fetching from `cards.scryfall.io` using `printing.system_id` (no rate limit) would remove our own 429 exposure entirely, but needs a default-printing-per-card rule.
- `fetch_tools.store_async` writes the response body to disk regardless of status; a >1 KB error page would be cached as a `.jpg` forever.
- `magic/fetcher.search_scryfall` paginates at 10 req/s against a 2 req/s limit, with immediate retries.
- `types-flask 1.1.6` is the final release of an obsolete stub (Flask ships its own types); it's why `send_file(max_age=)` doesn't type-check.
- **Pre-existing, found while testing:** `/api/archetypes2/?seasonId=all` fails on master (`BuildError` in `prepare_archetype` with `season_id=None`, line dates from May 2024; prod returns 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9d8bc0e1-5f58-4274-9033-62c9edb4cb8c)
