### PR TITLE
Remove submenu fade transition

### DIFF
--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -921,19 +921,13 @@ When you are in a middle width the main menu is always shown but the submenu is 
     }
 }
 
-/* Fade hover submenus at every width. Touch navigation does not sustain this hover state. */
+/* Show hover submenus at every width. Touch navigation does not sustain this hover state. */
 nav li > .item ~ .submenu {
     display: block;
-    opacity: 0;
-    transition:
-        opacity 0.2s ease,
-        visibility 0s linear 0.2s;
     visibility: hidden;
     width: var(--submenu-width);
 }
 nav li.submenu-open > .item ~ .submenu {
-    opacity: 1;
-    transition-delay: 0s;
     visibility: visible;
     z-index: 3;
 }
@@ -945,7 +939,6 @@ nav li.submenu-open > .item ~ .submenu {
     }
     nav li > .current ~ .submenu {
         display: block;
-        opacity: 1;
         visibility: visible;
         width: var(--submenu-width);
     }


### PR DESCRIPTION
The 0.2s ease-in on the hover submenu was fast enough that it looked like lag rather than an intentional animation. This removes the opacity transition and its visibility delay so the submenu shows and hides instantly. The now-redundant `opacity: 1` on the wide-screen rule is dropped too.

Nothing in the JS depended on the transition, so behaviour is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8f5428ee-e1e4-47fc-a472-6a548ce0eba1)
