### PR TITLE
Add live-table contract tests and Playwright browser tests with a CI browser job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,3 +114,41 @@ jobs:
       run: python build.py
     - name: Run jslint
       run: uv run --frozen python dev.py jslint
+
+  browser:
+    name: browser
+    runs-on: ubuntu-latest
+    env:
+      mysql_user: root
+      mysql_passwd: bad-password
+      mysql_host: 127.0.0.1
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.13'
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        version: '0.9.26'
+        enable-cache: true
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v7.0.0
+      with:
+        node-version: 24.12.0
+        cache: npm
+    - uses: getong/mariadb-action@v1.11
+      with:
+        mysql root password: bad-password
+        mariadb version: 11
+    - name: Install dependencies
+      run: uv sync --frozen --dev
+    - name: Build javascript
+      run: npm ci && npm run build
+    - name: Install Chromium
+      run: uv run --frozen playwright install --with-deps chromium
+    - run: uv run --frozen python run.py init-cards
+    - name: Run browser tests
+      run: PD_BROWSER_TESTS=1 uv run --frozen pytest --no-cov -p no:cacheprovider decksite/browser_test.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
+      with:
+        lfs: true  # The font sources the symbols font is built from are LFS objects.
     - name: Set up Python 3.13
       uses: actions/setup-python@v7
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,5 +150,7 @@ jobs:
     - name: Install Chromium
       run: uv run --frozen playwright install --with-deps chromium
     - run: uv run --frozen python run.py init-cards
+    - name: Build symbols font
+      run: uv run --frozen python run.py maintenance fonts
     - name: Run browser tests
       run: PD_BROWSER_TESTS=1 uv run --frozen pytest --no-cov -p no:cacheprovider decksite/browser_test.py

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -34,7 +34,8 @@ if ENABLED:
 
 # Fixed entry points. More pages are discovered from the links on these so the test needs no knowledge of what data the site has.
 PAGES = ['/', '/decks/', '/people/', '/cards/', '/metagame/', '/competitions/', '/tournaments/leaderboards/', '/resources/', '/about/']
-DISCOVER = [('/decks/', '.decktable a[href^="/people/"]'), ('/decks/', '.decktable a[href^="/archetypes/"]'), ('/decks/', '.decktable a[href^="/competitions/"]'), ('/decks/', '.decktable a[href^="/decks/"]'), ('/cards/', '.cardtable a[href^="/cards/"]')]
+# Links in tables may carry a /seasons/N/ prefix, so match anywhere in the href.
+DISCOVER = [('/decks/', '.decktable a[href*="/people/"]'), ('/decks/', '.decktable a[href*="/archetypes/"]'), ('/decks/', '.decktable a[href*="/competitions/"]'), ('/decks/', '.decktable a[href*="/decks/"]'), ('/cards/', '.cardtable a[href*="/cards/"]')]
 LIVE_TABLE_CLASSES = ['decktable', 'cardtable', 'persontable', 'matchtable', 'leaderboardtable', 'headtoheadtable']
 LOAD_TIMEOUT = 15_000
 VIEWPORTS = {'mobile': (400, 800), 'medium': (1200, 800), 'wide': (1700, 900)}  # Either side of the 900px and 1600px breakpoints in pd.css.
@@ -114,6 +115,9 @@ def discover_pages(page: 'Page') -> list[str]:
 def test_pages_render_with_data_and_without_errors(browser: 'Browser', site: Container) -> None:
     page, collector = new_page(browser, site)
     pages = PAGES + discover_pages(page)
+    if site.seed:
+        # Only the seeded database has this person, so a server answering from any other database (the dev one, say) turns this into a 404 below.
+        pages.append(f'/people/{site.seed.person}/')
     problems = list(collector.problems)
     for path in pages:
         collector.problems.clear()
