### PR TITLE
Show archetypes moving in the metagame on the home page (#12568)

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -25,6 +25,17 @@ class SeasonStats(TypedDict):
 
 BASE_ARCHETYPES: dict[Archetype, Archetype] = {}
 
+# The length of each of the two periods movers and shakers compares. A week is short enough that
+# what it shows is news and long enough that most archetypes clear the minimum match count.
+WINDOW_DAYS = 7
+
+# Matches needed in one of the two windows before an archetype can be a mover. Because an archetype's
+# change in meta share is bounded by its meta share, a rare archetype cannot move far enough to reach
+# the top or bottom of the list anyway, and in practice anything from 1 to 15 picks the same
+# archetypes. This is set to a little more than a single 5-round league run purely as a floor against
+# a freak low-volume week.
+MIN_MATCHES = 6
+
 def load_archetype(archetype: int | str) -> Archetype:
     try:
         archetype_id = int(archetype)
@@ -197,6 +208,7 @@ def preaggregate() -> None:
     preaggregate_disjoint_archetype_person()
     preaggregate_matchups()
     preaggregate_matchups_person()
+    preaggregate_archetype_days()
 
 def preaggregate_archetypes() -> None:
     table = '_arch_stats'
@@ -393,6 +405,55 @@ def preaggregate_disjoint_archetype_person() -> None:
             ct.name
         HAVING
             season.season_id IS NOT NULL
+    """
+    preaggregation.preaggregate(table, sql)
+
+# Disjoint archetype stats bucketed by the UTC day a match was played on, so that we can compare
+# recent form against the immediately preceding period. Unlike the other archetype preaggregates
+# this is keyed on match date rather than deck creation date, because "what happened this week" is a
+# question about matches, not about when a decklist was first uploaded.
+def preaggregate_archetype_days() -> None:
+    table = '_arch_day_stats'
+    sql = f"""
+        CREATE TABLE IF NOT EXISTS _new{table} (
+            archetype_id INT NOT NULL,
+            season_id INT NOT NULL,
+            day INT NOT NULL,
+            num_decks INT NOT NULL,
+            wins INT NOT NULL,
+            losses INT NOT NULL,
+            draws INT NOT NULL,
+            deck_type ENUM('league', 'tournament', 'other') NOT NULL,
+            PRIMARY KEY (season_id, day, archetype_id, deck_type),
+            FOREIGN KEY (season_id) REFERENCES season (id) ON UPDATE CASCADE ON DELETE CASCADE,
+            FOREIGN KEY (archetype_id) REFERENCES archetype (id) ON UPDATE CASCADE ON DELETE CASCADE
+        ) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci AS
+        SELECT
+            d.archetype_id,
+            season.season_id,
+            FLOOR(m.date / 86400) * 86400 AS day,
+            COUNT(DISTINCT d.id) AS num_decks,
+            SUM(CASE WHEN dm.games > IFNULL(odm.games, 0) THEN 1 ELSE 0 END) AS wins, -- IFNULL so we still count byes as wins.
+            SUM(CASE WHEN dm.games < odm.games THEN 1 ELSE 0 END) AS losses,
+            SUM(CASE WHEN dm.games = odm.games THEN 1 ELSE 0 END) AS draws,
+            (CASE WHEN ct.name = 'League' THEN 'league' WHEN ct.name = 'Gatherling' THEN 'tournament' ELSE 'other' END) AS deck_type
+        FROM
+            `match` AS m
+        INNER JOIN
+            deck_match AS dm ON dm.match_id = m.id
+        INNER JOIN
+            deck_match AS odm ON odm.match_id = m.id AND odm.deck_id <> dm.deck_id
+        INNER JOIN
+            deck AS d ON d.id = dm.deck_id
+        {query.competition_join()}
+        {query.season_join()}
+        GROUP BY
+            d.archetype_id,
+            season.season_id,
+            day,
+            ct.name
+        HAVING
+            season_id IS NOT NULL AND archetype_id IS NOT NULL
     """
     preaggregation.preaggregate(table, sql)
 
@@ -658,6 +719,75 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
         {limit}
     """
     return archetype_list_from(sql, order_by is None)
+
+# Archetypes whose share of the metagame has moved most over the last `window_days` days of the
+# season, compared against the `window_days` immediately before that. /metagame has no time axis, so
+# this is the one thing the home page can say about the metagame that a link to /metagame cannot.
+# Both windows are clamped to the season, so nothing from the previous season leaks in over rotation.
+@retry_after_calling(preaggregate)
+def load_movers_and_shakers(season_id: int, window_days: int = WINDOW_DAYS, min_matches: int = MIN_MATCHES) -> list[Archetype]:
+    window = window_days * 60 * 60 * 24
+    season_query = query.season_query(season_id)
+    sql = f"""
+        WITH bounds AS (
+            -- One day past the most recent day with any matches in this season. For the current
+            -- season that is tomorrow; for a past season it is the day after the season ended.
+            SELECT
+                MAX(day) + 86400 AS end_date
+            FROM
+                _arch_day_stats
+            WHERE
+                {season_query}
+        ),
+        windows AS (
+            SELECT
+                ads.archetype_id,
+                SUM(CASE WHEN ads.day >= b.end_date - {window} THEN ads.wins + ads.losses + ads.draws ELSE 0 END) AS num_matches,
+                SUM(CASE WHEN ads.day >= b.end_date - {window} THEN ads.wins ELSE 0 END) AS wins,
+                SUM(CASE WHEN ads.day >= b.end_date - {window} THEN ads.losses ELSE 0 END) AS losses,
+                SUM(CASE WHEN ads.day >= b.end_date - {window} THEN ads.draws ELSE 0 END) AS draws,
+                SUM(CASE WHEN ads.day < b.end_date - {window} THEN ads.wins + ads.losses + ads.draws ELSE 0 END) AS previous_num_matches
+            FROM
+                _arch_day_stats AS ads
+            CROSS JOIN
+                bounds AS b
+            WHERE
+                ({season_query}) AND ads.day >= b.end_date - {window * 2} AND ads.day < b.end_date
+            GROUP BY
+                ads.archetype_id
+        ),
+        totals AS (
+            SELECT
+                SUM(num_matches) AS total_matches,
+                SUM(previous_num_matches) AS previous_total_matches
+            FROM
+                windows
+        )
+        SELECT
+            a.id,
+            a.name,
+            w.num_matches,
+            w.wins,
+            w.losses,
+            w.draws,
+            CAST(ROUND((w.wins / NULLIF(w.wins + w.losses, 0)) * 100, 1) AS DOUBLE) AS win_percent,
+            w.num_matches / t.total_matches AS meta_share,
+            w.num_matches / t.total_matches - (CASE WHEN t.previous_total_matches > 0 THEN w.previous_num_matches / t.previous_total_matches ELSE 0 END) AS meta_share_change
+        FROM
+            windows AS w
+        INNER JOIN
+            archetype AS a ON a.id = w.archetype_id
+        CROSS JOIN
+            totals AS t
+        WHERE
+            -- Either window will do: an archetype that played 90 matches last week and 11 this week
+            -- is the most interesting faller there is, and a floor on the current window alone would
+            -- be exactly the thing that hid it.
+            GREATEST(w.num_matches, w.previous_num_matches) >= {min_matches}
+        ORDER BY
+            meta_share_change DESC, w.num_matches DESC, a.name
+    """
+    return [Archetype(r) for r in db().select(sql)]
 
 def archetype_list_from(sql: str, should_preorder: bool) -> tuple[list[Archetype], int]:
     rs = db().select(sql)

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -93,3 +93,84 @@ def test_archetype_quality_sorts_put_no_match_archetypes_last(sort_by: str) -> N
 
     assert ascending[-1].id == 2
     assert descending[-1].id == 2
+
+
+@with_test_db
+@pytest.mark.functional
+def test_load_movers_and_shakers_compares_the_last_week_to_the_week_before() -> None:
+    archetype.preaggregate_archetype_days()
+    day = 86400
+    latest = 100 * day
+    db().execute(f"""
+        INSERT INTO _arch_day_stats
+            (archetype_id, season_id, day, num_decks, wins, losses, draws, deck_type)
+        VALUES
+            -- Riser: no matches in the first week, the largest share of them in the second.
+            (1, 1, {latest - day * 10}, 1, 0, 0, 0, 'league'),
+            (1, 1, {latest}, 5, 6, 4, 0, 'league'),
+            -- Faller: most of the matches in the first week, a quarter of them in the second.
+            (2, 1, {latest - day * 10}, 5, 5, 5, 0, 'league'),
+            (2, 1, {latest}, 2, 3, 3, 0, 'league'),
+            -- Steady: the same number of matches in both weeks.
+            (3, 1, {latest - day * 10}, 5, 3, 3, 0, 'league'),
+            (3, 1, {latest}, 5, 3, 3, 0, 'league'),
+            -- Below the minimum match count in both weeks, so not a mover, but still part of the
+            -- metagame everything else is a share of.
+            (4, 1, {latest}, 1, 1, 0, 0, 'league')
+    """)
+
+    movers = archetype.load_movers_and_shakers(1, min_matches=6)
+
+    assert [a.id for a in movers] == [1, 3, 2]
+    assert [round(float(a.meta_share_change), 3) for a in movers] == [0.435, -0.114, -0.364]
+    assert movers[0].wins == 6
+    assert movers[0].losses == 4
+    assert movers[0].win_percent == 60.0
+
+
+@with_test_db
+@pytest.mark.functional
+def test_load_movers_and_shakers_does_not_compare_across_a_rotation() -> None:
+    archetype.preaggregate_archetype_days()
+    day = 86400
+    latest = 100 * day
+    db().execute(f"""
+        INSERT INTO _arch_day_stats
+            (archetype_id, season_id, day, num_decks, wins, losses, draws, deck_type)
+        VALUES
+            (1, 1, {latest - day * 10}, 5, 10, 10, 0, 'league'),
+            (1, 1, {latest}, 5, 5, 5, 0, 'league'),
+            (2, 2, {latest - day * 10}, 5, 50, 50, 0, 'league'),
+            (2, 2, {latest}, 5, 50, 50, 0, 'league')
+    """)
+
+    movers = archetype.load_movers_and_shakers(1, min_matches=1)
+
+    assert [a.id for a in movers] == [1]
+    assert float(movers[0].meta_share) == 1.0
+    assert float(movers[0].meta_share_change) == 0.0
+
+
+@with_test_db
+@pytest.mark.functional
+def test_load_movers_and_shakers_includes_an_archetype_that_stopped_being_played() -> None:
+    archetype.preaggregate_archetype_days()
+    day = 86400
+    latest = 100 * day
+    db().execute(f"""
+        INSERT INTO _arch_day_stats
+            (archetype_id, season_id, day, num_decks, wins, losses, draws, deck_type)
+        VALUES
+            (1, 1, {latest - day * 10}, 5, 5, 5, 0, 'league'),
+            (1, 1, {latest}, 5, 5, 5, 0, 'league'),
+            -- Played a lot last week and nothing at all this week, which is the most dramatic fall
+            -- there is and so must not be filtered out for having no matches in the current window.
+            (2, 1, {latest - day * 10}, 5, 5, 5, 0, 'league')
+    """)
+
+    movers = archetype.load_movers_and_shakers(1, min_matches=10)
+
+    assert [a.id for a in movers] == [1, 2]
+    assert float(movers[1].meta_share) == 0.0
+    assert float(movers[1].meta_share_change) == -0.5
+    assert movers[1].win_percent is None

--- a/decksite/main.py
+++ b/decksite/main.py
@@ -10,6 +10,7 @@ from werkzeug.exceptions import InternalServerError
 
 from decksite import APP, SEASONS, auth, deck_name, get_season_id
 from decksite.cache import cached
+from decksite.data import archetype as archs
 from decksite.data import card as cs
 from decksite.data import deck as ds
 from decksite.data import match as ms
@@ -29,7 +30,8 @@ def home() -> str:
     decks = ds.latest_decks(season_id=season_id)
     top_8_plus_basics = 'LIMIT 13'
     cards, total = cs.load_cards_with_total(limit=top_8_plus_basics, season_id=season_id)
-    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats())
+    movers_and_shakers = archs.load_movers_and_shakers(season_id)
+    view = Home(ns.all_news(decks, max_items=10), decks, cards, ms.stats(), movers_and_shakers)
     return view.page()
 
 @APP.route('/export/<int:deck_id>/')

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -5,6 +5,32 @@
         <p><a href="{{url}}">{{link_text}}</a></p>
     </section>
 {{/deck_tables}}
