### PR TITLE
Revert "Show top archetypes by deck count on home page (#12568)"

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -10,7 +10,6 @@ from werkzeug.exceptions import InternalServerError
 
 from decksite import APP, SEASONS, auth, deck_name, get_season_id
 from decksite.cache import cached
-from decksite.data import archetype as archs
 from decksite.data import card as cs
 from decksite.data import deck as ds
 from decksite.data import match as ms
@@ -30,8 +29,7 @@ def home() -> str:
     decks = ds.latest_decks(season_id=season_id)
     top_8_plus_basics = 'LIMIT 13'
     cards, total = cs.load_cards_with_total(limit=top_8_plus_basics, season_id=season_id)
-    all_archetypes = archs.load_archetypes(order_by='num_decks DESC', season_id=season_id)
-    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats(), all_archetypes)
+    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats())
     return view.page()
 
 @APP.route('/export/<int:deck_id>/')

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -5,30 +5,6 @@
         <p><a href="{{url}}">{{link_text}}</a></p>
     </section>
 {{/deck_tables}}
-{{#has_top_archetypes}}
-    <section>
-        <h2>{{_ Top Archetypes}}</h2>
-        <table>
-            <thead>
-                <th>Archetype</th>
-                <th># Decks</th>
-                <th>Record</th>
-                <th>Win %</th>
-            </thead>
-            <tbody>
-                {{#archetypes}}
-                    <tr data-href="{{url}}" class="clickable">
-                        <td><a href="{{url}}">{{name}}</a></td>
-                        <td class="n">{{num_decks}}</td>
-                        <td class="n">{{#show_record}}{{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}{{/show_record}}</td>
-                        <td class="n">{{#show_record}}{{win_percent}}{{/show_record}}</td>
-                    </tr>
-                {{/archetypes}}
-            </tbody>
-        </table>
-        <p><a href="{{archetypes_url}}">{{_ More archetypes…}}</a></p>
-    </section>
-{{/has_top_archetypes}}
 {{#has_top_cards}}
     <section>
         <h2>{{_ Top Cards}}</h2>

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -1,7 +1,6 @@
 from flask import url_for
 from flask_babel import gettext
 
-from decksite.data.archetype import Archetype
 from decksite.view import View
 from magic import rotation, seasons, tournaments
 from magic.models import Card, Deck
@@ -10,12 +9,11 @@ from shared.container import Container
 
 
 class Home(View):
-    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int], all_archetypes: list[Archetype]) -> None:
+    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int]) -> None:
         super().__init__()
         self.setup_news(news)
         self.setup_decks(decks)
         self.setup_cards(cards)
-        self.setup_archetypes(all_archetypes)
         self.setup_rotation()
         self.setup_stats(matches_stats)
         self.setup_tournaments()
@@ -94,12 +92,6 @@ class Home(View):
         self.has_top_cards = len(cards) > 0
         self.cards = self.top_cards  # To get prepare_card treatment
         self.cards_url = url_for('.cards')
-
-    def setup_archetypes(self, all_archetypes: list[Archetype]) -> None:
-        top = [a for a in all_archetypes if a.get('num_decks')][:8]
-        self.archetypes = top
-        self.has_top_archetypes = len(top) > 0
-        self.archetypes_url = url_for('.archetypes')
 
     def setup_rotation(self) -> None:
         self.season_start_display = dtutil.display_date(seasons.last_rotation())


### PR DESCRIPTION
Reverts the home page "Top Archetypes" section added in #15109 (merged 2026-09-02 without review).

## The bug

`load_archetypes` returns **inclusive** (closure) counts — a parent archetype's `num_decks` includes every descendant's decks. #15109 sorted that list flat by `num_decks DESC` and took the top 8, which does two wrong things at once: it surfaces the abstract category roots instead of the decks people play, and it counts each deck again for every ancestor it has.

Measured against a copy of the production database:

**Season 43** — 7 of 8 rows are categories, not decks:

```
Combo 174 · Aggro 158 · Midrange 103 · Control 92
Storm 53 · Aggro-Control 49 · Blazing Shoal Combo 44 · Ramp 42
```

**Season 42** — the double counting is visible in adjacent rows: `Actual Twin 214` sits directly above `Izzet Twin 212`. Those are the same 212 decks, listed twice.

## Why revert rather than fix

Switching to `load_disjoint_archetypes` does fix the ranking — season 43 becomes `Izzet Storm 41 · Equipment Aggro 29 · Azorius Control 20 · Combo 18 · …`, all real archetypes, each deck counted once. But the fixed version is just `/metagame`'s first eight rows rendered a second time, which does not earn homepage space: a visitor gets nothing they could not get from following a link.

#12568 asked to "expose something about metagame on home" — "top decks or movers-and-shakers or something". `/archetypes`, which this section linked to, is the older tree view and not that page. The ticket is worth doing, but built on `/metagame` and on something `/metagame` cannot show: movement over a time window. That needs a preaggregate keyed by week, which does not exist yet — every archetype preaggregate today is keyed by `(archetype_id, season_id, deck_type)`.

Reverting so the homepage is clean while that is specced.

## Validation

- `dev.py lint` and `mypy decksite` clean (142 files)
- Home page renders 200 against a copy of the production database, "Top Archetypes" gone, "Top Cards" and all other sections intact
- No other caller of `Home` or of the removed view attributes — `has_top_archetypes`, `setup_archetypes` and home's `archetypes_url` have no remaining references (the `archetypes_url` in `view.py`/`seasons.mustache` is a separate, pre-existing one)

The one line not restored to its pre-#15109 state is `season_id = get_season_id()` in `home()`, which #15109 introduced. Both surviving calls use it, so removing it would just mean calling `get_season_id()` twice.

Refs #12568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
