### PR TITLE
Prevent preaggregate failures from taking down web requests

### DIFF
--- a/analysis/analysis.py
+++ b/analysis/analysis.py
@@ -8,7 +8,7 @@ from magic.models.card import Card
 from shared import configuration
 from shared.container import Container
 from shared.database import sqlescape
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_list, retry_after_calling
 
 
 def preaggregate() -> None:
@@ -66,7 +66,7 @@ def preaggregate_played_person() -> None:
     """.format(table=table, logsite_database=configuration.get('logsite_database'), season_join=query.season_join())
     preaggregation.preaggregate(table, sql)
 
-@retry_after_calling(preaggregate_played_person)
+@retry_after_calling(preaggregate_played_person, fallback=empty_list)
 def played_cards_by_person(person_id: int, season_id: int) -> list[Card]:
     sql = f"""
         SELECT

--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -302,7 +302,7 @@ def h2h_api() -> Response:
     """
     order_by = clauses.head_to_head_order_by(request.args.get('sortBy'), request.args.get('sortOrder'))
     page, page_size, limit = pagination(request.args)
-    season_id = seasons.season_id(str(request.args.get('seasonId')), None)
+    season_id = cast(int | None, seasons.season_id(str(request.args.get('seasonId')), None))
     person_id = int(request.args.get('personId', 0))
     q = request.args.get('q', '').strip()
     where = clauses.text_match_where('opp.mtgo_username', q) if q else 'TRUE'
@@ -444,7 +444,7 @@ def archetypes2_api() -> Response:
     order_by = clauses.archetype_order_by(request.args.get('sortBy'), request.args.get('sortOrder'))
     page, page_size, limit = pagination(request.args, DEFAULT_GRID_PAGE_SIZE)
     tournament_only = request.args.get('deckType') == 'tournament'
-    season_id = seasons.season_id(str(request.args.get('seasonId')), None)
+    season_id = cast(int | None, seasons.season_id(str(request.args.get('seasonId')), None))
     results, total = archs.load_disjoint_archetypes(where=where, order_by=order_by, limit=limit, season_id=season_id, tournament_only=tournament_only)
     archetype_key_cards = playability.key_cards_long(season_id, [r.id for r in results])
     cards = oracle.cards_by_name()

--- a/decksite/data/achievements.py
+++ b/decksite/data/achievements.py
@@ -12,20 +12,22 @@ from magic import tournaments
 from magic.models import Deck
 from shared import logger
 from shared.container import Container
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_optional, retry_after_calling
 from shared.pd_exception import InvalidArgumentException
 
 LEADERBOARD_TOP_N = 5
 LEADERBOARD_LIMIT = 12
 
 def load_achievements(p: Person | None, season_id: int | None, with_detail: bool = False) -> list[Container]:
+    if with_detail and p is None:
+        raise InvalidArgumentException('A person is required when loading achievement detail.')
     achievements = []
     for a in Achievement.all_achievements:
         desc = Container({'title': a.title, 'description_safe': a.description_safe})
         desc.summary = a.load_summary(season_id=season_id)
         desc.legend = a.display(p) if p else ''
         if with_detail:
-            desc.detail = a.detail(p, season_id=season_id)
+            desc.detail = a.detail(cast(Person, p), season_id=season_id)
         else:
             desc.percent = a.percent(season_id=season_id)
             desc.leaderboard = a.leaderboard(season_id=season_id)
@@ -170,7 +172,7 @@ class Achievement:
         return ''
 
     # Note: load_summary must be overridden if in_db=False!
-    @retry_after_calling(preaggregate_achievements)
+    @retry_after_calling(preaggregate_achievements, fallback=empty_optional)
     def load_summary(self, season_id: int | None = None) -> str | None:
         season_condition = query.season_query(season_id)
         sql = f'SELECT SUM(`{self.key}`) AS num, COUNT(DISTINCT person_id) AS pnum FROM _achievements WHERE `{self.key}` > 0 AND {season_condition}'
@@ -183,7 +185,7 @@ class Achievement:
             return f'Earned{times_text} by {players_text}.'
         return None
 
-    @retry_after_calling(preaggregate_achievements)
+    @retry_after_calling(preaggregate_achievements, fallback=lambda: 0.0)
     def percent(self, season_id: int | None = None) -> float:
         season_condition = query.season_query(season_id)
         sql = f'SELECT SUM(CASE WHEN {self.key} > 0 THEN 1 ELSE 0 END) AS pnum, COUNT(*) AS mnum FROM _achievements WHERE {season_condition}'
@@ -193,7 +195,7 @@ class Achievement:
         except ZeroDivisionError:
             return 0
 
-    @retry_after_calling(preaggregate_achievements)
+    @retry_after_calling(preaggregate_achievements, fallback=empty_optional)
     def detail(self, p: Person, season_id: int | None = None) -> list[Deck] | None:
         if self.detail_sql is None:
             return None
@@ -218,6 +220,7 @@ class Achievement:
             result[f] = True
         return result
 
+    @retry_after_calling(preaggregate_achievements, fallback=empty_optional)
     def leaderboard(self, season_id: int | None = None) -> list[Container] | None:
         season_condition = query.season_query(season_id)
         person_query = query.person_query()
@@ -332,7 +335,7 @@ class TournamentOrganizer(Achievement):
         clarification = ' (all-time)' if season_id != 0 else ''
         return f'Earned by {len(self.hosts)} players{clarification}.'
 
-    @retry_after_calling(preaggregate_achievements)
+    @retry_after_calling(preaggregate_achievements, fallback=lambda: 0.0)
     def percent(self, season_id: int | None = None) -> float:
         sql = 'SELECT COUNT(*) AS mnum FROM _achievements'
         r = db().select(sql)[0]

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -10,7 +10,7 @@ from magic.models import Competition
 from shared import redis_wrapper as redis
 from shared.container import Container
 from shared.database import sqlescape
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_list, empty_page, retry_after_calling
 from shared.pd_exception import DoesNotExistException
 from shared.text import fold_accents, merge_slashes
 
@@ -577,7 +577,7 @@ def preaggregate_matchups_person() -> None:
     """
     preaggregation.preaggregate(table, sql)
 
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_list)
 def load_matchups(where: str = 'TRUE', archetype_id: int | None = None, person_id: int | None = None, season_id: int | None = None, tournament_only: bool = False) -> list[Container]:
     if person_id:
         table = '_matchup_ps_stats'