@@ -125,7 +129,7 @@ def test_pages_render_with_data_and_without_errors(browser: 'Browser', site: Con
         problems.extend(wait_for_live_tables(page))
         problems.extend(f'{path}: {p}' for p in collector.problems)
     if site.seed:
-        assert any('/people/' in p for p in pages) and any('/cards/' in p and p != '/cards/' for p in pages), f'Discovery found no person/card pages in {pages}'
+        assert any('/people/' in p and p != '/people/' for p in pages) and any('/cards/' in p and p != '/cards/' for p in pages), f'Discovery found no person/card pages in {pages}'
     assert not problems, '\n'.join(problems)
 
 

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -1,0 +1,217 @@
+"""
+Browser smoke tests: load real pages in headless Chromium and check what a user would see.
+
+The server-side smoke tests stop at the HTTP status code. These go further: the React live tables must actually fill
+with rows, no request the page makes may fail, no JavaScript may throw, and the navigation submenu must be genuinely
+visible (on screen, at the top, not clipped, not covered) at mobile, medium and wide widths, with a mouse and with touch.
+Both of the September 2026 production regressions (invisible submenu, empty /decks/) fail here.
+
+Two modes:
+
+- Local (default): PD_BROWSER_TESTS=1. Starts the Flask app in-process against the seeded test database.
+- Canary: PD_BROWSER_BASE_URL=https://pennydreadfulmagic.com. Runs the same read-only checks against a live site.
+
+Both need `uv run playwright install chromium` once. Set PD_BROWSER_CHANNEL=chrome to use an installed Google Chrome instead.
+Not part of the default pytest run: `python dev.py browser`, or in CI the separate `browser` job.
+"""
+import os
+import re
+import threading
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from shared.container import Container
+
+BASE_URL = os.environ.get('PD_BROWSER_BASE_URL', '').rstrip('/')
+ENABLED = bool(BASE_URL) or os.environ.get('PD_BROWSER_TESTS') == '1'
+
+pytestmark = [pytest.mark.browser, pytest.mark.skipif(not ENABLED, reason='Set PD_BROWSER_TESTS=1 or PD_BROWSER_BASE_URL to run browser tests')]
+
+if ENABLED:
+    from playwright.sync_api import Browser, Locator, Page, expect, sync_playwright
+
+# Fixed entry points. More pages are discovered from the links on these so the test needs no knowledge of what data the site has.
+PAGES = ['/', '/decks/', '/people/', '/cards/', '/metagame/', '/competitions/', '/tournaments/leaderboards/', '/resources/', '/about/']
+DISCOVER = [('/decks/', '.decktable a[href^="/people/"]'), ('/decks/', '.decktable a[href^="/archetypes/"]'), ('/decks/', '.decktable a[href^="/competitions/"]'), ('/decks/', '.decktable a[href^="/decks/"]'), ('/cards/', '.cardtable a[href^="/cards/"]')]
+LIVE_TABLE_CLASSES = ['decktable', 'cardtable', 'persontable', 'matchtable', 'leaderboardtable', 'headtoheadtable']
+LOAD_TIMEOUT = 15_000
+VIEWPORTS = {'mobile': (400, 800), 'medium': (1200, 800), 'wide': (1700, 900)}  # Either side of the 900px and 1600px breakpoints in pd.css.
+
+
+@pytest.fixture(scope='module')
+def browser() -> Iterator['Browser']:
+    with sync_playwright() as playwright:
+        b = playwright.chromium.launch(channel=os.environ.get('PD_BROWSER_CHANNEL') or None)
+        yield b
+        b.close()
+
+
+@pytest.fixture
+def site(request: pytest.FixtureRequest) -> Iterator[Container]:
+    if BASE_URL:
+        yield Container({'base_url': BASE_URL, 'seed': None})
+        return
+    from werkzeug.serving import make_server
+
+    from decksite.main import APP
+    seed = request.getfixturevalue('seeded_db')
+    server = make_server('127.0.0.1', 0, APP, threaded=True)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield Container({'base_url': f'http://127.0.0.1:{server.server_port}', 'seed': seed})
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+
+class ProblemCollector:
+    """Everything a user would experience as breakage but that never shows up in an HTTP status: JS exceptions, console errors, failed same-origin requests."""
+
+    def __init__(self, page: 'Page', base_url: str) -> None:
+        self.problems: list[str] = []
+        page.on('pageerror', lambda e: self.problems.append(f'uncaught exception: {e}'))
+        page.on('console', lambda m: self.problems.append(f'console.error: {m.text}') if m.type == 'error' else None)
+        page.on('response', lambda r: self.problems.append(f'HTTP {r.status} from {r.url}') if r.status >= 400 and r.url.startswith(base_url) else None)
+        page.on('requestfailed', lambda r: self.problems.append(f'request failed: {r.url} ({r.failure})') if r.url.startswith(base_url) else None)
+
+
+def new_page(browser: 'Browser', site: Container, viewport: tuple[int, int] = VIEWPORTS['medium'], **context_args: Any) -> tuple['Page', ProblemCollector]:
+    context = browser.new_context(viewport={'width': viewport[0], 'height': viewport[1]}, base_url=site.base_url, **context_args)
+    page = context.new_page()
+    return page, ProblemCollector(page, site.base_url)
+
+
+def wait_for_live_tables(page: 'Page') -> list[str]:
+    """Wait for every live table/grid on the page to finish loading and return a problem per one that is empty or errored."""
+    problems = []
+    for css_class in [*LIVE_TABLE_CLASSES, 'metagamegrid']:
+        for i in range(page.locator(f'div.{css_class}').count()):
+            root = page.locator(f'div.{css_class}').nth(i)
+            rows = root.locator('.metagame-grid > *' if css_class == 'metagamegrid' else 'table tbody tr')
+            try:
+                expect(rows.first).to_be_attached(timeout=LOAD_TIMEOUT)
+            except AssertionError:
+                error = root.locator('.message.error')
+                detail = error.first.text_content() if error.count() else ('still loading' if root.locator('.loading').count() else 'no rows')
+                problems.append(f'{page.url}: {css_class} #{i} is empty ({detail})')
+    return problems
+
+
+def discover_pages(page: 'Page') -> list[str]:
+    found = []
+    for source, selector in DISCOVER:
+        page.goto(source)
+        wait_for_live_tables(page)
+        href = page.locator(selector).first.get_attribute('href') if page.locator(selector).count() else None
+        if href and href.startswith('/') and href not in found:
+            found.append(href)
+    return found
+
+
+def test_pages_render_with_data_and_without_errors(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site)
+    pages = PAGES + discover_pages(page)
+    problems = list(collector.problems)
+    for path in pages:
+        collector.problems.clear()
+        response = page.goto(path)
+        assert response is not None
+        if response.status != 200:
+            problems.append(f'{path}: HTTP {response.status}')
+            continue
+        problems.extend(wait_for_live_tables(page))
+        problems.extend(f'{path}: {p}' for p in collector.problems)
+    if site.seed:
+        assert any('/people/' in p for p in pages) and any('/cards/' in p and p != '/cards/' for p in pages), f'Discovery found no person/card pages in {pages}'
+    assert not problems, '\n'.join(problems)
+
+
+def submenu_items(page: 'Page') -> 'Locator':
+    return page.locator('.menu > li:has(.submenu):visible')
+
+
+def open_nav_if_drawer(page: 'Page') -> None:
+    if page.locator('.hamburger').is_visible():
+        page.locator('.hamburger').click()
+        expect(page.locator('nav')).to_have_class(re.compile(r'\bshowing\b'))
+
+
+def assert_submenu_usable(page: 'Page', item: 'Locator', label: str) -> None:
+    """The submenu must be fully on screen, start at the top of the viewport, and its links must be the thing under the cursor (so neither clipped by a scroll container nor covered by another element)."""
+    submenu = item.locator('.submenu')
+    expect(submenu).to_have_css('opacity', '1', timeout=3000)
+    expect(submenu).to_have_css('visibility', 'visible')
+    viewport = page.viewport_size
+    assert viewport
+    box = submenu.bounding_box()
+    assert box, f'{label}: submenu has no box'
+    assert box['height'] > 0 and box['width'] > 0, f'{label}: submenu has no size {box}'
+    assert abs(box['y']) <= 1, f'{label}: submenu should start at the top of the viewport but its top is at y={box["y"]}'
+    assert box['x'] >= 0 and box['x'] + box['width'] <= viewport['width'] + 1, f'{label}: submenu is horizontally off screen {box} in {viewport}'
+    assert box['y'] + box['height'] <= viewport['height'] + 1, f'{label}: submenu runs off the bottom {box} in {viewport}'
+    links = submenu.locator('a.item')
+    assert links.count() > 0, f'{label}: submenu has no links'
+    for i in [0, links.count() - 1]:
+        link = links.nth(i)
+        link_box = link.bounding_box()
+        assert link_box, f'{label}: submenu link {i} has no box'
+        x, y = link_box['x'] + link_box['width'] / 2, link_box['y'] + link_box['height'] / 2
+        under_cursor = page.evaluate('([x, y]) => { const e = document.elementFromPoint(x, y); return e ? (e.closest("a.item")?.textContent ?? e.outerHTML.slice(0, 120)) : null; }', [x, y])
+        assert under_cursor == link.text_content(), f'{label}: submenu link {link.text_content()!r} is covered or clipped; the element at its centre is {under_cursor!r}'
+
+
+@pytest.mark.parametrize('viewport_name', list(VIEWPORTS))
+def test_submenu_opens_on_hover(browser: 'Browser', site: Container, viewport_name: str) -> None:
+    page, collector = new_page(browser, site, VIEWPORTS[viewport_name])
+    page.goto('/')
+    open_nav_if_drawer(page)
+    items = submenu_items(page)
+    assert items.count() >= 2
+    # The first item is near the top so it can look right even when submenus are wrongly anchored to their own menu item. The last one cannot.
+    for index in [0, items.count() - 1]:
+        item = items.nth(index)
+        item.locator(':scope > a.item').hover()
+        expect(item).to_have_class(re.compile(r'\bsubmenu-open\b'), timeout=3000)
+        assert_submenu_usable(page, item, f'{viewport_name} item {index}')
+        page.mouse.move(0, page.viewport_size['height'] - 1) if page.viewport_size else None
+        expect(item).not_to_have_class(re.compile(r'\bsubmenu-open\b'), timeout=3000)
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
+def test_submenu_opens_on_tap_and_stays_open(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site, VIEWPORTS['mobile'], has_touch=True, is_mobile=True)
+    page.goto('/')
+    assert page.evaluate('matchMedia("(hover: none)").matches'), 'Touch emulation should report (hover: none)'
+    open_nav_if_drawer(page)
+    items = submenu_items(page)
+    item = items.nth(items.count() - 1)
+    link = item.locator(':scope > a.item')
+    link.tap()
+    expect(item).to_have_class(re.compile(r'\bsubmenu-open\b'), timeout=3000)
+    assert_submenu_usable(page, item, 'touch')
+    expect(page).to_have_url(re.compile(r'/$'))  # First tap opens the submenu without following the link.
+    other = items.nth(0)
+    other.locator(':scope > a.item').tap()
+    expect(other).to_have_class(re.compile(r'\bsubmenu-open\b'), timeout=3000)
+    expect(item).not_to_have_class(re.compile(r'\bsubmenu-open\b'))
+    href = other.locator(':scope > a.item').get_attribute('href')
+    assert href and href != '/'
+    other.locator(':scope > a.item').tap()  # Second tap on the open item follows its link.
+    expect(page).to_have_url(re.compile(re.escape(href) + '$'), timeout=LOAD_TIMEOUT)
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
+def test_current_submenu_shown_in_flow_when_wide(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site, VIEWPORTS['wide'])
+    page.goto('/decks/')
+    item = page.locator('.menu > li:has(> a.item.current):has(.submenu)')
+    expect(item).to_have_count(1)
+    assert_submenu_usable(page, item, 'wide current')
+    submenu_box = item.locator('.submenu').bounding_box()
+    main_box = page.locator('main').bounding_box()
+    assert submenu_box and main_box
+    assert main_box['x'] >= submenu_box['x'] + submenu_box['width'] - 1, f'Page content at x={main_box["x"]} is under the in-flow submenu ending at {submenu_box["x"] + submenu_box["width"]}'
+    assert not collector.problems, '\n'.join(collector.problems)

--- a/decksite/conftest.py
+++ b/decksite/conftest.py
@@ -83,6 +83,7 @@ def _build_seed() -> Container:
         person.preaggregate()
         card.preaggregate()
         deck.preaggregate()
+        _verify_seed(len(DECKS))
 
     return Container({
         'db_name': SEED_DB_NAME,
@@ -99,6 +100,28 @@ def _build_seed() -> Container:
         'archetype_with_two_decks': ARCHETYPE_WITH_TWO_DECKS,
         'archetype_with_one_deck': ARCHETYPE_WITH_ONE_DECK,
     })
+
+
+def _verify_seed(num_decks: int) -> None:
+    """Tell "the fixture is broken" apart from "the site is broken": the site must be able to see the decks we just inserted."""
+    from decksite.data import deck
+    from decksite.database import db
+    from magic import seasons
+
+    season_num = seasons.current_season_num()
+    _, total = deck.load_decks_with_total(season_id=season_num)
+    if total == num_decks:
+        return
+    diagnostics = {
+        'database': db().value('SELECT DATABASE()'),
+        'server': db().select('SELECT VERSION() AS version, @@sql_mode AS sql_mode, @@session.time_zone AS time_zone, UNIX_TIMESTAMP(NOW()) AS now_ts'),
+        'current_season_num': season_num,
+        'season': db().select('SELECT id, number, code, start_date FROM season ORDER BY id DESC LIMIT 3'),
+        'competition': db().select('SELECT c.id, c.start_date, c.end_date, cs.name AS series, ct.name AS type FROM competition AS c LEFT JOIN competition_series AS cs ON cs.id = c.competition_series_id LEFT JOIN competition_type AS ct ON ct.id = cs.competition_type_id'),
+        'deck': db().select('SELECT id, person_id, competition_id, created_date, retired FROM deck'),
+        'deck_cache': db().select('SELECT deck_id, season_id, wins, draws, losses, legal_formats FROM deck_cache'),
+    }
+    raise AssertionError(f'Seeded database built but the site finds {total} of {num_decks} decks in season {season_num}:\n' + '\n'.join(f'{k}: {v}' for k, v in diagnostics.items()))
 
 
 @pytest.fixture

--- a/decksite/conftest.py
+++ b/decksite/conftest.py
@@ -1,0 +1,114 @@
+"""
+Fixtures for decksite tests.
+
+`seeded_db` points decksite at a small, freshly-built database containing a couple of people,
+a tournament, a few decks and matches. It exists so that tests can tell "the page rendered but
+showed nothing" apart from "the page works" - a page returning 200 with zero decks is exactly the
+kind of failure that a bare smoke test cannot see.
+
+The database is built once per test session (schema + seed data is a few seconds) and only the
+configured database name is switched per test, so tests are cheap.
+"""
+import datetime
+from collections.abc import Iterator
+
+import pytest
+
+from decksite.data.top import Top
+from shared import configuration, dtutil
+from shared.container import Container
+
+SEED_DB_NAME = configuration.get_str('decksite_test_database') + '_seeded'
+
+# Everything in here is deliberately boring and real: real card names (they must exist in the cards db), a real
+# competition series, real archetype names from the schema's initial data.
+PERSON = 'SmokeTester'
+OPPONENT = 'SmokeOpponent'
+COMPETITION_NAME = 'Smoke Test Tournament'
+COMPETITION_SERIES = 'Penny Dreadful Thursdays'
+CARD_IN_TWO_DECKS = 'Lightning Bolt'
+CARD_IN_ONE_DECK = 'Counterspell'
+ARCHETYPE_WITH_TWO_DECKS = 'Aggro'
+ARCHETYPE_WITH_ONE_DECK = 'Control'
+
+DECKS = [
+    {'name': 'Smoke Red Aggro', 'identifier': 'smoke-1', 'mtgo_username': PERSON, 'archetype': 'Aggro', 'finish': 1,
+     'cards': {'maindeck': {CARD_IN_TWO_DECKS: 4, 'Mountain': 56}, 'sideboard': {}}},
+    {'name': 'Smoke Black Aggro', 'identifier': 'smoke-2', 'mtgo_username': PERSON, 'archetype': 'Aggro', 'finish': 2,
+     'cards': {'maindeck': {CARD_IN_TWO_DECKS: 4, 'Swamp': 56}, 'sideboard': {}}},
+    {'name': 'Smoke Blue Control', 'identifier': 'smoke-3', 'mtgo_username': OPPONENT, 'archetype': 'Control', 'finish': 3,
+     'cards': {'maindeck': {CARD_IN_ONE_DECK: 4, 'Island': 56}, 'sideboard': {}}},
+]
+
+_seed: Container | None = None
+
+
+def _build_seed() -> Container:
+    from decksite import database
+    from decksite.data import archetype, card, competition, deck, match, person
+    from decksite.database import db
+    from decksite.main import APP
+    from maintenance import insert_seasons
+
+    with APP.test_request_context('/'):
+        db().execute(f'DROP DATABASE IF EXISTS {SEED_DB_NAME}')
+        db().execute(f'CREATE DATABASE {SEED_DB_NAME} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci')
+        db().execute(f'USE {SEED_DB_NAME}')
+        database.setup()
+        insert_seasons.run()
+        # A fresh schema has archetypes but no closure rows (prod gets those when archetypes are created through the admin pages) and every archetype query goes through the closure table.
+        db().execute('INSERT INTO archetype_closure (ancestor, descendant, depth) SELECT id, id, 0 FROM archetype')  # The schema's season table stops years ago; deck_cache.season_id comes from it, so without this every season-scoped query is empty.
+
+        now = dtutil.now()
+        competition_id = competition.get_or_insert_competition(now - datetime.timedelta(days=1), now - datetime.timedelta(hours=20), COMPETITION_NAME, COMPETITION_SERIES, 'https://example.com/smoke-test-tournament', Top.EIGHT)
+        decks = []
+        for raw in DECKS:
+            params: deck.RawDeckDescription = {
+                'name': raw['name'],  # type: ignore[typeddict-item]
+                'url': f'https://example.com/{raw["identifier"]}',
+                'source': 'Gatherling',
+                'identifier': raw['identifier'],  # type: ignore[typeddict-item]
+                'cards': raw['cards'],  # type: ignore[typeddict-item]
+                'archetype': raw['archetype'],  # type: ignore[typeddict-item]
+                'mtgo_username': raw['mtgo_username'],  # type: ignore[typeddict-item]
+                'competition_id': competition_id,
+                'finish': raw['finish'],  # type: ignore[typeddict-item]
+            }
+            decks.append(deck.add_deck(params))
+        match_time = now - datetime.timedelta(hours=22)
+        match.insert_match(match_time, decks[0].id, 2, decks[2].id, 1, round_num=1)
+        match.insert_match(match_time, decks[1].id, 0, decks[2].id, 2, round_num=1)
+        # The site reads most listings from preaggregated tables that a cron job normally rebuilds. Build them now.
+        archetype.preaggregate()
+        person.preaggregate()
+        card.preaggregate()
+        deck.preaggregate()
+
+    return Container({
+        'db_name': SEED_DB_NAME,
+        'person': PERSON,
+        'person_id': decks[0].person_id,
+        'opponent': OPPONENT,
+        'competition_id': competition_id,
+        'deck_ids': [d.id for d in decks],
+        'num_decks': len(decks),
+        'num_people': 2,
+        'num_matches': 2,
+        'card_in_two_decks': CARD_IN_TWO_DECKS,
+        'card_in_one_deck': CARD_IN_ONE_DECK,
+        'archetype_with_two_decks': ARCHETYPE_WITH_TWO_DECKS,
+        'archetype_with_one_deck': ARCHETYPE_WITH_ONE_DECK,
+    })
+
+
+@pytest.fixture
+def seeded_db() -> Iterator[Container]:
+    global _seed
+    old_db_name = configuration.get_str('decksite_database')
+    configuration.CONFIG['decksite_database'] = SEED_DB_NAME
+    try:
+        if _seed is None:
+            _seed = _build_seed()
+        yield _seed
+    finally:
+        configuration.CONFIG['decksite_database'] = old_db_name

--- a/decksite/conftest.py
+++ b/decksite/conftest.py
@@ -45,7 +45,7 @@ _seed: Container | None = None
 
 def _build_seed() -> Container:
     from decksite import database
-    from decksite.data import archetype, card, competition, deck, match, person
+    from decksite.data import archetype, card, competition, deck, match, person, season
     from decksite.database import db
     from decksite.main import APP
     from maintenance import insert_seasons
@@ -55,9 +55,12 @@ def _build_seed() -> Container:
         db().execute(f'CREATE DATABASE {SEED_DB_NAME} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci')
         db().execute(f'USE {SEED_DB_NAME}')
         database.setup()
+        # The schema's season table stops at season 21. deck_cache.season_id comes from it, so without this every season-scoped query is empty.
         insert_seasons.run()
+        # decksite.data.season caches the season table in a module-level list on first use. Any earlier test that called get_season_id() filled it from whatever database was configured then (in CI a schema-only one), so it must be dropped here and again on teardown.
+        season.SEASONS.clear()
         # A fresh schema has archetypes but no closure rows (prod gets those when archetypes are created through the admin pages) and every archetype query goes through the closure table.
-        db().execute('INSERT INTO archetype_closure (ancestor, descendant, depth) SELECT id, id, 0 FROM archetype')  # The schema's season table stops years ago; deck_cache.season_id comes from it, so without this every season-scoped query is empty.
+        db().execute('INSERT INTO archetype_closure (ancestor, descendant, depth) SELECT id, id, 0 FROM archetype')
 
         now = dtutil.now()
         competition_id = competition.get_or_insert_competition(now - datetime.timedelta(days=1), now - datetime.timedelta(hours=20), COMPETITION_NAME, COMPETITION_SERIES, 'https://example.com/smoke-test-tournament', Top.EIGHT)
@@ -126,6 +129,7 @@ def _verify_seed(num_decks: int) -> None:
 
 @pytest.fixture
 def seeded_db() -> Iterator[Container]:
+    from decksite.data import season
     global _seed
     old_db_name = configuration.get_str('decksite_database')
     configuration.CONFIG['decksite_database'] = SEED_DB_NAME
@@ -135,3 +139,4 @@ def seeded_db() -> Iterator[Container]:
         yield _seed
     finally:
         configuration.CONFIG['decksite_database'] = old_db_name
+        season.SEASONS.clear()

--- a/decksite/live_table_test.py
+++ b/decksite/live_table_test.py
@@ -1,0 +1,177 @@
+"""
+Contract tests between the server-rendered pages, the React live tables, and the API they load from.
+
+Every "live" table on the site is an empty <div class="decktable" data-...> that DataManager (shared_web/static/js/datamanager.jsx)
+turns into a request to an /api/ endpoint. The browser sends *every* data-* attribute, usually as an empty string, and
+nothing in the Python test suite used to make that request, so a server change that treated an empty string as a filter
+shipped and emptied /decks/. These tests render the real page against a seeded database, read the data-* attributes off
+the real element, build the request exactly as DataManager.load() would, and check that rows come back.
+"""
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+from bs4 import BeautifulSoup
+from flask.testing import FlaskClient
+
+from decksite.main import APP
+from shared.container import Container
+
+DATAMANAGER_JSX = Path('shared_web/static/js/datamanager.jsx')
+
+
+@dataclass
+class LiveTable:
+    page: str
+    css_class: str
+    endpoint: str
+    min_total: int
+    fixed_props: dict[str, str] = field(default_factory=dict)  # Props the mounting JSX passes explicitly, before {...e.dataset}.
+
+    def __str__(self) -> str:
+        return f'{self.css_class} on {self.page}'
+
+
+def live_tables(seed: Container) -> list[LiveTable]:
+    competition_page = f'/competitions/{seed.competition_id}/'
+    person_page = f'/people/{seed.person}/'
+    return [
+        LiveTable('/decks/', 'decktable', '/api/decks/', seed.num_decks),
+        LiveTable('/decks/league/', 'decktable', '/api/decks/', 0),
+        LiveTable(person_page, 'decktable', '/api/decks/', 2),
+        LiveTable(person_page, 'cardtable', '/api/cards2/', 1),
+        LiveTable(person_page, 'headtoheadtable', '/api/h2h/', 1),
+        LiveTable(f'/cards/{seed.card_in_two_decks}/', 'decktable', '/api/decks/', 2),
+        LiveTable(f'/cards/{seed.card_in_one_deck}/', 'decktable', '/api/decks/', 1),
+        LiveTable('/cards/', 'cardtable', '/api/cards2/', 1),
+        LiveTable('/people/', 'persontable', '/api/people/', seed.num_people),
+        LiveTable(competition_page, 'decktable', '/api/decks/', seed.num_decks),
+        LiveTable(competition_page, 'cardtable', '/api/cards2/', 1),
+        LiveTable('/metagame/', 'metagamegrid', '/api/archetypes2/', 1, {'initialSortBy': 'quality', 'initialSortOrder': 'AUTO'}),
+        LiveTable('/tournaments/leaderboards/', 'leaderboardtable', '/api/leaderboards/', 1),
+        LiveTable(f'/archetypes/{seed.archetype_with_two_decks}/', 'decktable', '/api/decks/', 2),
+        LiveTable(f'/archetypes/{seed.archetype_with_two_decks}/', 'cardtable', '/api/cards2/', 1),
+    ]
+
+
+def datamanager_request_params() -> dict[str, str]:
+    """Parse the `const params = {...}` block in DataManager.load(): request key -> 'props.<name>' or a state variable name."""
+    source = DATAMANAGER_JSX.read_text()
+    block = re.search(r'const params = \{(.*?)\};', source, re.DOTALL)
+    assert block, 'Could not find the params block in DataManager.load()'
+    params = {}
+    for line in block.group(1).splitlines():
+        line = line.strip().rstrip(',')
+        if not line:
+            continue
+        m = re.fullmatch(r'"(\w+)": this\.props\.(\w+)', line)
+        if m:
+            params[m.group(1)] = f'props.{m.group(2)}'
+            continue
+        m = re.fullmatch(r'(\w+)', line)
+        assert m, f'Unrecognized line in DataManager.load() params: {line!r} - update this test to match'
+        params[m.group(1)] = m.group(1)
+    return params
+
+
+def known_prop_names() -> set[str]:
+    """Every prop DataManager declares plus every prop any table/grid component reads, so a data-* attribute nothing consumes is caught."""
+    source = DATAMANAGER_JSX.read_text()
+    block = re.search(r'DataManager\.propTypes = \{(.*?)\};', source, re.DOTALL)
+    assert block, 'Could not find DataManager.propTypes'
+    names = set(re.findall(r'"(\w+)":', block.group(1)))
+    for jsx in DATAMANAGER_JSX.parent.glob('*.jsx'):
+        names.update(re.findall(r'\bprops\.(\w+)', jsx.read_text()))
+    return names
+
+
+def dataset_key(attr: str) -> str:
+    """data-card-name -> cardName, data-hide-top8 -> hideTop8 (the browser's HTMLElement.dataset conversion)."""
+    return re.sub(r'-([a-z])', lambda m: m.group(1).upper(), attr.removeprefix('data-'))
+
+
+def simulate_datamanager_load(props: dict[str, str]) -> dict[str, Any]:
+    """Build the query string DataManager.load() sends for a component with these props, with state as it is on first load."""
+    if props.get('leagueOnly'):
+        deck_type = 'league'
+    elif props.get('tournamentOnly'):
+        deck_type = 'tournament'
+    else:
+        deck_type = 'all'
+    state = {
+        'deckType': deck_type,
+        'page': 0,
+        'pageSize': int(props['pageSize']),
+        'q': '',
+        'sortBy': props.get('initialSortBy'),
+        'sortOrder': props.get('initialSortOrder'),
+    }
+    params = {}
+    for key, source in datamanager_request_params().items():
+        value = props.get(source.removeprefix('props.')) if source.startswith('props.') else state[source]
+        if value is not None:  # axios omits undefined params but sends empty strings.
+            params[key] = value
+    return params
+
+
+def find_live_table(client: FlaskClient, table: LiveTable) -> dict[str, str]:
+    response = client.get(table.page)
+    assert response.status_code == 200, f'{table.page} returned {response.status_code}'
+    soup = BeautifulSoup(response.get_data(as_text=True), 'html.parser')
+    elements = soup.select(f'div.{table.css_class}')
+    assert elements, f'{table.page} does not contain a div.{table.css_class}'
+    props = dict(table.fixed_props)
+    for attr, value in elements[0].attrs.items():
+        if attr.startswith('data-'):
+            props[dataset_key(attr)] = value if isinstance(value, str) else ' '.join(value)
+    return props
+
+
+@pytest.mark.functional
+def test_every_live_table_loads_rows(seeded_db: Container) -> None:
+    client = APP.test_client()
+    known_props = known_prop_names()
+    failures = []
+    for table in live_tables(seeded_db):
+        try:
+            props = find_live_table(client, table)
+        except AssertionError as e:
+            failures.append(str(e))
+            continue
+        unknown = set(props) - known_props
+        if unknown:
+            failures.append(f'{table}: template passes {sorted(unknown)} which DataManager does not declare in propTypes')
+        params = simulate_datamanager_load(props)
+        response = client.get(table.endpoint, query_string=params)
+        if response.status_code != 200:
+            failures.append(f'{table}: GET {table.endpoint} {params} returned {response.status_code}')
+            continue
+        data = response.get_json()
+        if data is None or 'objects' not in data or 'total' not in data:
+            failures.append(f'{table}: GET {table.endpoint} {params} did not return objects/total')
+            continue
+        if data['total'] < table.min_total or len(data['objects']) < min(table.min_total, 1):
+            failures.append(f'{table}: expected at least {table.min_total} rows but got total={data["total"]} objects={len(data["objects"])} for GET {table.endpoint} {params}')
+    assert not failures, '\n'.join(failures)
+
+
+@pytest.mark.functional
+def test_live_deck_table_filters_still_filter(seeded_db: Container) -> None:
+    """The mirror image of the test above: a real filter value must reduce the results, so that "ignore empty filters" never becomes "ignore filters"."""
+    client = APP.test_client()
+    base = simulate_datamanager_load(find_live_table(client, LiveTable('/decks/', 'decktable', '/api/decks/', 0)))
+
+    def total(**overrides: str) -> int:
+        response = client.get('/api/decks/', query_string=base | overrides)
+        assert response.status_code == 200
+        return int(response.get_json()['total'])
+
+    assert total() == seeded_db.num_decks
+    assert total(cardName=seeded_db.card_in_two_decks) == 2
+    assert total(cardName=seeded_db.card_in_one_deck) == 1
+    assert total(personId=str(seeded_db.person_id)) == 2
+    assert total(competitionId=str(seeded_db.competition_id)) == seeded_db.num_decks
+    assert total(deckType='league') == 0
+    assert total(seasonId='all') == seeded_db.num_decks

--- a/dev.py
+++ b/dev.py
@@ -164,6 +164,39 @@ def unit(argv: list[str]) -> None:
 def test(argv: list[str]) -> None:
     runtests(argv, '')
 
+SMOKE_TESTS = ['decksite/smoke_test.py', 'decksite/live_table_test.py', 'logsite/smoke_test.py']
+
+def do_smoke() -> None:
+    print('>>>> Running smoke tests (needs a database)')
+    code = subprocess.call(['pytest', '--no-cov', '-p', 'no:cacheprovider', *SMOKE_TESTS])
+    if code:
+        sys.exit(code)
+
+@cli.command()
+def smoke() -> None:
+    """Render every page with a live table against a seeded database and check the API calls the browser would make return rows. A few seconds."""
+    do_smoke()
+
+def do_browser(base_url: str | None) -> None:
+    env = dict(os.environ)
+    if base_url:
+        print(f'>>>> Running browser tests against {base_url}')
+        env['PD_BROWSER_BASE_URL'] = base_url
+        args = ['--noconftest']  # The root conftest wants a cards database; the canary needs nothing but a browser.
+    else:
+        print('>>>> Running browser tests against a local server (needs a database and a built JS bundle)')
+        env['PD_BROWSER_TESTS'] = '1'
+        args = []
+    code = subprocess.call(['pytest', '--no-cov', '-p', 'no:cacheprovider', *args, 'decksite/browser_test.py'], env=env)
+    if code:
+        sys.exit(code)
+
+@cli.command()
+@click.option('--url', default=None, help='Run read-only against a deployed site (for example https://pennydreadfulmagic.com) instead of a local server.')
+def browser(url: str | None = None) -> None:
+    """Load real pages in headless Chromium: live tables fill, nothing errors, the menu is usable at every width. Run `uv run playwright install chromium` once first."""
+    do_browser(url)
+
 def do_sort(fix: bool) -> None:
     print('>>>> Checking imports')
     args = ['-m', 'ruff', 'check', '.', '--select', 'I']

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     ],
     "presets": [
       "@babel/preset-env",
-      "@babel/preset-react"
+      [
+        "@babel/preset-react",
+        {
+          "development": false
+        }
+      ]
     ]
   },
   "bugs": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dev = [
     "brotli",
     "ruff==0.16.5",
     "mypy-extensions",
+    "playwright==1.62.0",
 ]
 
 [tool.ruff]

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,6 +7,7 @@ markers =
     gatherling: Gatherling integration tests
     goldfish: Goldfish integration tests
     external: External integrations
