### PR TITLE
Match archetype URL names with one normalisation, not two (#12494)

### DIFF
--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -1,4 +1,3 @@
-import re
 import urllib.parse
 
 from flask import redirect, request, url_for
@@ -17,6 +16,7 @@ from decksite.deck_type import DeckType
 from decksite.views import Archetype, Archetypes, Card, Cards, Deck, Decks, Matchups, Metagame, Seasons
 from magic import oracle
 from shared.pd_exception import DoesNotExistException, InvalidDataException
+from shared.text import merge_slashes
 
 
 @APP.route('/decks/')
@@ -97,9 +97,6 @@ def is_canonical_url_name(submitted_name: str, canonical_name: str) -> bool:
     `Bedeck / Bedazzle`. Redirecting to the double-slashed URL would only get it merged again, forever.
     """
     return merge_slashes(submitted_name) == merge_slashes(canonical_name)
-
-def merge_slashes(name: str) -> str:
-    return re.sub(r'\s*/+\s*', '/', name)
 
 def parse_card_name(name: str) -> str:
     return oracle.valid_name(decode_card_name(name))

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -12,6 +12,7 @@ from shared.container import Container
 from shared.database import sqlescape
 from shared.decorators import retry_after_calling
 from shared.pd_exception import DoesNotExistException
+from shared.text import fold_accents, merge_slashes
 
 
 class Archetype(Container, NodeMixin):
@@ -36,15 +37,38 @@ WINDOW_DAYS = 7
 # a freak low-volume week.
 MIN_MATCHES = 6
 
+def url_name_key(name: str) -> str:
+    """The form two archetype names must share to be the same name in a URL.
+
+    Slashes because the proxies in front of us merge repeated ones, dashes because we accept them for
+    spaces, case and accents because the collation this lookup used to lean on ignored both and
+    /archetypes/Seance/ has always found Séance. Dashes go first, so `Leave-//-Chance` reduces the
+    same way `Leave // Chance` does.
+
+    One function, applied to both sides of the comparison. #12494 was two normalisations that disagreed.
+    """
+    return fold_accents(merge_slashes(name.replace('-', ' '))).casefold()
+
+def archetype_id_from_name(name: str) -> int | None:
+    """Find the archetype whose name matches one given in a URL, or None.
+
+    Read the names and compare in Python rather than normalising in SQL: there is one rule and one
+    implementation of it. The table is small and the only caller is a cached page.
+    """
+    wanted = url_name_key(name)
+    for r in db().select('SELECT id, name FROM archetype'):
+        if url_name_key(r['name']) == wanted:
+            return int(r['id'])
+    return None
+
 def load_archetype(archetype: int | str) -> Archetype:
     try:
         archetype_id = int(archetype)
     except ValueError as c:
-        name = titlecase.titlecase(archetype)
-        name_without_dashes = name.replace('-', ' ')
-        archetype_id = db().value("SELECT id FROM archetype WHERE REPLACE(REPLACE(name, ' // ', ' / '), '-', ' ') = %s", [name_without_dashes])
-        if not archetype_id:
-            raise DoesNotExistException(f'Did not find archetype with name of `{name}`') from c
+        found = archetype_id_from_name(str(archetype))
+        if not found:
+            raise DoesNotExistException(f'Did not find archetype with name of `{titlecase.titlecase(archetype)}`') from c
+        archetype_id = found
     arch = Archetype()
     arch.id = int(archetype_id)
     arch.name = db().value('SELECT name FROM archetype WHERE id = %s', [archetype_id])

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -7,6 +7,8 @@ import pytest
 from decksite.data import archetype, clauses
 from decksite.database import db
 from decksite.testutil import with_test_db
+from shared.pd_exception import DoesNotExistException
+from shared.text import merge_slashes
 
 
 class FakeDatabase:
@@ -128,6 +130,43 @@ def test_load_movers_and_shakers_compares_the_last_week_to_the_week_before() -> 
     assert movers[0].win_percent == 60.0
 
 
+@pytest.mark.parametrize(('a', 'b'), [
+    ('Leave // Chance Midrange', 'Leave / Chance Midrange'),   # What the proxies send after merging slashes.
+    ('Leave // Chance Midrange', 'Leave/Chance Midrange'),
+    ('Leave // Chance Midrange', 'leave // chance midrange'),
+    ('Leave // Chance Midrange', 'Leave-//-Chance-Midrange'),  # Dashes stand in for spaces.
+    ('Séance', 'Seance'),                                      # utf8mb4_unicode_ci ignored accents; so must we.
+    ('-1/-1 Counters', '-1/-1 Counters'),
+])
+def test_url_name_key_treats_these_as_the_same_name(a: str, b: str) -> None:
+    assert archetype.url_name_key(a) == archetype.url_name_key(b)
+
+
+@pytest.mark.parametrize(('a', 'b'), [
+    ('Leave // Chance Midrange', 'Arrive // Fortune Midrange'),
+    ('-1/-1 Counters', '+1/+1 Counters'),
+    ('Aggro', 'Aggro Control'),
+])
+def test_url_name_key_keeps_these_apart(a: str, b: str) -> None:
+    assert archetype.url_name_key(a) != archetype.url_name_key(b)
+
+
+@with_test_db
+@pytest.mark.functional
+@pytest.mark.parametrize('url_name', [
+    'Leave // Chance Midrange',
+    'Leave / Chance Midrange',
+    'Leave/Chance Midrange',
+    'leave // chance midrange',
+    'Leave-//-Chance-Midrange',
+])
+def test_load_archetype_finds_name_containing_slashes(url_name: str) -> None:
+    """#15124 made these URLs route, but the two sides normalised slashes differently so the lookup still missed."""
+    db().execute("INSERT INTO archetype (name, description) VALUES ('Leave // Chance Midrange', '')")
+
+    assert archetype.load_archetype(merge_slashes(url_name)).name == 'Leave // Chance Midrange'
+
+
 @with_test_db
 @pytest.mark.functional
 def test_load_movers_and_shakers_does_not_compare_across_a_rotation() -> None:
@@ -149,6 +188,14 @@ def test_load_movers_and_shakers_does_not_compare_across_a_rotation() -> None:
     assert [a.id for a in movers] == [1]
     assert float(movers[0].meta_share) == 1.0
     assert float(movers[0].meta_share_change) == 0.0
+
+
+def test_load_archetype_finds_accented_name_spelled_without_accents() -> None:
+    """/archetypes/Seance/ has always worked because the collation ignores accents. Keep it working."""
+    db().execute("INSERT INTO archetype (name, description) VALUES ('Séance', '')")
+
+    assert archetype.load_archetype(merge_slashes('Seance')).name == 'Séance'
+    assert archetype.load_archetype(merge_slashes('Séance')).name == 'Séance'
 
 
 @with_test_db
@@ -174,3 +221,19 @@ def test_load_movers_and_shakers_includes_an_archetype_that_stopped_being_played
     assert float(movers[1].meta_share) == 0.0
     assert float(movers[1].meta_share_change) == -0.5
     assert movers[1].win_percent is None
+
+
+def test_load_archetype_still_finds_names_with_dashes_around_slashes() -> None:
+    """-1/-1 Counters is the case #15124 did fix; do not regress it."""
+    db().execute("INSERT INTO archetype (name, description) VALUES ('-1/-1 Counters', '')")
+
+    assert archetype.load_archetype(merge_slashes('-1/-1 Counters')).name == '-1/-1 Counters'
+
+
+@with_test_db
+@pytest.mark.functional
+def test_load_archetype_raises_for_unknown_name() -> None:
+    db().execute("INSERT INTO archetype (name, description) VALUES ('Leave // Chance Midrange', '')")
+
+    with pytest.raises(DoesNotExistException):
+        archetype.load_archetype(merge_slashes('Arrive // Fortune Midrange'))

--- a/shared/text.py
+++ b/shared/text.py
@@ -1,5 +1,6 @@
 import html
 import re
+import unicodedata
 from typing import Any
 
 import emoji
@@ -39,3 +40,15 @@ def unambiguous_prefixes(words: list[str]) -> list[str]:
             if n == 1:
                 prefixes.append(prefix)
     return prefixes
+
+def merge_slashes(name: str) -> str:
+    """Collapse each run of slashes, and the whitespace around it, to a bare '/'.
+
+    The proxies in front of us merge repeated slashes, so `/cards/Bedeck // Bedazzle/` arrives as
+    `Bedeck / Bedazzle`. Both spellings, and the stored `Bedeck // Bedazzle`, share this form.
+    """
+    return re.sub(r'\s*/+\s*', '/', name)
+
+def fold_accents(s: str) -> str:
+    """Drop combining marks, so `Seance` and `Séance` compare equal as they do under utf8mb4_unicode_ci."""
+    return ''.join(c for c in unicodedata.normalize('NFKD', s) if not unicodedata.combining(c))


### PR DESCRIPTION
Follow-up to #15124, which did not fix the case #12494 is about.

## The bug

On production right now:

- https://pennydreadfulmagic.com/archetypes/Leave%20//%20Chance%20Midrange/ → **404**
- https://pennydreadfulmagic.com/archetypes/199/ → 200, same archetype

#15124 changed the routes to `<path:archetype_id>` and applied `merge_slashes()` to the captured name. That part helped: `/archetypes/-1/-1 Counters/` works because of it. But it also reimplemented the same rule a second time in SQL, and the two copies disagree:

```
merge_slashes('Leave / Chance Midrange')  ->  'Leave/Chance Midrange'    # strips the spaces
REPLACE(name, ' // ', ' / ')              ->  'Leave / Chance Midrange'  # keeps them
```

They can never be equal.

## The fix

Rather than make the SQL mirror the Python more carefully, drop the second copy.

- `merge_slashes` moves to `shared/text.py`, so `decksite.data` can use it without a circular import (`decksite.controllers.metagame` already imports `decksite.data.archetype`).
- `url_name_key()` reduces both the URL name and the stored name to one comparable form. One rule, one implementation, applied to both sides.

## What the old lookup relied on

The SQL comparison ran under `utf8mb4_unicode_ci`, which ignores case **and accents**. `/archetypes/Seance/` has always found `Séance` (id 149, and it is the only non-ASCII archetype name of the 592). Comparing in Python silently loses that, so `url_name_key` folds accents and case explicitly. There is a test.

Dashes are replaced *before* slashes are merged, so `Leave-//-Chance-Midrange` reduces the same way `Leave // Chance Midrange` does.

## Performance

`archetype_id_from_name` reads the 592 names and compares in Python. The only caller is `load_archetype`, from one `@cached()` page. The query it replaces called `REPLACE()` on the column, so it was already a full scan and could not use the index either.

## Tests

- `url_name_key` unit tests: six spellings that must match, three pairs that must stay apart. No database.
- Functional: insert an archetype with `//`, look it up through every spelling that reaches the app. Insert `Séance`, find it as `Seance`. Keep `-1/-1 Counters` working. Negative case raises.

The four slash cases fail against #15124 as merged — mutation-checked, not assumed.

`pytest decksite/ shared/text_test.py`: 494 passed. Lint and mypy clean.

## Not fixed here

`/archetypes/Leave-Chance-Midrange/` still 404s. Dashes stand in for spaces, never for ` // `, and that has never worked. Say if you want it to.

Fixes #12494

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7c405b4c-ccb4-4e17-a083-e6fb4368e767)
