### PR TITLE
Make Conductor cloud previews ready in about a minute

### DIFF
--- a/.conductor/README.md
+++ b/.conductor/README.md
@@ -28,14 +28,39 @@ Then verify `http://127.0.0.1:<local_port>/` from the Mac before sharing that li
 This database is an implementation detail; if its schema changes, use the Ports UI.
 Leave the development server running after verification.
 
-If the Ports toggle is unavailable, an agent can also forward port 5000 through
-Conductor's existing SSH mapping for remote port 22. Use a temporary key restricted
-to forwarding `127.0.0.1:5000`, no shell access, and a temporary known-hosts file.
-The sandbox's sshd may use `/root/.ssh/authorized_keys` (check `sshd -T`). Record
-the chosen Mac URL and tunnel control socket in `.context/pd-preview.json` so the
-next agent can reuse or stop it. This is a temporary fallback; the Ports panel is
-the normal way to manage forwarding, and the SSH tunnel ends when its connection
-to the cloud workspace closes.
+If the Ports toggle is unavailable, use `.conductor/preview-tunnel.py` on the Mac
+to forward port 5000 through Conductor's existing SSH mapping for remote port 22.
+A plain `ssh -f -N` tunnel is insufficient: VM restart/resume kills the database,
+web server, and SSH connection. The supervisor reconnects, and its restricted SSH
+command runs `.conductor/preview-ssh.sh` to restart MariaDB and decksite as needed.
+The supervisor exits when Conductor closes the workspace's SSH listener.
+
+Use a temporary key restricted to `127.0.0.1:5000` forwarding and a forced command
+that runs `preview-ssh.sh` as the workspace user. For this Amazon Linux sandbox,
+the authorized-key options are:
+
+```text
+restrict,port-forwarding,permitopen="127.0.0.1:5000",command="/usr/bin/sudo -u vercel-sandbox /bin/bash <workspace-path>/.conductor/preview-ssh.sh"
+```
+
+The sandbox's sshd may use `/root/.ssh/authorized_keys` (check `sshd -T`). Preserve
+existing keys. Store the temporary private key as `id` on the Mac, together with
+a `known_hosts` file containing the verified cloud SSH host key. Copy
+`preview-tunnel.py` to that temporary directory and start it with:
+
+```sh
+python3 /tmp/<preview-directory>/preview-tunnel.py \
+  --directory /tmp/<preview-directory> --ssh-port <Conductor-SSH-local-port> \
+  --web-port <Mac-preview-port>
+```
+
+Launch the supervisor detached with logs saved in that directory, and record its
+PID and the chosen Mac URL in `.context/pd-preview.json`. Stop it with
+`kill "$(cat /tmp/<preview-directory>/supervisor.pid)"`. This is a temporary
+fallback; the Ports panel remains the normal way to manage forwarding. The Mac
+supervisor must be restarted after quitting Conductor or restarting the Mac.
+Verify recovery by stopping the preview and its database, then checking that the
+same Mac URL returns HTTP 200 without manually restarting either service.
 
 ## Database lifecycle
 

