### PR TITLE
Require the browser job to merge, add a production canary, update the docs

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,51 @@
+name: Production Canary
+# Merged code reaches production within minutes via a deploy hook. This runs the read-only browser smoke tests
+# (decksite/browser_test.py) against the live site shortly after every push to master and on a schedule, so a
+# regression that CI could not see (empty tables, invisible menu, JS errors) is caught in minutes, not from user reports.
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: '17 */2 * * *'
+  workflow_dispatch:
+    inputs:
+      url:
+        description: Site to check
+        default: https://pennydreadfulmagic.com
+
+concurrency:
+  group: production-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    name: canary
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.13'
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        version: '0.9.26'
+        enable-cache: true
+    - name: Install dependencies
+      run: uv sync --frozen --dev
+    - name: Install Chromium
+      run: uv run --frozen playwright install --with-deps chromium
+    - name: Wait for the deploy hook
+      if: github.event_name == 'push'
+      run: sleep 90
+    - name: Run browser tests against production
+      env:
+        PD_BROWSER_BASE_URL: ${{ github.event.inputs.url || 'https://pennydreadfulmagic.com' }}
+      run: uv run --frozen pytest --no-cov -p no:cacheprovider --noconftest decksite/browser_test.py
+    - name: Notify Discord
+      if: failure() && env.DISCORD_WEBHOOK_URL != ''
+      env:
+        DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      run: |
+        curl -sS -H 'Content-Type: application/json' -d "{\"content\": \"Production canary FAILED after ${{ github.event_name }} (${{ github.sha }}): ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\"}" "$DISCORD_WEBHOOK_URL"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,6 +9,7 @@ queue_rules:
       - status-success=lint
       - status-success=test
       - status-success=jslint
+      - status-success=browser
       - base=master
     merge_conditions:
       # Conditions to get out of the queue (= merged)
@@ -16,6 +17,7 @@ queue_rules:
       - status-success=lint
       - status-success=test
       - status-success=jslint
+      - status-success=browser
     merge_method: rebase
   - name: trusted
     queue_conditions:
@@ -28,6 +30,7 @@ queue_rules:
       - status-success=lint
       - status-success=test
       - status-success=jslint
+      - status-success=browser
     merge_method: merge
   - name: default
     merge_conditions:
@@ -36,6 +39,7 @@ queue_rules:
       - status-success=lint
       - status-success=test
       - status-success=jslint
+      - status-success=browser
 
 pull_request_rules:
   - name: automatic merge dependency updates
@@ -44,6 +48,7 @@ pull_request_rules:
       - status-success=lint
       - status-success=test
       - status-success=jslint
+      - status-success=browser
       - author~=(pyup-bot|dependabot)
       - -files~=^(!?.github/workflows/)
     actions:
@@ -67,6 +72,7 @@ priority_rules:
       - status-success=lint
       - status-success=test
       - status-success=jslint
