### PR TITLE
Show real archetypes on the home page, not taxonomy roots (#12568)

### DIFF
--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -93,3 +93,71 @@ def test_archetype_quality_sorts_put_no_match_archetypes_last(sort_by: str) -> N
 
     assert ascending[-1].id == 2
     assert descending[-1].id == 2
+
+
+def _make_hierarchy() -> None:
+    """Aggro (root) with child Red Deck Wins, and Control (root) with no children. Decks belong only to the leaves."""
+    db().execute("DELETE FROM archetype_closure")
+    db().execute("DELETE FROM archetype")
+    db().execute("INSERT INTO archetype (id, name, description) VALUES (1, 'Aggro', ''), (2, 'Red Deck Wins', ''), (3, 'Control', '')")
+    db().execute("""
+        INSERT INTO archetype_closure (ancestor, descendant, depth) VALUES
+            (1, 1, 0), (2, 2, 0), (3, 3, 0),
+            (1, 2, 1)
+    """)
+
+
+@with_test_db
+@pytest.mark.functional
+def test_home_page_archetypes_do_not_roll_children_into_parents() -> None:
+    """#15109 used load_archetypes, whose parents absorb their children, so the home page listed only taxonomy roots."""
+    _make_hierarchy()
+    archetype.preaggregate_disjoint_archetypes()
+    archetype.preaggregate_archetypes()
+    for table in ('_arch_disjoint_stats', '_arch_stats'):
+        db().execute(f"""
+            INSERT INTO {table}
+                (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
+            VALUES
+                (2, 1, 10, 0, 0, 0, 0, 0, 0, 'league'),
+                (3, 1, 4, 0, 0, 0, 0, 0, 0, 'league')
+        """)
+    # _arch_stats is the inclusive table, so Aggro carries Red Deck Wins' decks there but not in the disjoint one.
+    db().execute("""
+        INSERT INTO _arch_stats
+            (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
+        VALUES (1, 1, 10, 0, 0, 0, 0, 0, 0, 'league')
+    """)
+
+    disjoint, _ = archetype.load_disjoint_archetypes(order_by='num_decks DESC', season_id=1)
+    by_name = {a.name: a.num_decks for a in disjoint if a.get('num_decks')}
+
+    assert by_name == {'Red Deck Wins': 10, 'Control': 4}, 'the home page must show the archetypes decks are actually assigned to'
+    assert 'Aggro' not in by_name, 'Aggro has no decks of its own; it only looks popular when children are rolled up'
+
+
+@with_test_db
+@pytest.mark.functional
+def test_home_page_archetype_counts_add_up_to_the_number_of_decks() -> None:
+    """The property that makes the list a metagame breakdown: each deck counted once.
+
+    A parent may legitimately appear next to its child if it has decks of its own, but its count must
+    exclude the child's. Under the inclusive loader Aggro would read 11 and the column would sum to 25.
+    """
+    _make_hierarchy()
+    archetype.preaggregate_disjoint_archetypes()
+    db().execute("""
+        INSERT INTO _arch_disjoint_stats
+            (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
+        VALUES
+            (1, 1, 1, 0, 0, 0, 0, 0, 0, 'league'),
+            (2, 1, 10, 0, 0, 0, 0, 0, 0, 'league'),
+            (3, 1, 4, 0, 0, 0, 0, 0, 0, 'league')
+    """)
+
+    shown, _ = archetype.load_disjoint_archetypes(order_by='num_decks DESC', season_id=1)
+    shown = [a for a in shown if a.get('num_decks')][:8]  # What Home.setup_archetypes does.
+    counts = {a.name: a.num_decks for a in shown}
+
+    assert counts == {'Red Deck Wins': 10, 'Control': 4, 'Aggro': 1}
+    assert sum(counts.values()) == 15, 'the counts must add up to the number of decks, not more'

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -30,7 +30,9 @@ def home() -> str:
     decks = ds.latest_decks(season_id=season_id)
     top_8_plus_basics = 'LIMIT 13'
     cards, total = cs.load_cards_with_total(limit=top_8_plus_basics, season_id=season_id)
-    all_archetypes = archs.load_archetypes(order_by='num_decks DESC', season_id=season_id)
+    # Disjoint, not load_archetypes: the latter rolls a child's decks up into its parent, so the top of the list
+    # is always the taxonomy roots (Aggro, Control, ...) and every deck is counted once per ancestor.
+    all_archetypes, _ = archs.load_disjoint_archetypes(order_by='num_decks DESC', season_id=season_id)
     view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats(), all_archetypes)
     return view.page()
 

--- a/decksite/main_test.py
+++ b/decksite/main_test.py
@@ -1,7 +1,17 @@
+import contextlib
+
 import pytest
 
 from decksite import main
