### PR TITLE
Fix submenu no longer showing (clipped by menu scroll container)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -823,12 +823,12 @@ nav {
     display: flex;
     flex-direction: column;
     height: 100vh;
+    overflow-y: auto; /* Scroll here, not on .menu: a scroll container on .menu would clip the absolutely-positioned .submenu popover, whose containing block is a .menu > li. */
     position: relative;
 }
 
 .menu {
     flex: 1;
-    overflow-y: auto;
 }
 
 .submenu {


### PR DESCRIPTION
## Problem

The nav submenu stopped showing on production at every width.

## Cause

#12593 ("Fix archetype badge z-index hack…") added:

\`\`\`css
ul.menu > li {
    position: relative; /* Establishes containing block for the absolutely-positioned badge. */
}
\`\`\`

This gives the badge its containing block — but it also makes each \`li\` the containing block for the absolutely-positioned \`.submenu\`. That pulls the submenu inside \`.menu\`'s scroll box (\`overflow-y: auto\` forces \`overflow-x\` to compute to \`auto\`, creating a clip region). Because the submenu is positioned at \`left: var(--main-menu-width)\` — right at the edge of the menu column — it lands entirely outside \`.menu\`'s clip box and is never painted, at any width.

## Fix

Move the menu's scroll safety from \`.menu\` to \`nav\`, so \`.menu\` no longer establishes a scroll/clip box and the submenu popover can escape the menu column again.

- The badge keeps its \`li\` containing block (badge fix from #12593 preserved).
- The medium-width branch already sets \`nav { overflow: visible }\`.
- At narrow/wide widths the nav expands to \`--full-menu-width\` whenever a submenu is shown, so the popover always fits inside nav and isn't clipped.

## Validation

Rendered a standalone harness of the menu markup against \`pd.css\` in headless Chrome, before and after:

- **Before:** submenu fully clipped / invisible despite \`.submenu-open\`.
- **After:** submenu popover renders correctly to the right of the menu column; badge still hangs off the icon.

Verified across all three width regimes (≤900 drawer, 901–1600 popover, ≥1601 in-flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ebe6c795-5c9a-41c3-baa7-b1832601a613)