+      - status-success=browser
     priority: 2500
     allow_checks_interruption: true
   - name: priority for queue `trusted`

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ There are various levels of granularity but in general use you want:
 
 Check the dev.py source code for the full set of options including `unit`, `types`, `lint` (covered by `test` above) as well as `functional` (integration tests), `perf` (performance tests). `release` will take you all the way from your committed change to a PR via the tests (needs GitHub's commandline `gh` installed).
 
+Two more targets look at what a user would actually see, because a page can return 200 and still be broken:
+
+- `uv run --frozen python dev.py smoke` renders every page that has a "live" React table against a small seeded database (`decksite/conftest.py`), makes exactly the API request the browser's DataManager would make from the page's `data-*` attributes, and checks rows come back. A few seconds. Run it when you touch templates, CSS, JSX, `decksite/controllers/api.py` or `decksite/data/clauses.py`.
+- `uv run --frozen python dev.py browser` loads real pages in headless Chromium (`decksite/browser_test.py`): live tables fill, no request fails, no JavaScript throws, and the navigation submenu is genuinely visible and clickable at mobile, medium and wide widths, by mouse and by touch. Needs `uv run --frozen playwright install chromium` once and a built JS bundle. About 30 seconds. `--url https://pennydreadfulmagic.com` runs the same checks read-only against a deployed site; the `Production Canary` GitHub workflow does that after every push to master and every two hours.
+
+CI runs the browser tests as a separate `browser` job, in parallel, so they add no time to the main test job. It is a required check: `.mergify.yml` lists it alongside `mypy`, `lint`, `test` and `jslint`, so a red `browser` job blocks the merge.
+
 ### Validating card-import changes
 
 Changes to the Scryfall importer should also be checked with two disposable databases made from exactly the same bulk data:

--- a/backlog_sweep/FIXER_PROMPT.md
+++ b/backlog_sweep/FIXER_PROMPT.md
@@ -78,10 +78,22 @@ Never print the contents of `config.json`; it holds real credentials.
      full suite once the bootstrap above has run). If the environment cannot run
      these, record exactly what you ran and what failed for environmental reasons in
      `tests.detail` — do NOT claim tests passed if they didn't run.
+   - **If you touched a template, CSS, JS/JSX, `decksite/controllers/api.py` or
+     `decksite/data/clauses.py`, also run `uv run --frozen python dev.py smoke`**
+     (renders every page with a live table against a seeded database and makes the
+     API calls the browser would make; a few seconds, needs the database from the
+     bootstrap). For CSS/JS/menu changes additionally run
+     `uv run --frozen playwright install chromium && uv run --frozen python dev.py browser`
+     (headless Chromium: tables fill, no JS errors, menu usable at every width).
+     A 200 from a page is not evidence that the page works; two sweep PRs in
+     September 2026 shipped an invisible menu and an empty /decks/ with green CI.
 4. Self-review `git diff origin/master...` — every hunk must serve #{{ISSUE}}.
-5. Commit (imperative one-line summary mentioning the issue, e.g.
+5. Never mark a PR ready for review, never approve, and never comment `@mergifyio`
+   anything. Those are the human's actions; doing them yourself is how unreviewed
+   code reached production on 2026-09-02.
+6. Commit (imperative one-line summary mentioning the issue, e.g.
    `Fix <thing> (#{{ISSUE}})`) and push: `git push -u origin {{BRANCH}}`.
-6. Write the PR title/body for the dispatcher. Body must contain: what was wrong,
+7. Write the PR title/body for the dispatcher. Body must contain: what was wrong,
    what changed, how it was validated (including any environmental test caveats,
    honestly disclosed), and the line `Fixes #{{ISSUE}}`.
 
@@ -133,9 +145,10 @@ command ran and passed.
   `logsite_migrations/`, `.github/workflows/`, `Dockerfile`, `setup.py`,
   `pyproject.toml` dependency sections) then opens the PR:
   `gh pr create --base master --head <branch> --title … --body-file … --draft`
-  (**draft is mandatory** — see `DISPATCHER_SPEC.md` §8; Mergify auto-merges
-  non-draft PRs authored by bakert, so draft is the merge brake, and bakert marks
-  a PR ready for review when he has reviewed it). The dispatcher verifies
+  (**draft is mandatory** — see `DISPATCHER_SPEC.md` §8. No Mergify rule matches
+  PRs authored by bakert, so nothing merges one until a human clicks merge or
+  comments `@mergifyio queue`; draft keeps it off the reviewable pile until
+  bakert has reviewed it and marks it ready). The dispatcher verifies
   `isDraft=true` before journaling `PR_OPENED` and closes the PR if it is not.
   Validation failure ⇒ escalate, do not open the PR.
 - `tests.result != "passed"` does not block the PR but must be disclosed in the body

--- a/backlog_sweep/RUNBOOK.md
+++ b/backlog_sweep/RUNBOOK.md
@@ -53,8 +53,11 @@ Then, deliberately and in this order:
 
 ## Operating rules that are not optional
 
