### PR TITLE
Run the production canary without a database

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -42,7 +42,9 @@ jobs:
     - name: Run browser tests against production
       env:
         PD_BROWSER_BASE_URL: ${{ github.event.inputs.url || 'https://pennydreadfulmagic.com' }}
-      run: uv run --frozen pytest --no-cov -p no:cacheprovider --noconftest decksite/browser_test.py
+        PYTHONPATH: .
+      # importlib mode imports the test file without importing the decksite package, whose __init__ opens a database connection; there is no database here.
+      run: uv run --frozen pytest --no-cov -p no:cacheprovider --noconftest --import-mode=importlib decksite/browser_test.py
     - name: Notify Discord
       if: failure() && env.DISCORD_WEBHOOK_URL != ''
       env:

--- a/dev.py
+++ b/dev.py
@@ -182,7 +182,9 @@ def do_browser(base_url: str | None) -> None:
     if base_url:
         print(f'>>>> Running browser tests against {base_url}')
         env['PD_BROWSER_BASE_URL'] = base_url
-        args = ['--noconftest']  # The root conftest wants a cards database; the canary needs nothing but a browser.
+        env['PYTHONPATH'] = '.'
+        # The root conftest wants a cards database and importing the decksite package opens a connection; the canary needs nothing but a browser.
+        args = ['--noconftest', '--import-mode=importlib']
     else:
         print('>>>> Running browser tests against a local server (needs a database and a built JS bundle)')
         env['PD_BROWSER_TESTS'] = '1'


### PR DESCRIPTION
The first canary run after #15186 failed at collection: importing `decksite/browser_test.py` imports the `decksite` package, whose `__init__` opens a database connection, and the canary runner has no database.

`--import-mode=importlib` loads the test file without importing the package. `dev.py browser --url` does the same so it mirrors the canary. Verified locally with `mysql_port=1`: 6 passed against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
