### PR TITLE
Revert global box-sizing: border-box (#15116)

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -57,10 +57,6 @@ abbr {
     text-decoration: none;
 }
 
-*, *::before, *::after {
-    box-sizing: border-box;
-}
-
 /*
 
 Typography
@@ -437,6 +433,7 @@ footer {
     background-color: var(--tertiary-background);
     border-top: 0.05rem solid var(--border);
     bottom: 0;
+    box-sizing: border-box; /* So we can just say 100% width and have the status bar with padding fit the screen. */
     color: var(--tertiary-text);
     left: 0;
     padding-bottom: 1em;
@@ -1591,6 +1588,10 @@ that element doesn't suddenly start floating above the subnav and the status bar
 
 */
 
+nav * {
+    box-sizing: border-box;
+}
+
 header, nav, main, footer {
     position: relative;
 }
@@ -1727,6 +1728,7 @@ We also show the meta share of a deck in this way.
     border-bottom: 0.05rem solid var(--border);
     border-right: 0.05rem solid var(--border);
     border-top: 0.05rem solid var(--border);
+    box-sizing: border-box;
     display: inline-block;
     height: calc(18rem / 20); /* height (18px) + td.contains-mana-bar padding-top (3px) + td.contains-mana-bar padding-bottom (4px) must equal main td padding-top (5px) + main td padding-bottom (5px) + main td font-size (15px) * main td line-height (1). */
 }
@@ -2078,6 +2080,7 @@ button, main input, select, textarea, .uploader-label {
 
 
 button, input, form label, select, textarea {
+    box-sizing: border-box; /* Ignore padding when sizing so we can get elements the same height more easily. */
     margin-top: 1rem;
 }
 
@@ -2234,6 +2237,7 @@ Box of FAQs and intro materials that appears on every page until dismissed.
 .intro {
     background: var(--tertiary-background);
     border: 0.05rem solid var(--border);
+    box-sizing: border-box;
     max-width: calc(var(--max-readable-line-length) + 4.1rem); /* Preserve the readable content width while including the padding and border in the box's width. */
     padding: 2rem;
     position: relative; /* So that we can absolutely position the dismiss x in the corner. */
@@ -2336,6 +2340,7 @@ Search
 
 .search input {
     border: 0;
+    box-sizing: border-box; /* Lets us specify width the same as the search results below it without having to account for padding. */
     font-size: var(--reading-font-size);
     line-height: var(--reading-line-height); /* Give the search text a little room to breathe. */
     /*
@@ -2603,6 +2608,7 @@ main .ss-grid a.season-icon-link:hover, main .season-grid a.season-icon-link:hov
 
 .season-grid .season-icon-link {
     align-items: center;
+    box-sizing: border-box; /* So the padding doesn't push the cells past their minimum size. */
     display: flex;
     justify-content: center;
     min-height: 1.777rem;
@@ -2661,6 +2667,7 @@ ul.menu > li {
 .badge {
     background-color: var(--badge-background);
     border-radius: 0.85em; /* Half the height, so one or two digits is a circle and a rare three-digit count is a tidy pill rather than spilling out of one. */
+    box-sizing: border-box; /* So the min-width is the whole circle, padding included. */
     color: var(--badge-text);
     font-size: 0.6rem; /* Smaller than the smallest text token. A badge hangs off an icon so it has to read as smaller than one. */
     height: 1.7em;
@@ -2758,6 +2765,7 @@ Achievements
 }
 
 .achievement-bar span {
+    box-sizing: border-box; /* Let's us specify height 100% without having to account for padding. */
     display: inline-block;
     height: 100%; /* All parts of the bar should have the same height. */
     left: 0;
@@ -2984,6 +2992,7 @@ Metagame
 
 .metagame-grid .card {
     border: 0.05rem solid var(--line);
+    box-sizing: border-box;
     display: block;
     margin: 0;
     width: 100%;
@@ -3035,6 +3044,10 @@ From https://codepen.io/mallendeo/pen/eLIiG
 
 .toggle {
     display: none;
+}
+
+.toggle, .toggle::after, .toggle::before, .toggle *, .toggle *:after, .toggle *:before, .toggle + .toggle-button {
+    box-sizing: border-box;
 }
 
 .toggle::-moz-selection, .toggle::after::-moz-selection, .toggle::before::-moz-selection, .toggle *::-moz-selection, .toggle *:after::-moz-selection, .toggle *:before::-moz-selection, .toggle + .toggle-button::-moz-selection {
@@ -3153,6 +3166,7 @@ The old menu used to use most of this, now it's just used by the language switch
 
 .language-menu {
     background: var(--language-menu-background);
+    box-sizing: border-box; /* So we can position the first menu item's text flush-left with the page text without worrying about the padding used for page margin. */;
     color: var(--language-menu-text);
     display: none;
     left: 0;


### PR DESCRIPTION
Reverts the merge of #15116.

## Why

The 13 removed `box-sizing: border-box` declarations really were redundant. The problem is the other direction: the new global `*, *::before, *::after { box-sizing: border-box }` also caught elements that relied on the **content-box default** and sized themselves around it. Two are visibly broken in production right now.

**`.language-icon`** — `width: 35px; padding: 0.563rem`. The visible image went from 35px to 12.5px. The language switcher in the header (logged in, >900px) is a smudge.

**`table.with-marginalia`** — it compensates for the marginalia column with a hardcoded `margin-left: calc(calc(var(--marginalia-width) + 0.563em) * -1)` = `-68.4px`. That constant assumed `.marginalia` measured `width` *plus* its padding. Border-box moved the padding inside, so the column is now 60px and every starred table hangs 8.4px left of the page's content column.

## Measurements

Production at 1400px viewport, then with this branch's stylesheet swapped in via devtools:

| | before revert | after revert |
|---|---|---|
| visible icon width | 12.5px | 35.0px |
| table misalignment vs `main` content edge | -8.4px | -0.4px |

To see the misalignment yourself, open `/decks/` and paste:

```js
const m=document.querySelector('main'),x=m.getBoundingClientRect().left+parseFloat(getComputedStyle(m).paddingLeft);
document.body.insertAdjacentHTML('beforeend',`<div style="position:fixed;left:${x}px;top:0;width:1px;height:100%;background:red;z-index:9999"></div>`);
```

The COLORS column and the colour bars sit left of the red line.

## Why revert rather than fix forward

The change was pure cleanup with no user-facing benefit, and auditing every element whose box model silently changed is open-ended. This restores the individual declarations exactly, returning `pd.css` to its pre-#15116 state — verified as the exact inverse of the original diff.

Re-opens #12528.

🤖 Generated with [Claude Code](https://claude.com/claude-code)