-- PRs are **drafts, always** (Mergify auto-merges non-draft green PRs authored by
-  the automerge team — draft is the merge brake). The owner's review action is
+- PRs are **drafts, always**, and the sweep **never comments `@mergifyio`
+  anything**. The second half is the one that matters. Sweep PRs are authored by
+  bakert, and no Mergify rule auto-queues that author, so an undrafted sweep PR
+  sits there until a human acts. `@mergifyio queue` is that action, and it is
+  what merged 25 PRs unreviewed. The owner's review action is approving and
   marking ready-for-review.
 - The sweep **never merges, never force-pushes, never touches labels**, never
   edits `.github/workflows/`, migrations, or dependency manifests.
@@ -149,7 +152,9 @@ into the prompt files here via a normal PR.
 
 ## Lessons register (hard-won, do not relearn)
 
-- The "do not merge" label does nothing in this repo; drafts are the only brake.
+- The "do not merge" label does nothing in this repo. Nothing auto-merges a
+  bakert-authored PR either: no Mergify rule matches that author. What merges one
+  is a person typing `@mergifyio queue` or clicking merge.
 - `updatedAt` is useless as an activity guard (bulk labelling touches everything);
   use non-bot comments.
 - Data-retention changes are never easy-fixes (#12781).
@@ -157,3 +162,22 @@ into the prompt files here via a normal PR.
   commits already settled the question before classifying.
 - Trust nothing you didn't verify: check `isDraft` after PR creation, check
   workspace state after archiving, fetch before verifying claims against master.
+- Green CI is not "works". Merged code is live within minutes via the deploy
+  hook, and on 2026-09-02 a batch of ~25 sweep PRs was marked ready and merged
+  without a human looking; two shipped user-visible breakage (invisible menu,
+  empty /decks/) that no test could see because nothing rendered a page with
+  data or ran a browser. Now `dev.py smoke` and `dev.py browser` exist, a
+  `browser` CI job runs the latter on every PR, and the `Production Canary`
+  workflow checks the live site after every push to master. `browser` is a
+  required check in `.mergify.yml`, so a red one blocks the merge.
+- `@mergifyio queue` is the hole. The agent marked the PRs ready and commented
+  it with the owner's own GitHub token. Only the first queue rule requires
+  `#approved-reviews-by>=1`. The `default` queue has no queue conditions at all,
+  so anything sent there merges on green checks alone, review or no review. That
+  is the route the 25 PRs took. The owner has decided to leave it: requiring an
+  approval would mean another maintainer approving every one of his PRs, since
+  GitHub blocks self-approval. The control is elsewhere: the token an agent runs
+  with cannot comment on PRs, so it cannot queue anything. The rule stands on
+  behaviour as well as scope: never run Mergify commands, never approve, never
+  mark a PR ready. A human does that, one PR at a time, and after a batch someone
+  watches the canary and the site.


### PR DESCRIPTION
Follow-up to #15174, whose `browser` job is now on master and green.

- **`.mergify.yml`** — `status-success=browser` added in all six places `mypy`, `lint`, `test` and `jslint` appear. Nothing removed. After this lands, open PRs need "Update branch" before they can merge, since their CI runs predate the job.
- **`.github/workflows/canary.yml`** — runs the read-only browser tests (`decksite/browser_test.py`) against pennydreadfulmagic.com after every push to master (90s after, for the deploy hook), every two hours, and on dispatch with a URL. Posts to Discord on failure if a `DISCORD_WEBHOOK_URL` secret exists; silent otherwise.
- **README, `backlog_sweep/RUNBOOK.md`, `backlog_sweep/FIXER_PROMPT.md`** — document `dev.py smoke` and `dev.py browser`, and correct the merge mechanics: no Mergify rule matches bakert-authored PRs, so nothing merges one until a human queues it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