+    browser: Headless-browser smoke tests (opt in with PD_BROWSER_TESTS=1 or PD_BROWSER_BASE_URL, see decksite/browser_test.py)
 filterwarnings =
     # https://github.com/python-restx/flask-restx/issues/553
     ignore:.*RefResolver.*:DeprecationWarning:flask_restx

--- a/shared/configuration.py
+++ b/shared/configuration.py
@@ -212,7 +212,9 @@ def get(key: str) -> str | list[str] | int | float | None:
         print(f'CONFIG: {key}={cfg[key]}')
         return cfg[key]
     if key in cfg:
-        CONFIG.update(cfg)
+        # Cache everything we just read, but never clobber a value already in CONFIG: tests point decksite_database at a scratch database by writing to CONFIG directly.
+        for k, v in cfg.items():
+            CONFIG.setdefault(k, v)
         return cfg[key]
     if key in DEFAULTS:
         # Lock in the default value if we use it.

--- a/uv.lock
+++ b/uv.lock
@@ -798,6 +798,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/ab/d26750f2b7242c2b90ea2ad71de70cfcd73a948a49513188a0fc0d6fc15a/greenlet-3.3.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:7ab327905cabb0622adca5971e488064e35115430cec2c35a50fd36e72a315b3", size = 275205, upload-time = "2026-01-23T15:30:24.556Z" },
     { url = "https://files.pythonhosted.org/packages/10/d3/be7d19e8fad7c5a78eeefb2d896a08cd4643e1e90c605c4be3b46264998f/greenlet-3.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:65be2f026ca6a176f88fb935ee23c18333ccea97048076aef4db1ef5bc0713ac", size = 599284, upload-time = "2026-01-23T16:00:58.584Z" },
     { url = "https://files.pythonhosted.org/packages/ae/21/fe703aaa056fdb0f17e5afd4b5c80195bbdab701208918938bd15b00d39b/greenlet-3.3.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7a3ae05b3d225b4155bda56b072ceb09d05e974bc74be6c3fc15463cf69f33fd", size = 610274, upload-time = "2026-01-23T16:05:29.312Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/95df0b6a935103c0452dad2203f5be8377e551b8466a29650c4c5a5af6cc/greenlet-3.3.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:12184c61e5d64268a160226fb4818af4df02cfead8379d7f8b99a56c3a54ff3e", size = 624375, upload-time = "2026-01-23T16:15:55.915Z" },
     { url = "https://files.pythonhosted.org/packages/cb/86/5c6ab23bb3c28c21ed6bebad006515cfe08b04613eb105ca0041fecca852/greenlet-3.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6423481193bbbe871313de5fd06a082f2649e7ce6e08015d2a76c1e9186ca5b3", size = 612904, upload-time = "2026-01-23T15:32:52.317Z" },
     { url = "https://files.pythonhosted.org/packages/c2/f3/7949994264e22639e40718c2daf6f6df5169bf48fb038c008a489ec53a50/greenlet-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:33a956fe78bbbda82bfc95e128d61129b32d66bcf0a20a1f0c08aa4839ffa951", size = 1567316, upload-time = "2026-01-23T16:04:23.316Z" },
     { url = "https://files.pythonhosted.org/packages/8d/6e/d73c94d13b6465e9f7cd6231c68abde838bb22408596c05d9059830b7872/greenlet-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4b065d3284be43728dd280f6f9a13990b56470b81be20375a207cdc814a983f2", size = 1636549, upload-time = "2026-01-23T15:33:48.643Z" },