+from decksite.data import archetype
+from decksite.data.archetype import Archetype
+from decksite.database import db
+from decksite.testutil import with_test_db
 from magic.models import Card
+
+
+class _Done(Exception):
+    """Raised to stop home() once we have the archetype list; rendering the page is not what is under test."""
 
 
 def test_image_route_applies_requested_printing_without_mutating_cached_card(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -24,3 +34,49 @@ def test_image_route_applies_requested_printing_without_mutating_cached_card(mon
     assert captured[0].preferred_printing_system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
     assert cached_card.get('preferred_printing') is None
     assert cached_card.get('preferred_printing_system_id') is None
+
+
+@with_test_db
+@pytest.mark.functional
+def test_home_page_asks_for_disjoint_archetypes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#15109 called load_archetypes, which rolls a child's decks up into its parent.
+
+    That put the taxonomy roots (Aggro, Control, ...) at the top of the home page's Top Archetypes
+    table and counted every deck once per ancestor. Pin the loader the page actually uses.
+    """
+    db().execute("DELETE FROM archetype_closure")
+    db().execute("DELETE FROM archetype")
+    db().execute("INSERT INTO archetype (id, name, description) VALUES (1, 'Aggro', ''), (2, 'Red Deck Wins', '')")
+    db().execute("INSERT INTO archetype_closure (ancestor, descendant, depth) VALUES (1, 1, 0), (2, 2, 0), (1, 2, 1)")
+    archetype.preaggregate_disjoint_archetypes()
+    archetype.preaggregate_archetypes()
+    for table in ('_arch_disjoint_stats', '_arch_stats'):
+        db().execute(f"""
+            INSERT INTO {table}
+                (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
+            VALUES (2, 1, 10, 0, 0, 0, 0, 0, 0, 'league')
+        """)
+    db().execute("""
+        INSERT INTO _arch_stats
+            (archetype_id, season_id, num_decks, wins, losses, draws, perfect_runs, tournament_wins, tournament_top8s, deck_type)
+        VALUES (1, 1, 10, 0, 0, 0, 0, 0, 0, 'league')
+    """)
+
+    captured: list[Archetype] = []
+
+    def capture(_news, _decks, _cards, _stats, all_archetypes):  # type: ignore[no-untyped-def]
+        captured.extend(all_archetypes)
+        raise _Done
+
+    monkeypatch.setattr(main, 'Home', capture)
+    monkeypatch.setattr(main, 'get_season_id', lambda: 1)
+    # Everything home() loads before the archetypes needs preaggregated tables we do not care about here.
+    monkeypatch.setattr(main.ds, 'latest_decks', lambda **_kwargs: [])
+    monkeypatch.setattr(main.cs, 'load_cards_with_total', lambda **_kwargs: ([], 0))
+    monkeypatch.setattr(main.ns, 'all_news', lambda *_args, **_kwargs: [])
+
+    with main.APP.test_request_context('/'), contextlib.suppress(_Done):
+        main.home()
+
+    with_decks = {a.name: a.num_decks for a in captured if a.get('num_decks')}
+    assert with_decks == {'Red Deck Wins': 10}, 'Aggro has no decks of its own and must not inherit its child\'s'


### PR DESCRIPTION
Follow-up to #15109. The feature works, but it's reading from the wrong loader.

## The bug

Open https://pennydreadfulmagic.com/ and read the Top Archetypes table:

| | |
|---|---|
| Combo | 187 |
| Aggro | 175 |
| Midrange | 117 |
| Control | 110 |
| Aggro-Control | 66 |
| Ramp | 60 |
| Storm | 54 |
| Blazing Shoal Combo | 48 |

Seven of the eight are top-level taxonomy categories, not decks anyone plays. And the counts double up — Combo's 187 already contains Storm's 54 and Blazing Shoal Combo's 48.

`main.py` called `load_archetypes()`, the **inclusive** loader. The docstring on its sibling says so outright:

> Load a list of all archetypes where archetype categories do NOT include the stats of their children. [...] See also `load_archetypes` that does it the other way.

Ordering an inclusive list by `num_decks DESC` can only ever put the roots on top — a parent's count is by construction ≥ each of its children's.

## The fix

Use `load_disjoint_archetypes()`, so each deck is counted once against the archetype it is actually assigned to. Comment at the call site explaining which loader is wanted and why, since the two names are one word apart.

## Tests

- `archetype_test.py` — a parent/child pair where the decks belong only to the child: the parent must not inherit them, and the column must sum to the number of decks rather than more.
- `main_test.py` — captures the list `home()` actually builds, so the choice of loader is pinned at the call site and not just tested in the abstract. **This one fails against #15109 as merged** (`Aggro` shows 10 decks it does not have), mutation-checked.

Full `pytest decksite/`: 476 passed. Lint and mypy clean.

Fixes #12568

🤖 Generated with [Claude Code](https://claude.com/claude-code)