+{{#has_movers_and_shakers}}
+    <section>
+        <h2>{{_ Metagame}} <span class="subtitle">{{movers_and_shakers_window}}</span></h2>
+        <table>
+            <thead>
+                <th>Archetype</th>
+                <th class="n">Meta Share</th>
+                <th class="n">Change</th>
+                <th class="n">Record</th>
+                <th class="n">Win %</th>
+            </thead>
+            <tbody>
+                {{#archetypes}}
+                    <tr data-href="{{url}}" class="clickable">
+                        <td><a href="{{url}}">{{name}}</a></td>
+                        <td class="n">{{meta_share_display}}</td>
+                        <td class="n">{{meta_share_change_display}}</td>
+                        <td class="n">{{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}</td>
+                        <td class="n">{{win_percent}}</td>
+                    </tr>
+                {{/archetypes}}
+            </tbody>
+        </table>
+        <p><a href="{{metagame_url}}">{{_ More metagame…}}</a></p>
+    </section>
+{{/has_movers_and_shakers}}
 {{#has_top_cards}}
     <section>
         <h2>{{_ Top Cards}}</h2>

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -1,6 +1,7 @@
 from flask import url_for
 from flask_babel import gettext
 
+from decksite.data.archetype import WINDOW_DAYS, Archetype
 from decksite.view import View
 from magic import rotation, seasons, tournaments
 from magic.models import Card, Deck
@@ -9,11 +10,12 @@ from shared.container import Container
 
 
 class Home(View):
-    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int]) -> None:
+    def __init__(self, news: list[Container], decks: list[Deck], cards: list[Card], matches_stats: dict[str, int], movers_and_shakers: list[Archetype]) -> None:
         super().__init__()
         self.setup_news(news)
         self.setup_decks(decks)
         self.setup_cards(cards)
+        self.setup_movers_and_shakers(movers_and_shakers)
         self.setup_rotation()
         self.setup_stats(matches_stats)
         self.setup_tournaments()
@@ -93,6 +95,15 @@ class Home(View):
         self.cards = self.top_cards  # To get prepare_card treatment
         self.cards_url = url_for('.cards')
 
+    def setup_movers_and_shakers(self, movers_and_shakers: list[Archetype]) -> None:
+        movers = biggest_movers(movers_and_shakers)
+        for a in movers:
+            a.meta_share_display = f'{a.meta_share * 100:.1f}%'
+            a.meta_share_change_display = f'{"↑" if a.meta_share_change > 0 else "↓"} {abs(a.meta_share_change) * 100:.1f}'
+        self.archetypes = movers  # Named archetypes so that View.prepare_archetypes gives them urls.
+        self.has_movers_and_shakers = len(movers) > 0
+        self.movers_and_shakers_window = gettext('Last %(days)d days', days=WINDOW_DAYS)
+
     def setup_rotation(self) -> None:
         self.season_start_display = dtutil.display_date(seasons.last_rotation())
         self.season_end_display = dtutil.display_date(seasons.next_rotation())
@@ -129,3 +140,13 @@ class Home(View):
                 ],
             },
         ]
+
+# movers_and_shakers arrives sorted by meta share change, most improved first. Show the biggest
+# risers and the biggest fallers, and if there aren't enough of one take more of the other, so that a
+# week where everything is up (the first week of a season) still fills the table.
+def biggest_movers(movers_and_shakers: list[Archetype], max_rows: int = 8, max_per_direction: int = 4) -> list[Archetype]:
+    risers = [a for a in movers_and_shakers if a.meta_share_change > 0]
+    fallers = [a for a in movers_and_shakers if a.meta_share_change < 0]
+    num_risers = min(len(risers), max(max_per_direction, max_rows - len(fallers)))
+    num_fallers = min(len(fallers), max_rows - num_risers)
+    return risers[:num_risers] + fallers[len(fallers) - num_fallers:]

--- a/decksite/views/home_test.py
+++ b/decksite/views/home_test.py
@@ -1,0 +1,36 @@
+import pytest
+
+from decksite.data.archetype import Archetype
+from decksite.views.home import biggest_movers
+
+
+def movers(*changes: float) -> list[Archetype]:
+    return [Archetype({'id': i, 'meta_share_change': change}) for i, change in enumerate(changes)]
+
+
+def test_biggest_movers_shows_the_biggest_risers_and_the_biggest_fallers() -> None:
+    all_movers = movers(0.05, 0.04, 0.03, 0.02, 0.01, -0.01, -0.02, -0.03, -0.04, -0.05)
+
+    assert [a.id for a in biggest_movers(all_movers)] == [0, 1, 2, 3, 6, 7, 8, 9]
+
+
+def test_biggest_movers_ignores_archetypes_that_did_not_move() -> None:
+    all_movers = movers(0.05, 0.0, 0.0, -0.05)
+
+    assert [a.id for a in biggest_movers(all_movers)] == [0, 3]
+
+
+@pytest.mark.parametrize(('changes', 'expected'), [
+    # Everything is rising, as in the first week of a season, so show eight risers.
+    ((0.08, 0.07, 0.06, 0.05, 0.04, 0.03, 0.02, 0.01), [0, 1, 2, 3, 4, 5, 6, 7]),
+    # Only two fallers, so take six risers rather than leaving two rows empty.
+    ((0.06, 0.05, 0.04, 0.03, 0.02, 0.01, -0.01, -0.02), [0, 1, 2, 3, 4, 5, 6, 7]),
+    # Only one riser, so take seven fallers.
+    ((0.06, -0.01, -0.02, -0.03, -0.04, -0.05, -0.06, -0.07), [0, 1, 2, 3, 4, 5, 6, 7]),
+])
+def test_biggest_movers_fills_the_table_from_whichever_direction_has_enough(changes: tuple[float, ...], expected: list[int]) -> None:
+    assert [a.id for a in biggest_movers(movers(*changes))] == expected
+
+
+def test_biggest_movers_is_empty_when_nothing_moved() -> None:
+    assert biggest_movers([]) == []


### PR DESCRIPTION
Closes #12568

A "Metagame" section on the home page, above Top Cards, subtitled "Last 7 days". Eight rows: the four archetypes whose share of the metagame rose most over the last 7 days and the four that fell most, versus the 7 days before that, with each archetype's record and win % for the current week.

`/metagame` has no time axis, so movement over a window is the one thing home can say about the metagame that a link to `/metagame` cannot. A static top 8 by deck count was tried in #15109 and reverted in #15172.

## How

- **`_arch_day_stats` preaggregate**: disjoint archetype wins/losses/draws keyed on `(season_id, day, archetype_id, deck_type)`. Keyed on `match.date` rather than deck creation because "what happened this week" is about matches. Bucketed by day so any window length is the same query. ~10s to build nightly, in line with its neighbours.
- **`load_movers_and_shakers()`** reads it in ~20ms. Windows end the day after the season's most recent match, so past seasons show their final week. Meta share is share of all matches in the window. Season filtering is by `season_id`, so nothing bleeds across a rotation.
- **Floor** is `GREATEST(current, previous) >= 6`. Flooring on the current window alone silently hid the most dramatic fallers (e.g. Nadu Combo 90 → 11 matches). An archetype with zero current matches renders as `0.0% ↓2.0 0–0`, which is intended.
- **View** takes 4 risers + 4 fallers, backfilling from whichever side has enough, so week 1 of a season fills with risers.
- **No new CSS.** Direction uses ↑/↓, which the main font provides and the rotation table already uses.

## Validation

- `ruff check .` clean, `mypy decksite/` clean
- 3 functional DB tests + 6 unit tests added, full decksite suite passing
- Rendered against the dev database and eyeballed across seasons 39–43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/88680f42-b00c-4fc7-a94d-9a27ad77a299)
