### PR TITLE
Add AGENTS.md and CLAUDE.md for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Working in this repo
+
+## Merging pull requests
+
+To merge a PR, comment `@mergifyio queue` on it (for example `gh pr comment <number> --body "@mergifyio queue"`).
+Mergify then merges it once the mypy, lint, test and jslint checks pass.
+
+Do not use the "merge when ready" label. It is a leftover from an old CI setup and Mergify ignores it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds an `AGENTS.md` with instructions for coding agents working in this repo, and a one-line `CLAUDE.md` that points at it (Claude Code reads CLAUDE.md, most other agents read AGENTS.md).

It records how PRs get merged here: comment `@mergifyio queue`, never the stale "merge when ready" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)