### PR TITLE
Revert Top Archetypes on the home page (#15109)

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -10,7 +10,6 @@ from werkzeug.exceptions import InternalServerError
 
 from decksite import APP, SEASONS, auth, deck_name, get_season_id
 from decksite.cache import cached
-from decksite.data import archetype as archs
 from decksite.data import card as cs
 from decksite.data import deck as ds
 from decksite.data import match as ms
@@ -30,8 +29,7 @@ def home() -> str:
     decks = ds.latest_decks(season_id=season_id)
     top_8_plus_basics = 'LIMIT 13'
     cards, total = cs.load_cards_with_total(limit=top_8_plus_basics, season_id=season_id)
-    all_archetypes = archs.load_archetypes(order_by='num_decks DESC', season_id=season_id)
-    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats(), all_archetypes)
+    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats())
     return view.page()
 
 @APP.route('/export/<int:deck_id>/')

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -5,30 +5,6 @@
         <p><a href="{{url}}">{{link_text}}</a></p>
     </section>
 {{/deck_tables}}
-{{#has_top_archetypes}}
-    <section>
-        <h2>{{_ Top Archetypes}}</h2>
-        <table>
-            <thead>
-                <th>Archetype</th>
-                <th># Decks</th>
-                <th>Record</th>
-                <th>Win %</th>
-            </thead>
-            <tbody>
-                {{#archetypes}}
-                    <tr data-href="{{url}}" class="clickable">
-                        <td><a href="{{url}}">{{name}}</a></td>
-                        <td class="n">{{num_decks}}</td>
-                        <td class="n">{{#show_record}}{{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}{{/show_record}}</td>
-                        <td class="n">{{#show_record}}{{win_percent}}{{/show_record}}</td>
-                    </tr>
-                {{/archetypes}}
-            </tbody>
-        </table>
-        <p><a href="{{archetypes_url}}">{{_ More archetypes…}}</a></p>
-    </section>
-{{/has_top_archetypes}}
 {{#has_top_cards}}
     <section>
         <h2>{{_ Top Cards}}</h2>

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -1,7 +1,6 @@
 from flask import url_for
 from flask_babel import gettext
 
-from decksite.data.archetype import Archetype
 from decksite.view import View
 from magic import rotation, seasons, tournaments
 from magic.models import Card, Deck
@@ -10,12 +9,11 @@ from shared.container import Container
 
 
 class Home(View):
-    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int], all_archetypes: list[Archetype]) -> None:
+    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int]) -> None:
         super().__init__()
         self.setup_news(news)
         self.setup_decks(decks)
         self.setup_cards(cards)
-        self.setup_archetypes(all_archetypes)
         self.setup_rotation()
         self.setup_stats(matches_stats)
         self.setup_tournaments()
@@ -94,12 +92,6 @@ class Home(View):
         self.has_top_cards = len(cards) > 0
         self.cards = self.top_cards  # To get prepare_card treatment
         self.cards_url = url_for('.cards')
-
-    def setup_archetypes(self, all_archetypes: list[Archetype]) -> None:
-        top = [a for a in all_archetypes if a.get('num_decks')][:8]
-        self.archetypes = top
-        self.has_top_archetypes = len(top) > 0
-        self.archetypes_url = url_for('.archetypes')
 
     def setup_rotation(self) -> None:
         self.season_start_display = dtutil.display_date(seasons.last_rotation())


### PR DESCRIPTION
Reverts the merge of #15109. Replaces #15171, which fixed the counts but not the feature.

## Why

#12568 says:

> Expose something about metagame on home
> Top decks or movers-and-shakers or something

#15109 read that as a static table of the archetypes with the most decks. On production right now that table is:

| | |
|---|---|
| Combo | 193 |
| Aggro | 175 |
| Midrange | 117 |
| Control | 110 |
| Aggro-Control | 66 |
| Ramp | 60 |
| Storm | 54 |
| Blazing Shoal Combo | 48 |

Seven of the eight are top-level taxonomy categories rather than decks anyone plays, because it loads from `load_archetypes()` — the inclusive loader, whose parents absorb their children's stats. Ordering that by `num_decks DESC` can only ever put the roots on top. The counts also double up: Combo's 193 already contains Storm's 54 and Blazing Shoal Combo's 48.

`load_disjoint_archetypes()` would fix the counts. It would not fix the feature. The intent is recent movers in quality, surfaced on `/archetypes` — not a table of totals on the home page. Better to take it out and build the thing that was asked for.

## Conflict

`main.py` conflicted with #15126, which renamed `load_cards` to `load_cards_with_total` after #15109 landed. Resolved by keeping #15126's call and dropping only the archetype lines. The unused `archetype as archs` import goes with them.

## Checks

- `pytest decksite/` — 473 passed, matching clean master exactly
- `GET /` returns 200 with no `Top Archetypes` section
- lint and mypy clean
- no `setup_archetypes` / `has_top_archetypes` / `Top Archetypes` left anywhere

Re-opens #12568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)