### PR TITLE
Handle timezone-aware modo bug timestamps

### DIFF
--- a/modo_bugs/update.py
+++ b/modo_bugs/update.py
@@ -1,5 +1,4 @@
 import codecs
-import datetime
 import json
 import logging
 import re
@@ -9,7 +8,7 @@ import urllib.parse
 import requests
 from github.Issue import Issue
 
-from shared import configuration
+from shared import configuration, dtutil
 from shared.custom_types import BugData
 from shared.lazy import lazy_property
 
@@ -82,8 +81,13 @@ def verification_numbers() -> None:
     print('... Done')
 
 
+def age_in_days(issue: Issue) -> int:
+    # PyGithub gives timezone-aware datetimes; a naive now() cannot be subtracted from one.
+    return (dtutil.now() - issue.updated_at).days
+
+
 def process_issue(issue: Issue) -> None:
-    age = (datetime.datetime.now() - issue.updated_at).days
+    age = age_in_days(issue)
     if age < 5:
         fix_user_errors(issue)
         apply_screenshot_labels(issue)
@@ -162,7 +166,7 @@ def process_issue(issue: Issue) -> None:
         if 'Deck Building' in labels:
             bug['cade_bug'] = True
 
-        age = (datetime.datetime.now() - issue.updated_at).days
+        age = age_in_days(issue)
         if 'Help Wanted' in labels:
             bug['help_wanted'] = True
         elif age > 60:

--- a/modo_bugs/update_test.py
+++ b/modo_bugs/update_test.py
@@ -1,0 +1,10 @@
+import datetime
+from types import SimpleNamespace
+
+from modo_bugs import update
+
+
+def test_age_in_days_handles_pygithub_aware_datetimes() -> None:
+    """PyGithub 2.x returns tz-aware datetimes. A naive now() minus one of those is a TypeError, which took down every issue in update.main()."""
+    issue = SimpleNamespace(updated_at=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=7, hours=1))
+    assert update.age_in_days(issue) == 7  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- calculate issue age with the project's timezone-aware clock
- use the shared helper at both age checks
- add a regression test for PyGithub's timezone-aware timestamps

## Test plan

- `uv run --frozen pytest modo_bugs/update_test.py`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