--- a/.conductor/README.md
+++ b/.conductor/README.md
@@ -1,0 +1,102 @@
+# Conductor development
+
+Local macOS workspaces keep using native uv/npm and the existing MariaDB services.
+Their decksite script must pass the allocated `CONDUCTOR_PORT`. Cloud scripts do
+not run on macOS and do not use Docker.
+
+## Cloud startup and previews
+
+The shared setup script runs `bash .conductor/setup.sh`. It syncs Python dependencies,
+restores a prepared database, and builds JavaScript. Use the **decksite_cloud** run
+script to start the app on port 5000 with Python auto-reload and no interactive
+debugger. After changing JavaScript, run `npm run build` (or `npm run watch`).
+
+**Enable port forwarding in the workspace's Ports panel.** Merely detecting port
+5000 in the VM does not enable forwarding on the Mac. Open the forwarded entry for
+5000; its Mac port can differ from 5000 and can change when reconnecting. A cloud
+`http://127.0.0.1:5000` health check verifies the VM only, not the Mac tunnel.
+
+An agent with RunLocalCommand can identify the actual mapping with this read-only
+query on the Mac (substitute the current `CONDUCTOR_WORKSPACE_ID`):
+
+```sh
+sqlite3 -readonly "$HOME/Library/Application Support/com.conductor.app/conductor.db" \
+  "SELECT local_port FROM port_forwards WHERE workspace_id = '<workspace-id>' AND remote_port = 5000 AND enabled = 1;"
+```
+
+Then verify `http://127.0.0.1:<local_port>/` from the Mac before sharing that link.
+This database is an implementation detail; if its schema changes, use the Ports UI.
+Leave the development server running after verification.
+
+If the Ports toggle is unavailable, an agent can also forward port 5000 through
+Conductor's existing SSH mapping for remote port 22. Use a temporary key restricted
+to forwarding `127.0.0.1:5000`, no shell access, and a temporary known-hosts file.
+The sandbox's sshd may use `/root/.ssh/authorized_keys` (check `sshd -T`). Record
+the chosen Mac URL and tunnel control socket in `.context/pd-preview.json` so the
+next agent can reuse or stop it. This is a temporary fallback; the Ports panel is
+the normal way to manage forwarding, and the SSH tunnel ends when its connection
+to the cloud workspace closes.
+
+## Database lifecycle
+
+Cloud MariaDB runs as the workspace user on `127.0.0.1:3307`, with its data in
+`.context/pd-cloud/mysql`. It does not modify `/var/lib/mysql` or fight a preexisting
+service on 3306. Setup writes matching development credentials and database names
+to gitignored `config.json`, disables issue reporting/Redis/Sentry, and verifies
+deck data, card data, search suggestions, and the generated font. Search assets
+live in `.context/pd-cloud` so a JavaScript build cannot remove them.
+
+The snapshot contains decksite's sanitized dev data, Scryfall cards, empty prices,
+pdlogs and test databases, a Whoosh index, search suggestions, the symbols font,
+and the homepage's daily archetype summary (which is missing from the SQL dump).
+It is a development dataset, not a complete copy of every production database.
+No copied config files or credentials from the user's Mac go into the snapshot.
+
+Setup downloads the `dev-db-snapshot` release's archive, manifest, and checksums
+using authenticated `gh`. The release is a draft so building a snapshot does not
+publish a release announcement. Cloud credentials need repository contents access
+that can read this draft. Checksums, MariaDB major/minor, and architecture are
+checked before extraction. A repeated setup reuses the workspace database;
+it never refreshes or overwrites local edits. An incomplete or incompatible
+database fails with an actionable error instead of starting a long SQL import.
+
+The base cloud image should already have MariaDB **11.8**, uv, Node **24**/npm, gh,
+zstd, pkg-config, and the MariaDB C development headers. Missing MariaDB packages
+are installed with dnf on Amazon Linux. Package installation and a cold Python
+dependency download may exceed the 1–2 minute target. Keep the image's dependencies
+warm; database seeding belongs in the snapshot workflow, not an image boot hook.
+Remove any old external boot hook that downloads/imports SQL when editing that
+image configuration; these repository scripts do not rely on it.
+
+Measured in the September 4, 2026 Amazon Linux cloud workspace: **46.8 seconds**
+for a fresh GitHub snapshot download, checksum verification, database restore,
+Python sync, npm install, and JavaScript build, plus **10.7 seconds** to start decksite and receive HTTP 200
+(**57.5 seconds total**). This used the existing image's
+toolchains/Python environment and a 1.46 GB archive. Network speed and missing
+dependencies affect subsequent workspaces; this is a measurement, not a hard SLA.
+
+## Refresh the snapshot
+
+`.github/workflows/dev-db-snapshot.yml` builds weekly and on demand after merging.
+It installs matching native MariaDB, imports the public sanitized SQL, initializes
+cards, generates assets and homepage summaries, shuts down cleanly, and verifies
+a fresh restore and real HTTP responses from core pages before
+uploading the archive. Rebuilding takes several minutes, outside workspace startup.
+Concurrent refreshes are serialized. If startup happens during asset replacement,
+a checksum/download failure is safe: retry setup after the workflow finishes.
+
+To build manually in a fresh Linux checkout with dependencies installed:
+
+```sh
+python3 .conductor/cloud.py build-snapshot
+```
+
+The builder refuses an existing `.context/pd-cloud`. For offline restore testing,
+set `PD_CLOUD_SNAPSHOT_DIR` to the absolute path of `.context/pd-cloud-artifacts`.
+For snapshot builds, `PD_DEV_SQL` can point to a previously downloaded sanitized
+`dev-db.sql.gz`. Normal workspace setup never invokes the snapshot builder.
+
+Shared run-script changes appear on the Mac after merging to the default branch;
+cloud setup uses the branch used to create the workspace. Machine-local settings
+can override these shared settings, so check `.conductor/settings.local.toml` if
+Conductor runs an unexpected command.

