### PR TITLE
Fix daily maintenance jobs crashing on load_decks/load_people list return

### DIFF
--- a/maintenance/deck_hash.py
+++ b/maintenance/deck_hash.py
@@ -17,7 +17,7 @@ def recalculate(deck_ids: set[int] | None = None) -> None:
     else:
         where = 'd.id IN ({})'.format(', '.join(map(str, sorted(deck_ids))))
         redis.clear(*(f'decksite:deck:{deck_id}' for deck_id in deck_ids))
-    all_decks, _ = deck.load_decks(where=where)
+    all_decks = deck.load_decks(where=where)
     for d in all_decks:
         # Recalculate all hashes, in case they've changed.  Or we've changed the default sort order.
         cards = {'maindeck': d['maindeck'], 'sideboard': d['sideboard']}

--- a/maintenance/deck_hash_test.py
+++ b/maintenance/deck_hash_test.py
@@ -7,9 +7,9 @@ def test_recalculate_selected_decks_uses_an_id_filter(monkeypatch: pytest.Monkey
     where: list[str] = []
     cleared: list[str] = []
 
-    def load_decks(**kwargs: str) -> tuple[list[object], int]:
+    def load_decks(**kwargs: str) -> list[object]:  # load_decks returns a plain list; the total-bearing variant is load_decks_with_total.
         where.append(kwargs['where'])
-        return [], 0
+        return []
 
     monkeypatch.setattr(deck_hash.deck, 'load_decks', load_decks)
     monkeypatch.setattr(deck_hash.redis, 'clear', lambda *keys: cleared.extend(keys))

--- a/maintenance/deck_name.py
+++ b/maintenance/deck_name.py
@@ -5,7 +5,7 @@ from decksite.data import deck
 # Make your changes in deck_name.py and then run this to see which decks would change if re-normalized.
 
 def ad_hoc() -> None:
-    ds, _ = deck.load_decks()
+    ds = deck.load_decks()
     for d in ds:
         current = d.name
         potential = deck_name.normalize(d)

--- a/maintenance/elo.py
+++ b/maintenance/elo.py
@@ -26,7 +26,7 @@ def run() -> None:
     matches = db().select(sql)
     for m in matches:
         match(m)
-    current, _ = person.load_people()
+    current = person.load_people()
     people_by_id = {p.id: p for p in current}
     sql = 'UPDATE person SET elo = %s WHERE id = %s'
     for person_id, new_elo in sorted(PEOPLE.items(), key=lambda x: -x[1]):

--- a/maintenance/elo_test.py
+++ b/maintenance/elo_test.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+import pytest
+
+from maintenance import elo
+from shared.container import Container
+
+
+def test_run_reads_people_as_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """person.load_people returns a list, not (list, total). Unpacking it crashed the daily job."""
+    updates: list[list[Any]] = []
+
+    class FakeDb:
+        def select(self, sql: str) -> list[dict[str, str]]:
+            return [{'people': '1,2', 'games': '2,0'}]
+
+        def execute(self, sql: str, args: list[Any]) -> int:
+            updates.append(args)
+            return 1
+
+    monkeypatch.setattr(elo, 'db', lambda: FakeDb())
+    monkeypatch.setattr(elo.person, 'load_people', lambda: [Container({'id': 1, 'elo': 1500}), Container({'id': 2, 'elo': 1500})])
+    monkeypatch.setattr(elo, 'PEOPLE', {})
+
+    elo.run()
+
+    assert len(updates) == 2
+    assert {person_id for _, person_id in updates} == {1, 2}

--- a/maintenance/gatherling_substitutions.py
+++ b/maintenance/gatherling_substitutions.py
@@ -14,7 +14,7 @@ def ad_hoc() -> None:
     except (IndexError, TypeError, ValueError):
         start = dtutil.now() - datetime.timedelta(days=7)
     print(f'Checking all Gatherling decks from {start}. To check from a different date supply it as a commandline arg in the form YYYY-MM-DD')
-    decks, _ = deck.load_decks(f"d.created_date >= UNIX_TIMESTAMP('{start}') AND ct.name = 'Gatherling'")
+    decks = deck.load_decks(f"d.created_date >= UNIX_TIMESTAMP('{start}') AND ct.name = 'Gatherling'")
     print(f'Found {len(decks)} decks.')
     searcher = WhooshSearcher()
     for d in decks:

--- a/maintenance/typeahead.py
+++ b/maintenance/typeahead.py
@@ -33,7 +33,7 @@ def cards() -> list[dict[str, str]]:
 
 def people() -> list[dict[str, str]]:
     urls = []
-    ps, _ = person.load_people()
+    ps = person.load_people()
     for p in ps:
         urls.append({'name': p.name, 'type': 'Person', 'url': url_for('person', mtgo_username=p.name)})
     if not urls:

--- a/maintenance/typeahead_test.py
+++ b/maintenance/typeahead_test.py
@@ -1,0 +1,13 @@
+import pytest
+
+from decksite.main import APP
+from maintenance import typeahead
+from shared.container import Container
+
+
+def test_people_reads_people_as_a_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """person.load_people returns a list, not (list, total). Unpacking it crashed the daily job."""
+    monkeypatch.setattr(typeahead.person, 'load_people', lambda: [Container({'name': 'SmokeTester'})])
+    with APP.test_request_context('/'):
+        urls = typeahead.people()
+    assert urls == [{'name': 'SmokeTester', 'type': 'Person', 'url': '/people/SmokeTester/'}]


### PR DESCRIPTION
## What was wrong

#15126 (ba97f8a2) changed `deck.load_decks` and `person.load_people` to return a plain list, moving the `(rows, total)` shape to the new `*_with_total` variants, but only updated callers under `decksite/`. Five maintenance scripts still unpacked a tuple:

- `maintenance/elo.py` (DAILY)
- `maintenance/deck_hash.py` (DAILY, also called from `canonicalize_card_names`)
- `maintenance/typeahead.py` (DAILY)
- `maintenance/deck_name.py` (ad hoc)
- `maintenance/gatherling_substitutions.py` (ad hoc)

So Elo recalculation, decklist-hash recalculation and typeahead regeneration have raised `ValueError: too many values to unpack` on every run since that deploy. mypy allows unpacking a list, and `deck_hash_test.py` mocked `load_decks` with the old tuple shape, which is why CI stayed green.

## What changed

- Drop the `, _` unpack in the five scripts. `grep` confirms no other tuple-unpacking callers remain.
- `deck_hash_test.py` mock now returns a list so it can no longer mask this.
- New `maintenance/elo_test.py` and `maintenance/typeahead_test.py` exercise the daily paths with list-returning mocks. Both fail on master and pass here.

## Validation

- `dev.py lint` and `dev.py mypy` clean on all touched files.
- New tests fail on the unfixed code (`ValueError: not enough values to unpack`) and pass with the fix.
- Ran `elo.run()`, `deck_hash.recalculate()` and `typeahead.people()` end to end against a local dev database copy; all completed.

Found while reviewing the 2026-09-02 auto-merged sweep batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)