@@ -615,7 +615,7 @@ def load_matchups(where: str = 'TRUE', archetype_id: int | None = None, person_i
     """
     return [Container(m) for m in db().select(sql)]
 
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_list)
 def load_archetypes(order_by: str | None = None, person_id: int | None = None, season_id: int | None = None, tournament_only: bool = False) -> list[Archetype]:
     if person_id:
         table = '_arch_person_stats'
@@ -661,7 +661,7 @@ def load_archetypes(order_by: str | None = None, person_id: int | None = None, s
     return archs
 
 # Load a list of all archetypes where archetypes categories do NOT include the stats of their children. Thus Aggro is only decks assigned directly to Aggro and does not include Red Deck Wins. See also load_archetypes that does it the other way.
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_page)
 def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, limit: str = '', person_id: int | None = None, season_id: int | None = None, tournament_only: bool = False) -> tuple[list[Archetype], int]:
     if person_id:
         table = '_arch_disjoint_person_stats'
@@ -748,7 +748,7 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
 # season, compared against the `window_days` immediately before that. /metagame has no time axis, so
 # this is the one thing the home page can say about the metagame that a link to /metagame cannot.
 # Both windows are clamped to the season, so nothing from the previous season leaks in over rotation.
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_list)
 def load_movers_and_shakers(season_id: int, window_days: int = WINDOW_DAYS, min_matches: int = MIN_MATCHES) -> list[Archetype]:
     window = window_days * 60 * 60 * 24
     season_query = query.season_query(season_id)

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 
+from decksite import APP
 from decksite.data import archetype, clauses
 from decksite.database import db
 from decksite.testutil import with_test_db
@@ -48,6 +49,15 @@ def test_assign_clears_cached_deck_after_committing(monkeypatch: pytest.MonkeyPa
 
     database.commit.assert_called_once_with('assign_archetype')
     clear.assert_called_once_with('decksite:deck:42')
+
+
+@with_test_db
+@pytest.mark.functional
+def test_missing_movers_preaggregate_returns_no_data_during_a_web_request() -> None:
+    with APP.test_request_context('/'):
+        assert archetype.load_movers_and_shakers(1) == []
+
+    assert db().value("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = DATABASE() AND table_name = '_arch_day_stats'") == 0
 
 
 @with_test_db

--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -5,7 +5,7 @@ from magic.models import Card
 from shared import guarantee
 from shared.container import Container
 from shared.database import sqlescape
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_dict, empty_list, empty_page, retry_after_calling
 
 
 def load_competition_cards(competition_id: int, order_by: str, limit: str) -> tuple[list[Card], int]:
@@ -255,7 +255,6 @@ def preaggregate_trailblazer() -> None:
     """
     preaggregation.preaggregate(table, sql)
 
-@retry_after_calling(preaggregate)
 def load_cards(
         additional_where: str = 'TRUE',
         order_by: str = 'num_decks DESC, record, name',
@@ -270,6 +269,7 @@ def load_cards(
     cs, _ = load_cards_with_total(additional_where, order_by, limit, archetype_id, competition_id, person_id, season_id, tournament_only, all_legal)
     return cs
 
+@retry_after_calling(preaggregate, fallback=empty_page)
 def load_cards_with_total(
         additional_where: str = 'TRUE',
         order_by: str = 'num_decks DESC, record, name',
@@ -333,7 +333,6 @@ def load_cards_with_total(
         c.played_competitively = c.wins or c.draws or c.losses
     return cs, 0 if not rs else rs[0]['total']
 
-@retry_after_calling(preaggregate_card)
 def load_card(name: str, tournament_only: bool = False, season_id: int | None = None) -> Card:
     cs = load_cards(additional_where=f'name = {sqlescape(name)}', order_by='NULL', season_id=season_id, tournament_only=tournament_only)
     c = guarantee.at_most_one(cs)
@@ -346,7 +345,7 @@ def load_card(name: str, tournament_only: bool = False, season_id: int | None = 
     c.win_percent = None
     return c
 
-@retry_after_calling(preaggregate_unique)
+@retry_after_calling(preaggregate_unique, fallback=empty_list)
 def unique_cards_played(person_id: int) -> list[str]:
     sql = """
         SELECT
@@ -358,7 +357,7 @@ def unique_cards_played(person_id: int) -> list[str]:
     """
     return db().values(sql, [person_id])
 
-@retry_after_calling(preaggregate_trailblazer)
+@retry_after_calling(preaggregate_trailblazer, fallback=empty_dict)
 def trailblazer_cards(person_id: int) -> dict[str, int]:
     sql = """
         SELECT

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -6,7 +6,7 @@ from decksite.database import db
 from shared import dtutil, guarantee, logger
 from shared.container import Container
 from shared.database import sqlescape
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_page, retry_after_calling
 from shared.pd_exception import AlreadyExistsException, DatabaseException, DoesNotExistException
 
 
@@ -210,7 +210,7 @@ def preaggregate_head_to_head() -> None:
     """
     preaggregation.preaggregate(table, sql)
 
-@retry_after_calling(achievements.preaggregate_achievements)
+@retry_after_calling(achievements.preaggregate_achievements, fallback=lambda: None)
 def set_achievements(people: list[Person], season_id: int | None = None) -> None:
     people_by_id = {person.id: person for person in people}
     sql = achievements.load_query(people_by_id, season_id)
@@ -220,7 +220,7 @@ def set_achievements(people: list[Person], season_id: int | None = None) -> None
         people_by_id[result['id']].achievements = result
         people_by_id[result['id']].achievements.pop('id')
 
-@retry_after_calling(preaggregate_head_to_head)
+@retry_after_calling(preaggregate_head_to_head, fallback=empty_page)
 def load_head_to_head(person_id: int, where: str = 'TRUE', order_by: str = 'num_matches DESC, record DESC, win_percent DESC, wins DESC, opp_mtgo_username', limit: str = '', season_id: int | None = None) -> tuple[Sequence[Container], int]:
     season_query = query.season_query(season_id)
     sql = f"""

--- a/decksite/data/playability.py
+++ b/decksite/data/playability.py
@@ -4,7 +4,7 @@ from find import search
 from shared import logger
 from shared.container import Container
 from shared.database import sqlescape
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_dict, empty_list, retry_after_calling
 from shared.pd_exception import DatabaseNoSuchTableException
 
 SIDEBOARD_WEIGHT = 0.2
@@ -25,13 +25,13 @@ def preaggregate() -> None:
     preaggregate_season_playability()
     preaggregate_playability()
 
-def _season_table_and_where(season_id: int) -> tuple[str, str]:
+def _season_table_and_where(season_id: int | None) -> tuple[str, str]:
     if season_id:
         return '_season_archetype_playability', f'p.season_id = {season_id}'
     return '_archetype_playability', 'TRUE'
 
 # Map of archetype_id => cardname where cardname is the key card for that archetype for the supplied season, or all time if 0 supplied as season_id.
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_dict)
 def key_cards(season_id: int) -> dict[int, str]:
     table, where = _season_table_and_where(season_id)
     sql = f"""
@@ -58,8 +58,8 @@ def key_cards(season_id: int) -> dict[int, str]:
     return {r['archetype_id']: r['name'] for r in db().select(sql)}
 
 
-@retry_after_calling(preaggregate)
-def key_cards_long(season_id: int, archetype_ids: list[int] | None = None) -> dict[int, list[str]]:
+@retry_after_calling(preaggregate, fallback=empty_dict)
+def key_cards_long(season_id: int | None, archetype_ids: list[int] | None = None) -> dict[int, list[str]]:
     table, where = _season_table_and_where(season_id)
     where = f'({where}) AND p.playability > {USEFUL_PLAYABILITY_THRESHOLD}'
     if archetype_ids is not None:
@@ -85,7 +85,7 @@ def key_cards_long(season_id: int, archetype_ids: list[int] | None = None) -> di
         r[row['archetype_id']] = r.get(row['archetype_id'], []) + [row['name']]
     return r
 
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_dict)
 def playability() -> dict[str, float]:
     sql = """
         SELECT
@@ -96,7 +96,7 @@ def playability() -> dict[str, float]:
     """
     return {r['name']: float(r['playability']) for r in db().select(sql)}
 
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_list)
 def season_playability(season_id: int) -> list[Container]:
     # This is a temporary thing used to generate banners.
     # Feel free to replace it with something better.
@@ -113,7 +113,7 @@ def season_playability(season_id: int) -> list[Container]:
     """
     return [Container(r) for r in db().select(sql)]
 
-@retry_after_calling(preaggregate)
+@retry_after_calling(preaggregate, fallback=empty_dict)
 def rank() -> dict[str, int]:
     sql = query.ranks_select()
     return {r['name']: r['rank'] for r in db().select(sql)}

--- a/decksite/data/preaggregation.py
+++ b/decksite/data/preaggregation.py
@@ -1,14 +1,15 @@
 from decksite.database import db
 from shared import logger
-from shared.pd_exception import DatabaseException
+from shared.pd_exception import LockNotAcquiredException
 
 
 def preaggregate(table: str, sql: str) -> None:
     lock_key = f'preaggregation:{table}'
     try:
         db().get_lock(lock_key, 60 * 5)
-    except DatabaseException as e:
+    except LockNotAcquiredException as e:
         logger.warning(f'Not preaggregating {table} because of {e}')
+        return
     db().execute('SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED')
     db().execute(f'DROP TABLE IF EXISTS _new{table}')
     db().execute(sql)

--- a/decksite/data/preaggregation_test.py
+++ b/decksite/data/preaggregation_test.py
@@ -1,0 +1,17 @@
+from unittest import mock
+
+import pytest
+
+from decksite.data import preaggregation
+from shared.pd_exception import LockNotAcquiredException
+
+
+def test_preaggregate_does_not_rebuild_without_the_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    database = mock.Mock()
+    database.get_lock.side_effect = LockNotAcquiredException
+    monkeypatch.setattr(preaggregation, 'db', lambda: database)
+
+    preaggregation.preaggregate('_example', 'CREATE TABLE _new_example (_ INT)')
+
+    database.execute.assert_not_called()
+    database.release_lock.assert_not_called()

--- a/decksite/data/rule.py
+++ b/decksite/data/rule.py
@@ -6,7 +6,7 @@ from magic.decklist import parse_line
 from magic.models import Deck
 from shared import logger
 from shared.container import Container
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_list, retry_after_calling
 from shared.pd_exception import InvalidDataException
 
 IGNORE: list[str] = ['Commander', 'Unclassified']
@@ -75,12 +75,12 @@ def cache_all_rules() -> None:
     preaggregation.preaggregate(table, sql)
     logger.warning(f'Done creating {table}')
 
-@retry_after_calling(cache_all_rules)
+@retry_after_calling(cache_all_rules, fallback=lambda: 0)
 def num_classified_decks() -> int:
     sql = 'SELECT COUNT(DISTINCT(deck_id)) AS c FROM _applied_rules'
     return db().value(sql)
 
-@retry_after_calling(cache_all_rules)
+@retry_after_calling(cache_all_rules, fallback=empty_list)
 def mistagged_decks() -> list[Deck]:
     sql = """
             SELECT
@@ -117,7 +117,7 @@ def mistagged_decks() -> list[Deck]:
         d.rule_id, d.rule_archetype_id, d.rule_archetype_name = rule_archetypes[d.id]
     return result
 
-@retry_after_calling(cache_all_rules)
+@retry_after_calling(cache_all_rules, fallback=empty_list)
 def doubled_decks() -> list[Deck]:
     sql = """
         SELECT
@@ -145,7 +145,7 @@ def doubled_decks() -> list[Deck]:
         d.archetypes_from_rules_names = ', '.join(f'{a.archetype_name} ({a.rule_id})' for a in archetypes_from_rules[d.id])
     return result
 
-@retry_after_calling(cache_all_rules)
+@retry_after_calling(cache_all_rules, fallback=empty_list)
 def overlooked_decks() -> list[Deck]:
     sql = """
             SELECT
@@ -174,7 +174,7 @@ def overlooked_decks() -> list[Deck]:
     ds = deck.load_decks(where=f'd.id IN ({ids_list})')
     return ds
 
-@retry_after_calling(cache_all_rules)
+@retry_after_calling(cache_all_rules, fallback=empty_list)
 def load_all_rules() -> list[Container]:
     result = []
     result_by_id = {}

--- a/decksite/data/season.py
+++ b/decksite/data/season.py
@@ -5,7 +5,7 @@ from decksite.database import db
 from shared import dtutil
 from shared.container import Container
 from shared.database import sqlescape
-from shared.decorators import retry_after_calling
+from shared.decorators import empty_dict, retry_after_calling
 from shared.pd_exception import InvalidDataException
 
 SEASONS: list[Container] = []
@@ -118,7 +118,7 @@ def preaggregate_season_stats() -> None:
     values_s = ', '.join(values)
     db().execute(f'INSERT INTO {table} VALUES {values_s}')
 
-@retry_after_calling(preaggregate_season_stats)
+@retry_after_calling(preaggregate_season_stats, fallback=empty_dict)
 def season_stats() -> dict[int, dict[str, int | datetime.datetime]]:
     sql = """
         SELECT

--- a/shared/decorators.py
+++ b/shared/decorators.py
@@ -1,53 +1,140 @@
 import functools
 import logging
-import os
+import pathlib
+import subprocess
+import sys
+import threading
+import time
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import cast
 
-import fasteners
-import six
+from flask import has_request_context
 
-from shared.pd_exception import DatabaseException
-
-T = TypeVar('T')
-FuncType = Callable[..., T]
+from shared import configuration
+from shared.database import get_database
+from shared.pd_exception import DatabaseException, LockNotAcquiredException
 
 logger = logging.getLogger(__name__)
 
-def retry_after_calling(retry_func: Callable[[], None]) -> Callable[[FuncType[T]], FuncType[T]]:
-    def decorator(decorated_func: FuncType[T]) -> FuncType[T]:
+_REPRIME_COOLDOWN_SECONDS = 5 * 60
+_last_reprime_schedule: float | None = None
+_reprime_schedule_lock = threading.Lock()
+
+
+def empty_dict[K, V]() -> dict[K, V]:
+    return {}
+
+
+def empty_list[T]() -> list[T]:
+    return []
+
+
+def empty_optional[T]() -> T | None:
+    return None
+
+
+def empty_page[T]() -> tuple[list[T], int]:
+    return [], 0
+
+
+def schedule_reprime_cache() -> None:
+    """Start a detached reprime in production, at most once per worker per cooldown period.
+
+    The task runner's system-wide, non-blocking lock ensures that processes spawned by different
+    web workers or hosts cannot actually run concurrently.
+    """
+    if not configuration.production.value:
+        return
+
+    global _last_reprime_schedule
+    with _reprime_schedule_lock:
+        now = time.monotonic()
+        if _last_reprime_schedule is not None and now - _last_reprime_schedule < _REPRIME_COOLDOWN_SECONDS:
+            return
+        root = pathlib.Path(__file__).resolve().parent.parent
+        python = pathlib.Path(sys.prefix) / 'bin' / 'python'
+        try:
+            subprocess.Popen(
+                [str(python), str(root / 'run.py'), 'maintenance', 'reprime_cache'],
+                cwd=root,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        except OSError:
+            logger.exception('Unable to schedule reprime_cache in the background.')
+            return
+        _last_reprime_schedule = now
+        logger.warning('Scheduled reprime_cache in the background after a database read failed.')
+
+
+class _RetryAfterCalling:
+    def __init__(self, retry_func: Callable[[], None], fallback: Callable[[], object]) -> None:
+        self.retry_func = retry_func
+        self.fallback = fallback
+
+    def __call__[**P, T](self, decorated_func: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(decorated_func)
-        def wrapper(*args: list[Any], **kwargs: dict[str, Any]) -> Any:
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             try:
                 return decorated_func(*args, **kwargs)
             except DatabaseException as e:
-                logger.error(f"Got {e} trying to call {decorated_func.__name__} so calling {retry_func.__name__} first. If this is happening on user time that's undesirable.")
-                retry_func()
+                if has_request_context():  # type: ignore
+                    logger.error(f"Got {e} trying to call {decorated_func.__name__}. Returning its fallback during a web request.")
+                    schedule_reprime_cache()
+                    return cast(T, self.fallback())
+                logger.error(f"Got {e} trying to call {decorated_func.__name__} outside a web request, so calling {self.retry_func.__name__} first.")
+                self.retry_func()
                 try:
                     return decorated_func(*args, **kwargs)
                 except DatabaseException:
                     logger.error("That didn't help, giving up.")
                     raise
         return wrapper
-    return decorator
 
-def lock[T](func: FuncType[T]) -> T:
+
+def retry_after_calling(retry_func: Callable[[], None], *, fallback: Callable[[], object]) -> _RetryAfterCalling:
+    """Retry failed database reads outside HTTP requests; return declared empty data within them.
+
+    Requiring every caller to declare a typed fallback makes a new preaggregate-backed loader fail
+    during development if its no-data behavior has not been considered explicitly.
+    """
+    return _RetryAfterCalling(retry_func, fallback)
+
+
+def lock[T](func: Callable[..., T]) -> T:
     return func()
 
-def interprocess_locked(path: str) -> Callable:
-    """Acquires & releases a interprocess lock around call into
-       decorated function."""
 
-    lock = fasteners.InterProcessLock(path)
+class _SystemwideLock:
+    def __init__(self, lock_key: str) -> None:
+        self.lock_key = lock_key
 
-    def decorator(f: Callable) -> Callable:
-        @six.wraps(f)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            with lock:
-                r = f(*args, **kwargs)
-            os.remove(path)
-            return r
-
+    def __call__[**P](self, f: Callable[P, None]) -> Callable[P, None]:
+        @functools.wraps(f)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
+            lock_db = get_database(configuration.get_str('decksite_database'))
+            acquired = False
+            try:
+                try:
+                    lock_db.get_lock(self.lock_key, 0)
+                    acquired = True
+                except LockNotAcquiredException:
+                    logger.warning(f'Not running {f.__name__} because system-wide lock {self.lock_key} is already held.')
+                    return
+                return f(*args, **kwargs)
+            finally:
+                try:
+                    if acquired:
+                        lock_db.release_lock(self.lock_key)
+                finally:
+                    lock_db.close()
         return wrapper
 
-    return decorator
+
+def interprocess_locked(path: str) -> _SystemwideLock:
+    """Allow only one system-wide run, without queueing duplicate invocations.
+
+    MySQL named locks are shared by every process and host using the same production database,
+    unlike the old checkout-relative file lock. They are also released if a process exits.
+    """
+    return _SystemwideLock(f'penny-dreadful-tools:{path}')

--- a/shared/decorators_test.py
+++ b/shared/decorators_test.py
@@ -1,0 +1,136 @@
+import pathlib
+import subprocess
+import sys
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from flask import Flask
+
+from shared import configuration, decorators
+from shared.database import get_database
+from shared.pd_exception import DatabaseException, LockNotAcquiredException
+
+
+def named_mock(name: str, **kwargs: object) -> mock.Mock:
+    result = mock.Mock(**kwargs)
+    result.__name__ = name
+    return result
+
+
+def test_retry_after_calling_requires_the_developer_to_choose_a_fallback() -> None:
+    retry = named_mock('retry')
+
+    with pytest.raises(TypeError, match='fallback'):
+        decorators.retry_after_calling(retry)  # type: ignore[call-arg]
+
+
+def test_retry_after_calling_retries_outside_a_web_request() -> None:
+    retry = named_mock('retry')
+    decorated = named_mock('decorated', side_effect=[DatabaseException('missing'), 'ok'])
+    wrapped = decorators.retry_after_calling(retry, fallback=list)(decorated)
+
+    assert wrapped() == 'ok'
+    retry.assert_called_once_with()
+
+
+def test_retry_after_calling_returns_fallback_and_schedules_reprime_during_a_web_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = Flask(__name__)
+    retry = named_mock('retry')
+    fallback = mock.Mock(return_value=['empty'])
+    schedule = mock.Mock()
+    monkeypatch.setattr(decorators, 'schedule_reprime_cache', schedule)
+
+    @decorators.retry_after_calling(retry, fallback=fallback)
+    def unavailable() -> list[str]:
+        raise DatabaseException('missing')
+
+    with app.test_request_context('/'):
+        assert unavailable() == ['empty']
+
+    retry.assert_not_called()
+    fallback.assert_called_once_with()
+    schedule.assert_called_once_with()
+
+
+def test_schedule_reprime_cache_is_production_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    popen = mock.Mock()
+    monkeypatch.setitem(configuration.CONFIG, 'production', False)
+    monkeypatch.setattr(decorators.subprocess, 'Popen', popen)
+
+    decorators.schedule_reprime_cache()
+
+    popen.assert_not_called()
+
+
+def test_schedule_reprime_cache_detaches_once_per_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    popen = mock.Mock()
+    monkeypatch.setitem(configuration.CONFIG, 'production', True)
+    monkeypatch.setattr(decorators.subprocess, 'Popen', popen)
+    monkeypatch.setattr(decorators.time, 'monotonic', lambda: 42.0)
+    monkeypatch.setattr(decorators, '_last_reprime_schedule', None)
+
+    decorators.schedule_reprime_cache()
+    decorators.schedule_reprime_cache()
+
+    root = pathlib.Path(decorators.__file__).resolve().parent.parent
+    python = pathlib.Path(sys.prefix) / 'bin' / 'python'
+    popen.assert_called_once_with(
+        [str(python), str(root / 'run.py'), 'maintenance', 'reprime_cache'],
+        cwd=root,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def test_interprocess_locked_uses_a_nonblocking_systemwide_database_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    lock_db = mock.Mock()
+    monkeypatch.setattr(decorators, 'get_database', mock.Mock(return_value=lock_db))
+    work = mock.Mock(return_value=None)
+    work.__name__ = 'work'
+
+    wrapped = decorators.interprocess_locked('.task.lock')(work)
+
+    assert wrapped() is None
+    work.assert_called_once_with()
+    lock_db.get_lock.assert_called_once_with('penny-dreadful-tools:.task.lock', 0)
+    lock_db.release_lock.assert_called_once_with('penny-dreadful-tools:.task.lock')
+    lock_db.close.assert_called_once_with()
+
+
+def test_interprocess_locked_does_not_queue_another_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    lock_db = mock.Mock()
+    lock_db.get_lock.side_effect = LockNotAcquiredException
+    monkeypatch.setattr(decorators, 'get_database', mock.Mock(return_value=lock_db))
+    work = mock.Mock()
+    work.__name__ = 'work'
+
+    wrapped = decorators.interprocess_locked('.task.lock')(work)
+
+    assert wrapped() is None
+    work.assert_not_called()
+    lock_db.release_lock.assert_not_called()
+    lock_db.close.assert_called_once_with()
+
+
+@pytest.mark.functional
+def test_interprocess_locked_contends_across_real_database_connections() -> None:
+    path = f'.test-{uuid4()}.lock'
+    lock_key = f'penny-dreadful-tools:{path}'
+    holder = get_database(configuration.get_str('decksite_database'))
+    calls: list[bool] = []
+
+    @decorators.interprocess_locked(path)
+    def work() -> None:
+        calls.append(True)
+
+    holder.get_lock(lock_key, 0)
+    try:
+        work()
+        assert calls == []
+    finally:
+        holder.release_lock(lock_key)
+        holder.close()
+
+    work()
+    assert calls == [True]


### PR DESCRIPTION
## Summary

- return an explicitly declared empty fallback when a preaggregate-backed read fails during an HTTP request, instead of rebuilding synchronously on user time
- schedule a detached production `reprime_cache` after a failed read, with a per-worker cooldown and a non-blocking MySQL named lock that permits only one system-wide maintenance task
- require every `retry_after_calling` user to choose its fallback, so new loaders cannot silently inherit unsafe request behavior
- stop a per-table preaggregate rebuild when its lock is unavailable instead of continuing without the lock
- cover the original missing `_arch_day_stats` deployment failure and real MariaDB lock contention with regression tests

## Validation

- `uv run ruff check .`
- `uv run mypy decksite/ shared/`
- focused regression suite: 16 passed
- full non-logsite suite: 1009 passed, 2 skipped, 2 deselected

The two deselected tests are newly landed `master` archetype tests that insert names already present in this workspace's persistent development database; neither test nor its implementation is changed by this PR.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/88680f42-b00c-4fc7-a94d-9a27ad77a299)