--- a/.conductor/cloud.py
+++ b/.conductor/cloud.py
@@ -1,0 +1,275 @@
+"""Prepare an isolated, disposable MariaDB for Conductor cloud previews.
+
+Uses the system Python so database restoration does not import the application.
+The slow build-snapshot command is for CI/manual preparation, never workspace setup.
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+import platform
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent.parent
+STATE = ROOT / '.context' / 'pd-cloud'
+SOCKET = Path(tempfile.gettempdir()) / f'pd-cloud-{hashlib.sha256(str(ROOT).encode()).hexdigest()[:12]}.sock'
+PORT = 3307
+PASSWORD = 'pd-cloud-dev'
+REPO = 'PennyDreadfulMTG/Penny-Dreadful-Tools'
+TAG = 'dev-db-snapshot'
+ASSET = 'pd-cloud-db.tar.zst'
+DATABASES = ('decksite', 'cards', 'prices', 'pdlogs', 'decksite_test')
+
+
+def log(message: str) -> None:
+    sys.stdout.write(f'[pd-cloud] {message}\n')
+    sys.stdout.flush()
+
+
+def run(*args: str, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
+    return subprocess.run(args, check=True, **kwargs)
+
+
+def version() -> str:
+    output = subprocess.check_output(['mariadbd', '--version'], text=True)
+    match = re.search(r'(\d+\.\d+)\.\d+', output)
+    if not match:
+        raise RuntimeError(f'Cannot identify MariaDB version: {output}')
+    return match[1]
+
+
+def validate_manifest(manifest: dict[str, Any]) -> None:
+    expected = {'format': 1, 'mariadb': version(), 'architecture': platform.machine()}
+    for key, value in expected.items():
+        if manifest.get(key) != value:
+            raise RuntimeError(f'Snapshot {key}={manifest.get(key)!r}; this machine requires {value!r}. Rebuild the snapshot with matching MariaDB.')
+
+
+def sql(statement: str) -> str:
+    return subprocess.check_output([
+        'mariadb', '--no-defaults', f'--socket={SOCKET}', '--user=root',
+        '--batch', '--skip-column-names', '-e', statement,
+    ], text=True).strip()
+
+
+def running() -> bool:
+    return subprocess.run([
+        'mariadb-admin', '--no-defaults', f'--socket={SOCKET}', '--user=root', 'ping',
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode == 0
+
+
+def start() -> None:
+    if running():
+        return
+    log(f'Starting workspace MariaDB on 127.0.0.1:{PORT}')
+    with (STATE / 'mariadb.log').open('a') as output:
+        subprocess.Popen([
+            'mariadbd', '--no-defaults', f'--datadir={STATE / "mysql"}',
+            f'--socket={SOCKET}', f'--pid-file={STATE / "mariadb.pid"}',
+            '--bind-address=127.0.0.1', f'--port={PORT}',
+            '--innodb-buffer-pool-size=2G', '--innodb-flush-log-at-trx-commit=2',
+            '--max-allowed-packet=1G', '--skip-log-bin', '--performance-schema=OFF',
+        ], stdin=subprocess.DEVNULL, stdout=output, stderr=subprocess.STDOUT, start_new_session=True)
+    for _ in range(60):
+        if running():
+            return
+        time.sleep(0.5)
+    raise RuntimeError(f'MariaDB did not start. See {STATE / "mariadb.log"}')
+
+
+def stop() -> None:
+    run('mariadb-admin', '--no-defaults', f'--socket={SOCKET}', '--user=root', 'shutdown')
+    for _ in range(120):
+        if not (STATE / 'mariadb.pid').exists():
+            return
+        time.sleep(0.5)
+    raise RuntimeError('MariaDB did not shut down cleanly; refusing to snapshot it.')
+
+
+def configure() -> None:
+    path = ROOT / 'config.json'
+    config = json.loads(path.read_text()) if path.exists() else {}
+    config.update({
+        'mysql_host': '127.0.0.1', 'mysql_port': PORT,
+        'mysql_user': 'pennydreadful', 'mysql_passwd': PASSWORD,
+        'decksite_database': 'decksite', 'magic_database': 'cards',
+        'prices_database': 'prices', 'logsite_database': 'pdlogs',
+        'decksite_test_database': 'decksite_test',
+        'whoosh_index_dir': str(STATE / 'whoosh_index'),
+        'typeahead_data_path': str(STATE / 'typeahead.json'),
+        'production': False, 'create_github_issues': False, 'redis_enabled': False,
+        'sentry_token': None, 'flask_server_name': None, 'flask_cookie_domain': None,
+    })
+    if not config.get('oauth2_client_secret'):
+        config['oauth2_client_secret'] = secrets.token_hex(32)
+    temporary = path.with_suffix('.json.tmp')
+    temporary.write_text(json.dumps(config, indent=4, sort_keys=True) + '\n')
+    temporary.chmod(0o600)
+    temporary.replace(path)
+
+
+def verify() -> None:
+    # Verify actual data as the app user, not merely that the root socket responds.
+    output = subprocess.check_output([
+        'mariadb', '--no-defaults', '--host=127.0.0.1', f'--port={PORT}',
+        '--user=pennydreadful', '--batch', '--skip-column-names', '-e',
+        'SELECT EXISTS(SELECT 1 FROM decksite.deck); SELECT EXISTS(SELECT 1 FROM cards.card); '
+        'SELECT EXISTS(SELECT 1 FROM decksite._arch_day_stats);',
+    ], env={**os.environ, 'MYSQL_PWD': PASSWORD}, text=True)
+    if output.split() != ['1', '1', '1']:
+        raise RuntimeError('Snapshot is missing deck, card, or homepage summary data.')
+    if not list((STATE / 'whoosh_index').glob('*.toc')):
+        raise RuntimeError('Snapshot is missing its Whoosh search index.')
+    if not (STATE / 'typeahead.json').is_file() or not (STATE / 'symbols.woff2').is_file():
+        raise RuntimeError('Snapshot is missing search suggestions or the symbols font.')
+
+
+def restore() -> None:
+    if STATE.exists():
+        raise RuntimeError(f'{STATE} exists but has no completed manifest. Inspect it before moving it aside and retrying; no data has been overwritten.')
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix='pd-restore-', dir=STATE.parent) as temporary:
+        download = Path(temporary)
+        source = os.environ.get('PD_CLOUD_SNAPSHOT_DIR')
+        if source:
+            for name in (ASSET, 'manifest.json', 'SHA256SUMS'):
+                shutil.copyfile(Path(source) / name, download / name)
+        else:
+            log('Downloading prepared database snapshot from GitHub')
+            run('gh', 'release', 'download', TAG, '--repo', REPO, '--dir', str(download),
+                '--pattern', ASSET, '--pattern', 'manifest.json', '--pattern', 'SHA256SUMS')
+        run('sha256sum', '--check', 'SHA256SUMS', cwd=download)
+        validate_manifest(json.loads((download / 'manifest.json').read_text()))
+        log('Restoring database and search index')
+        unpacked = download / 'unpacked'
+        unpacked.mkdir()
+        run('tar', '--zstd', '--extract', '--file', str(download / ASSET),
+            '--directory', str(unpacked), '--no-same-owner')
+        shutil.copyfile(download / 'manifest.json', unpacked / 'manifest.json')
+        unpacked.rename(STATE)
+
+
+def setup() -> None:
+    started = time.monotonic()
+    if not (STATE / 'manifest.json').exists():
+        restore()
+    validate_manifest(json.loads((STATE / 'manifest.json').read_text()))
+    start()
+    verify()
+    configure()
+    fonts = ROOT / 'shared_web' / 'static' / 'fonts'
+    fonts.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(STATE / 'symbols.woff2', fonts / 'symbols.woff2')
+    log(f'Database ready in {time.monotonic() - started:.1f}s')
+
+
+def build_snapshot(output: Path) -> None:
+    if STATE.exists():
+        raise RuntimeError(f'Build requires a fresh {STATE}; existing data is never replaced.')
+    STATE.mkdir(parents=True)
+    run('mariadb-install-db', '--no-defaults', f'--datadir={STATE / "mysql"}',
+        '--auth-root-authentication-method=normal', '--skip-test-db')
+    start()
+    try:
+        for database in DATABASES:
+            sql(f'CREATE DATABASE `{database}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci')
+        sql(f"CREATE USER 'pennydreadful'@'127.0.0.1' IDENTIFIED BY '{PASSWORD}'")
+        for database in DATABASES:
+            sql(f"GRANT ALL ON `{database}`.* TO 'pennydreadful'@'127.0.0.1'")
+        configure()
+        dump = STATE / 'dev-db.sql.gz'
+        source = os.environ.get('PD_DEV_SQL')
+        if source:
+            shutil.copyfile(source, dump)
+        else:
+            run('curl', '--fail', '--location', '--retry', '3', '--output', str(dump),
+                'https://pennydreadfulmagic.com/static/dev-db.sql.gz')
+        log('Importing sanitized SQL (one-time snapshot build; takes several minutes)')
+        with subprocess.Popen(['gzip', '-dc', str(dump)], stdout=subprocess.PIPE) as decompressor:
+            run('mariadb', '--no-defaults', f'--socket={SOCKET}', '--user=root',
+                '--max-allowed-packet=1G', 'decksite', stdin=decompressor.stdout)
+            assert decompressor.stdout is not None
+            decompressor.stdout.close()
+            if decompressor.wait() != 0:
+                raise RuntimeError('SQL decompression failed')
+        dump.unlink()
+        log('Building card database and search index')
+        run('uv', 'run', '--frozen', 'python', 'run.py', 'init-cards')
+        build_derived_assets()
+        verify()
+    finally:
+        stop()
+    pack_snapshot(output)
+
+
+def build_derived_assets() -> None:
+    # This table is absent from the sanitized SQL dump. Without it the first
+    # homepage request triggers a full (slow) archetype preaggregation.
+    run('uv', 'run', '--frozen', 'python', '-c',
+        'from decksite.data import archetype; archetype.preaggregate_archetype_days()')
+    run('uv', 'run', '--frozen', 'python', '-c',
+        'from decksite import main; from maintenance import typeahead; '
+        'ctx = main.APP.test_request_context(); ctx.push(); typeahead.run(); ctx.pop()')
+    run('uv', 'run', '--frozen', 'python', '-c',
+        'from magic import oracle; oracle.init(); from maintenance import fonts; fonts.ad_hoc()')
+    shutil.copyfile(ROOT / 'shared_web/static/fonts/symbols.woff2', STATE / 'symbols.woff2')
+    check_pages()
+
+
+def check_pages() -> None:
+    run('uv', 'run', '--frozen', 'python', '-c',
+        'from decksite import main; client = main.APP.test_client(); '
+        'paths = ["/", "/decks/", "/cards/", "/api/search/?q=bolt"]; '
+        'results = [(path, client.get(path).status_code) for path in paths]; '
+        'assert all(status == 200 for _, status in results), results')
+
+
+def pack_snapshot(output: Path) -> None:
+    if running():
+        raise RuntimeError('Stop MariaDB cleanly before creating a snapshot.')
+    output.mkdir(parents=True, exist_ok=True)
+    manifest = {'format': 1, 'mariadb': version(), 'architecture': platform.machine(),
+                'created_at': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}
+    (output / 'manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')
+    log('Compressing cleanly stopped database')
+    run('tar', '-I', 'zstd -T0 -3', '-cf', str(output / ASSET), '-C', str(STATE),
+        'mysql', 'whoosh_index', 'typeahead.json', 'symbols.woff2')
+    with (output / 'SHA256SUMS').open('w') as sums:
+        run('sha256sum', ASSET, 'manifest.json', cwd=output, stdout=sums)
+    shutil.copyfile(output / 'manifest.json', STATE / 'manifest.json')
+    log(f'Snapshot ready: {output}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('command', choices=['setup', 'start', 'build-snapshot'])
+    parser.add_argument('--output', type=Path, default=ROOT / '.context' / 'pd-cloud-artifacts')
+    args = parser.parse_args()
+    if platform.system() != 'Linux' or (args.command != 'build-snapshot' and os.environ.get('CONDUCTOR_IS_LOCAL') != '0'):
+        parser.error('Cloud commands require CONDUCTOR_IS_LOCAL=0 on Linux; macOS uses its existing services.')
+    os.chdir(ROOT)
+    STATE.parent.mkdir(parents=True, exist_ok=True)
+    with (STATE.parent / 'pd-cloud.lock').open('w') as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            parser.error('Another cloud database setup is running; wait for it to finish.')
+        if args.command == 'build-snapshot':
+            build_snapshot(args.output.resolve())
+        else:
+            setup()
+
+
+if __name__ == '__main__':
+    main()

--- a/.conductor/cloud_test.py
+++ b/.conductor/cloud_test.py
@@ -1,0 +1,70 @@
+"""Run with python3 .conductor/cloud_test.py; no app/database imports needed."""
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import cloud
+
+
+class CloudSetupTest(unittest.TestCase):
+    def test_snapshot_requires_matching_database_version_and_architecture(self) -> None:
+        manifest = {'format': 1, 'mariadb': '11.8', 'architecture': 'x86_64'}
+        with patch.object(cloud, 'version', return_value='11.8'), patch.object(cloud.platform, 'machine', return_value='x86_64'):
+            cloud.validate_manifest(manifest)
+            for key, value in [('format', 2), ('mariadb', '11.4'), ('architecture', 'aarch64')]:
+                with self.subTest(key=key), self.assertRaises(RuntimeError):
+                    cloud.validate_manifest({**manifest, key: value})
+
+    def test_incomplete_database_is_not_overwritten(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            state = Path(directory)
+            sentinel = state / 'user-data'
+            sentinel.write_text('keep me')
+            with patch.object(cloud, 'STATE', state), self.assertRaisesRegex(RuntimeError, 'no data has been overwritten'):
+                cloud.restore()
+            self.assertEqual(sentinel.read_text(), 'keep me')
+
+    def test_config_reconciles_database_settings_and_preserves_other_preferences(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            path = root / 'config.json'
+            path.write_text(json.dumps({'mysql_passwd': 'stale', 'mysql_host': 'localhost', 'always_show_rotation': True}))
+            with patch.object(cloud, 'ROOT', root), patch.object(cloud, 'STATE', root / 'db'):
+                cloud.configure()
+                first = json.loads(path.read_text())
+                cloud.configure()
+                self.assertEqual(json.loads(path.read_text()), first)
+            self.assertEqual(first['mysql_passwd'], cloud.PASSWORD)
+            self.assertEqual(first['mysql_host'], '127.0.0.1')
+            self.assertEqual(first['mysql_port'], 3307)
+            self.assertTrue(first['always_show_rotation'])
+            self.assertFalse(first['production'])
+            self.assertFalse(first['create_github_issues'])
+
+    def test_corrupt_download_is_rejected_before_extraction(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / 'download'
+            source.mkdir()
+            (source / cloud.ASSET).write_bytes(b'corrupted archive')
+            (source / 'manifest.json').write_text('{}')
+            (source / 'SHA256SUMS').write_text('0' * 64 + '  ' + cloud.ASSET + '\n')
+            state = root / 'state'
+            with patch.object(cloud, 'STATE', state), patch.dict(os.environ, {'PD_CLOUD_SNAPSHOT_DIR': str(source)}):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    cloud.restore()
+            self.assertFalse(state.exists())
+
+    def test_local_setup_does_nothing(self) -> None:
+        result = subprocess.run(['bash', str(cloud.ROOT / '.conductor/setup.sh')],
+                                env={**os.environ, 'CONDUCTOR_IS_LOCAL': '1'}, capture_output=True)
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, b'')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.conductor/decksite-cloud.sh
+++ b/.conductor/decksite-cloud.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${CONDUCTOR_IS_LOCAL:-}" != 0 ]]; then
+    echo 'Use the local decksite run script with CONDUCTOR_PORT on macOS.' >&2
+    exit 1
+fi
+cd "$(dirname "$0")/.."
+export PATH="$HOME/.local/bin:$PATH"
+python3 .conductor/cloud.py start
+exec uv run --frozen python -c 'from decksite import main; main.APP.config["SESSION_COOKIE_SECURE"] = False; main.APP.run(host="0.0.0.0", port=5000, debug=False, use_reloader=True)'

--- a/.conductor/preview-ssh.sh
+++ b/.conductor/preview-ssh.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Restricted SSH entry point: restart this workspace's preview after VM resume.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+export CONDUCTOR_IS_LOCAL=0
+export PATH="$HOME/.local/bin:$PATH"
+mkdir -p .context
+# Keep a separate flock process alive even when the application execs/reloads.
+if [[ "${1:-}" != --locked ]]; then
+    exec flock .context/preview-ssh.lock bash .conductor/preview-ssh.sh --locked
+fi
+python3 .conductor/cloud.py start
+# A run-panel server may already be serving this workspace. Reuse it until it
+# exits; the Mac supervisor then reconnects and starts a replacement.
+if python3 -c 'import socket; socket.create_connection(("127.0.0.1", 5000), timeout=1).close()' 2>/dev/null; then
+    while python3 -c 'import socket; socket.create_connection(("127.0.0.1", 5000), timeout=1).close()' 2>/dev/null; do
+        sleep 5
+    done
+else
+    exec bash .conductor/decksite-cloud.sh
+fi

--- a/.conductor/preview-tunnel.py
+++ b/.conductor/preview-tunnel.py
@@ -1,0 +1,61 @@
+"""Mac-side SSH supervisor for one Conductor workspace; no extra dependencies.
+
+Use a key whose forced command is preview-ssh.sh, restricted to port 5000.
+Exit when Conductor closes this workspace's SSH listener. Otherwise reconnect
+after a VM restart; the forced command also restores MariaDB and decksite.
+"""
+import argparse
+import fcntl
+import os
+import signal
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--directory', required=True, type=Path)
+    parser.add_argument('--ssh-port', required=True, type=int)
+    parser.add_argument('--web-port', required=True, type=int)
+    args = parser.parse_args()
+    directory = args.directory.resolve()
+    child = None
+
+    def stop(_signum: int, _frame: object) -> None:
+        if child is not None and child.poll() is None:
+            child.terminate()
+            child.wait(timeout=15)
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    with (directory / 'supervisor.lock').open('w') as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        (directory / 'supervisor.pid').write_text(str(os.getpid()))
+        while True:
+            try:
+                with socket.create_connection(('127.0.0.1', args.ssh_port), timeout=5):
+                    pass
+            except OSError:
+                # Don't keep a closed/archived workspace alive or reconnect forever
+                # after the user quits Conductor.
+                return
+            child = subprocess.Popen([
+                'ssh', '-T', '-i', str(directory / 'id'),
+                '-o', 'IdentitiesOnly=yes', '-o', 'BatchMode=yes',
+                '-o', 'ExitOnForwardFailure=yes', '-o', 'ConnectTimeout=10',
+                '-o', 'ServerAliveInterval=5', '-o', 'ServerAliveCountMax=2',
+                '-o', 'StrictHostKeyChecking=yes',
+                '-o', f'UserKnownHostsFile={directory / "known_hosts"}',
+                '-p', str(args.ssh_port),
+                '-L', f'127.0.0.1:{args.web_port}:127.0.0.1:5000',
+                'root@127.0.0.1',
+            ], stdin=subprocess.DEVNULL)
+            child.wait()
+            time.sleep(3)
+
+
+if __name__ == '__main__':
+    main()

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,21 +1,12 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
-# Shared Conductor settings. Machine-local overrides (run scripts, files to copy)
-# belong in .conductor/settings.local.toml, which takes precedence per-key.
-#
-# The setup script bootstraps CLOUD workspaces only: fresh cloud sandboxes have no
-# uv and no build deps, so without this `uv run` fails. Local workspaces are
-# assumed to already have a working dev environment and are left alone.
-# (A MariaDB server is deliberately NOT set up here to keep workspace creation
-# fast; agents that need to run DB-backed tests can install one — see
-# backlog_sweep/FIXER_PROMPT.md for a verified recipe.)
-
+# Local macOS development uses its existing services and allocated port.
+# Cloud setup restores a prepared database; it never imports SQL at startup.
 [scripts]
-setup = """
-set -e
-if [ "${CONDUCTOR_IS_LOCAL:-0}" = "1" ]; then exit 0; fi
-export PATH="$HOME/.local/bin:$PATH"
-command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh
-command -v pkg-config >/dev/null 2>&1 || sudo dnf install -y -q pkgconf-pkg-config mariadb-connector-c-devel gcc python3-devel
-uv sync --frozen
-"""
+setup = "bash .conductor/setup.sh"
+
+[scripts.run.decksite_cloud]
+available_in = [ "cloud" ]
+command = "bash .conductor/decksite-cloud.sh"
+default = true
+icon = "play"

--- a/.conductor/setup.sh
+++ b/.conductor/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${CONDUCTOR_IS_LOCAL:-0}" == 1 ]]; then exit 0; fi
+cd "$(dirname "$0")/.."
+export PATH="$HOME/.local/bin:$PATH"
+if ! command -v uv >/dev/null; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+# Preinstall these in the cloud image to keep startup within 1–2 minutes.
+if ! command -v mariadbd >/dev/null || ! command -v pkg-config >/dev/null || ! command -v zstd >/dev/null; then
+    sudo dnf install -y mariadb118-server mariadb118-devel pkgconf-pkg-config gcc python3-devel zstd
+fi
+uv sync --frozen
+python3 .conductor/cloud.py setup
+npm ci --no-audit --no-fund
+npm run build

--- a/.github/workflows/dev-db-snapshot.yml
+++ b/.github/workflows/dev-db-snapshot.yml
@@ -1,0 +1,54 @@
+name: Build cloud development database
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '23 4 * * 0'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dev-db-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          lfs: true
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: '0.9.26'
+          enable-cache: true
+      - name: Install native MariaDB 11.8 and build dependencies
+        run: |
+          curl -fsSL https://r.mariadb.com/downloads/mariadb_repo_setup -o /tmp/mariadb_repo_setup
+          sudo bash /tmp/mariadb_repo_setup --mariadb-server-version=mariadb-11.8 --skip-maxscale --skip-tools
+          sudo apt-get update
+          sudo apt-get install -y mariadb-server libmariadb-dev pkg-config build-essential zstd
+          uv sync --frozen
+      - name: Check setup safeguards
+        run: python3 .conductor/cloud_test.py
+      - name: Build sanitized database and derived assets
+        run: python3 .conductor/cloud.py build-snapshot
+      - name: Verify a fresh restore
+        env:
+          CONDUCTOR_IS_LOCAL: '0'
+        run: |
+          mv .context/pd-cloud .context/pd-cloud-built
+          PD_CLOUD_SNAPSHOT_DIR="$PWD/.context/pd-cloud-artifacts" python3 .conductor/cloud.py setup
+          PYTHONPATH=.conductor python3 -c 'import cloud; cloud.check_pages()'
+      - name: Upload prepared database
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! gh release view dev-db-snapshot >/dev/null 2>&1; then
+            gh release create dev-db-snapshot --draft --target "$GITHUB_SHA" \
+              --title 'Cloud development database' \
+              --notes 'Prepared MariaDB 11.8 database from the public sanitized dev dump, plus Scryfall cards and generated search/font assets. Used by Conductor cloud setup.'
+          fi
+          gh release upload dev-db-snapshot .context/pd-cloud-artifacts/* --clobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,7 @@ Do not use the "merge when ready" label. It is a leftover from an old CI setup a
   port 5000. Port detection is separate from enabling forwarding in Conductor's
   Ports panel. Verify from the Mac with RunLocalCommand when available.
   Check `.context/pd-preview.json` for an existing temporary SSH preview tunnel.
+- Cloud VM restart/resume stops background services. An SSH fallback must use
+  `.conductor/preview-tunnel.py` on the Mac and the restricted
+  `.conductor/preview-ssh.sh` server entry point so it reconnects and restarts
+  decksite. Verify recovery, not just the initial HTTP response.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,18 @@ To merge a PR, comment `@mergifyio queue` on it (for example `gh pr comment <num
 Mergify then merges it once the mypy, lint, test and jslint checks pass.
 
 Do not use the "merge when ready" label. It is a leftover from an old CI setup and Mergify ignores it.
+
+## Development previews
+
+- Use native uv/npm and MariaDB; do not use Docker.
+- In local Conductor workspaces, use the repository's local decksite run script
+  and its allocated `CONDUCTOR_PORT`.
+- In cloud workspaces (`CONDUCTOR_IS_LOCAL=0`), use `bash .conductor/setup.sh`
+  and `bash .conductor/decksite-cloud.sh`. See `.conductor/README.md` for snapshot
+  preparation and troubleshooting. Do not import SQL during workspace setup.
+- For UI work, start the development server, verify the relevant page and assets,
+  and leave it running. Build JavaScript changes with `npm run build`.
+- Give the actual forwarded browser URL. Cloud port 5000 is not necessarily Mac
+  port 5000. Port detection is separate from enabling forwarding in Conductor's
+  Ports panel. Verify from the Mac with RunLocalCommand when available.
+  Check `.context/pd-preview.json` for an existing temporary SSH preview tunnel.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Repository for the tools used by the Penny Dreadful Community.
 
 View individual subdirectories for details
 
+For Conductor cloud setup and Mac browser previews, see [Conductor development](.conductor/README.md).
+
 [![Build Status](https://travis-ci.org/PennyDreadfulMTG/Penny-Dreadful-Tools.svg?branch=master)](https://travis-ci.org/PennyDreadfulMTG/Penny-Dreadful-Tools)
 [![Uptime Robot status](https://img.shields.io/uptimerobot/status/m778417564-ebc98d54a784806de06fee4d.svg)](https://status.pennydreadfulmagic.com)
 


### PR DESCRIPTION
Cloud workspaces had no repository-supported database setup or decksite run script. Add a native MariaDB snapshot restore and a cloud run script so a fresh workspace can serve decksite without importing SQL during startup. Local macOS scripts and their allocated ports continue to use existing services.

The snapshot includes sanitized decksite data, Scryfall cards, search assets, the symbols font, and the homepage summary missing from the SQL dump. Setup verifies checksums, database compatibility, and application credentials, preserves existing workspace data, and uses an isolated database on port 3307. A weekly/manual workflow builds and validates the snapshot before updating a draft release. The initial draft release is already populated.

Document how to enable Conductor forwarding and verify the actual Mac URL, including a reconnecting SSH supervisor when the Ports toggle is unavailable. Its restricted command restarts MariaDB and decksite after cloud VM restart/resume, and it exits when Conductor closes the workspace SSH listener.

Validation:
- Fresh download from GitHub, restore, dependency sync, and JS build: 46.8s; decksite returning HTTP 200: 57.5s total on the prepared Amazon Linux image.
- Five setup safeguard tests; Ruff, mypy, shell syntax, and Conductor settings schema checks pass.
- All six existing browser tests pass against the running server, including populated live tables and responsive navigation. The first run encountered a Scryfall 429 for Island; a successful image fetch was cached before rerunning.
- Recovery test: stopped MariaDB and both Flask processes; the same Mac URL returned HTTP 200 automatically in 19.9s.
- Homepage, decks, search, and font verified through the Conductor connection from the Mac.

The workflow will become scheduled after merge. The existing external image boot hook is independent of these scripts; the isolated database avoids conflicting with it. Cold toolchain installs or slow network access can exceed the measured startup time.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/f1d29a2f-dfbb-47fa-9b00-5155bd156161)