@@ -1459,6 +1460,7 @@ dev = [
     { name = "brotli" },
     { name = "mypy" },
     { name = "mypy-extensions" },
+    { name = "playwright" },
     { name = "ruff" },
     { name = "types-certifi" },
     { name = "types-chardet" },
@@ -1549,6 +1551,7 @@ dev = [
     { name = "brotli" },
     { name = "mypy", specifier = "==2.3.1" },
     { name = "mypy-extensions" },
+    { name = "playwright", specifier = "==1.62.0" },
     { name = "ruff", specifier = "==0.16.5" },
     { name = "types-certifi" },
     { name = "types-chardet" },
@@ -1605,6 +1608,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/5e/56ed133c789ba42cb831dad49252c01633027a9f7105a1b0c30938ce5b47/pip_check_reqs-3.0.0.tar.gz", hash = "sha256:f0cd0a78cf7da659b3a27191644eb4051b717331ed0c6049ce3db4a5a1d35003", size = 19047, upload-time = "2026-07-30T11:02:56.032Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/f3/449a613babb751bb6b2c8434bea705075f46fd0ef113f6a04560e58fa998/pip_check_reqs-3.0.0-py3-none-any.whl", hash = "sha256:593d85bdf72715a5ac152fbd3aa25275122a8449856cf4cd14e8b1c63ccbabfd", size = 12220, upload-time = "2026-07-30T11:02:55.003Z" },
+]
+
+[[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
 ]
 
 [[package]]
@@ -1771,6 +1793,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
     { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
     { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds two test suites that would have caught the two September 2nd regressions, plus a parallel `browser` CI job. Nothing here is yet a required check.

## What is added

- **`decksite/conftest.py`** — session-scoped `seeded_db` fixture. Builds `decksite_test_seeded` once per session: schema, seasons, archetype closure, 2 people, 1 competition, 3 decks, 2 matches, preaggregates. About 6s. Verifies the site can see the seeded decks before any test runs.
- **`decksite/live_table_test.py`** — renders every page that has a React live table, reads the real `data-*` attributes, rebuilds the request exactly as `DataManager.load()` in `datamanager.jsx` would, hits the API and asserts rows come back and that real filters still filter. Marked `functional`, so it runs under the existing `test` job (adds ~8s).
- **`decksite/browser_test.py`** — Playwright in headless Chromium. Pages fill with data, no same-origin request fails, no JS console errors, and the submenu is on screen and clickable at 400/1200/1700px by hover and by touch. Loads the seeded person's page explicitly, so a server answering from any other database is a 404. Marker `browser`; skipped unless `PD_BROWSER_TESTS=1` or `PD_BROWSER_BASE_URL` is set.
- **`.github/workflows/build.yml`** — new `browser` job alongside `test` (LFS checkout for the font sources, builds the symbols font). The `test` job is untouched.
- **`dev.py`** — `smoke` (live-table tests against the seeded DB) and `browser [--url]` (browser tests locally or against a deployed site).
- **`pyproject.toml` / `uv.lock` / `pytest.ini`** — playwright 1.62.0 as a dev dependency, `browser` marker.

## Two non-test changes, both found by running the new tests in CI

- **`package.json`** — `@babel/preset-react` gets `development: false`. Since the Babel 8 upgrade (892356ae) it emits `jsxDEV` calls unless `NODE_ENV` is set, and React's production `jsx-dev-runtime` leaves `jsxDEV` undefined, so `npm run build` with `NODE_ENV` unset produced a bundle that throws on every page and renders no live tables. Nothing in the repo sets `NODE_ENV`. Production's current bundle is clean, so the deploy host either sets it or built before the bump.
- **`shared/configuration.py`** — a first-time key read merged config.json into `CONFIG` with `update`, overwriting any value set at runtime. Production sets nothing at runtime, so no behaviour change there. Tests that point `decksite_database` at a scratch database were silently redirected to the configured one; now existing values win (`setdefault`).

## Verification

- Reverting the #15163 menu CSS fix fails all five menu tests.
- Reverting the #15166 empty-cardname fix fails both live-table tests.
- With the old `configuration.py`, the browser tests fail because the server answers from the dev database.
- `browser_test.py` passes against production via `dev.py browser --url https://pennydreadfulmagic.com`.
- Lint and mypy clean.

## Follow-up, separate PR

`browser` becomes a required check in `.mergify.yml` and a canary workflow runs it against production, once this job has reported green on master. Doing that here would block every PR on a check that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)