### PR TITLE
Run the canary's browser tests from outside the decksite package

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -43,8 +43,11 @@ jobs:
       env:
         PD_BROWSER_BASE_URL: ${{ github.event.inputs.url || 'https://pennydreadfulmagic.com' }}
         PYTHONPATH: .
-      # importlib mode imports the test file without importing the decksite package, whose __init__ opens a database connection; there is no database here.
-      run: uv run --frozen pytest --no-cov -p no:cacheprovider --noconftest --import-mode=importlib decksite/browser_test.py
+      # Collecting a test inside the decksite package imports decksite/__init__.py, which opens a database connection, and there is no database here.
+      # So run a copy of the file from outside the package. Same as dev.py browser --url.
+      run: |
+        mkdir -p /tmp/canary && cp decksite/browser_test.py /tmp/canary/
+        uv run --frozen pytest --no-cov -p no:cacheprovider --noconftest --rootdir=/tmp/canary -o markers=browser /tmp/canary/browser_test.py
     - name: Notify Discord
       if: failure() && env.DISCORD_WEBHOOK_URL != ''
       env:

--- a/dev.py
+++ b/dev.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 import time
 from collections.abc import Iterable
 
@@ -183,13 +185,16 @@ def do_browser(base_url: str | None) -> None:
         print(f'>>>> Running browser tests against {base_url}')
         env['PD_BROWSER_BASE_URL'] = base_url
         env['PYTHONPATH'] = '.'
-        # The root conftest wants a cards database and importing the decksite package opens a connection; the canary needs nothing but a browser.
-        args = ['--noconftest', '--import-mode=importlib']
+        # The root conftest wants a cards database and collecting a test inside the decksite package imports decksite/__init__.py, which opens a
+        # connection. The canary needs nothing but a browser, so run a copy of the file from outside the package (the canary workflow does the same).
+        outside = os.path.join(tempfile.mkdtemp(prefix='pd-browser-'), 'browser_test.py')
+        shutil.copyfile('decksite/browser_test.py', outside)
+        args = ['--noconftest', f'--rootdir={os.path.dirname(outside)}', '-o', 'markers=browser', outside]  # No pytest.ini out there, so register the marker by hand.
     else:
         print('>>>> Running browser tests against a local server (needs a database and a built JS bundle)')
         env['PD_BROWSER_TESTS'] = '1'
-        args = []
-    code = subprocess.call(['pytest', '--no-cov', '-p', 'no:cacheprovider', *args, 'decksite/browser_test.py'], env=env)
+        args = ['decksite/browser_test.py']
+    code = subprocess.call(['pytest', '--no-cov', '-p', 'no:cacheprovider', *args], env=env)
     if code:
         sys.exit(code)
 


### PR DESCRIPTION
The canary still fails at collection after #15189: pytest 9's importlib mode imports the module by its package name when it can, so `decksite/__init__.py` runs and opens a database connection the runner does not have.

Fix: copy `decksite/browser_test.py` to a temp dir and run it from there with `--noconftest`. Nothing in the file itself touches the package at import time. `dev.py browser --url` does the same so it stays a faithful local run of the canary.

Verified locally with `mysql_host=127.0.0.1`, `mysql_port=1` in config.json: the old command reproduces the CI error, the new one passes 6 of 6 against production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
