### PR TITLE
Fix /decks/ showing zero decks: ignore empty cardName filter

### DIFF
--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -310,7 +310,8 @@ def decks_where(args: dict[str, str], is_admin: bool, viewer_id: int | None) -> 
         parts.append(archetype_where(archetype_id))
     if args.get('personId'):
         person_id = int(args.get('personId', ''))
-    card_names = args.getlist('cardName') if hasattr(args, 'getlist') else ([args['cardName']] if args.get('cardName') else [])
+    raw_card_names = args.getlist('cardName') if hasattr(args, 'getlist') else [args.get('cardName')]
+    card_names = [name for name in raw_card_names if name]
     if card_names:
         parts.append(cards_where(card_names))
     if args.get('minWinRate'):

--- a/decksite/data/clauses_test.py
+++ b/decksite/data/clauses_test.py
@@ -55,6 +55,12 @@ def test_decks_where() -> None:
     assert "= 'League'" not in clauses.decks_where(args, False, 1)
     assert "= 'Gatherling'" not in clauses.decks_where(args, False, 1)
 
+def test_decks_where_ignores_empty_card_name() -> None:
+    # The deck table always sends cardName= (empty) from data-card-name="", which must not filter out every deck.
+    from werkzeug.datastructures import MultiDict
+    assert 'FALSE' not in clauses.decks_where(MultiDict([('cardName', '')]), False, 1)
+    assert 'FALSE' not in clauses.decks_where({'cardName': ''}, False, 1)
+
 def test_card_search_where() -> None:
     assert ("name IN ('Tasigur, the Golden Fang')", '') == clauses.card_search_where('Tasigur, the Golden Fang')
     assert ("cs.name IN ('Tasigur, the Golden Fang')", '') == clauses.card_search_where('Tasigur, the Golden Fang', column_name='cs.name')


### PR DESCRIPTION
## Prod outage fix

`/decks/` (and every deck listing) showed **0 decks**. Root cause is #15112.

The deck table always sends `cardName=` (empty) from `data-card-name=""` — long-standing, intentional behavior (the deck table's per-card filter; empty on the plain decks page). #15112 changed `decks_where` from `if args.get('cardName')` (empty string is falsy → skipped) to `args.getlist('cardName')`, which returns `['']` for the empty param. That truthy list ran `cards_where([''])` → `oracle.valid_name('')` raises → returned the literal `'FALSE'`, so the query became `WHERE … AND FALSE` → zero decks.

Confirmed against live prod: `/api/decks/?…&seasonId=43` → 717 decks; adding `&cardName=` → 0.

## Fix
Drop blank card names before building the clause, restoring the empty-string tolerance the code had for years. Multi-card search still builds `HAVING COUNT(DISTINCT card)`; `minWinRate` was unaffected (it uses `args.get` truthiness).

Adds `test_decks_where_ignores_empty_card_name` regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)