### PR TITLE
Remove redundant metagame quality rank

### DIFF
--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -133,6 +133,17 @@ def test_pages_render_with_data_and_without_errors(browser: 'Browser', site: Con
     assert not problems, '\n'.join(problems)
 
 
+def test_metagame_uses_number_sign_for_deck_count_without_quality_rank(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site)
+    page.goto('/metagame/')
+    assert not wait_for_live_tables(page)
+    deck_count = page.locator('[title="Number of Decks"]').first
+    expect(deck_count).to_be_visible()
+    assert (deck_count.text_content() or '').strip().startswith('#')
+    expect(page.locator('.quality-rank')).to_have_count(0)
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
 def submenu_items(page: 'Page') -> 'Locator':
     return page.locator('.menu > li:has(.submenu):visible')
 

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -671,7 +671,6 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
         table = '_arch_disjoint_stats'
         base_where = 'TRUE'
         group_by = 'a.id'
-    rank_where = "deck_type = 'tournament'" if tournament_only else 'TRUE'
     if tournament_only:
         base_where = f"({base_where}) AND deck_type = 'tournament'"
     where = f'({where}) AND ({base_where})'
@@ -689,21 +688,6 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
                 archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1
             WHERE
                 ({base_where}) AND ({season_query})
-        ),
-        season_ranks AS (
-            SELECT
-                a.id AS archetype_id,
-                RANK() OVER (ORDER BY {clauses.wilson_lower_bound_sql()} DESC) AS quality_rank
-            FROM
-                archetype AS a
-            LEFT JOIN
-                _arch_disjoint_stats AS ars ON a.id = ars.archetype_id
-            LEFT JOIN
-                archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1
-            WHERE
-                ({rank_where}) AND ({season_query})
-            GROUP BY
-                a.id, aca.ancestor
         )
         SELECT
             a.id,
@@ -721,8 +705,7 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
             CAST(ROUND((SUM(wins) / NULLIF(SUM(wins + losses), 0)) * 100, 1) AS DOUBLE) AS win_percent,
             COUNT(*) OVER () AS total,
             SUM(wins + losses + draws) / tc.total_matches AS meta_share,
-            {clauses.wilson_lower_bound_sql()} AS quality_score,
-            sr.quality_rank
+            {clauses.wilson_lower_bound_sql()} AS quality_score
         FROM
             archetype AS a
         LEFT JOIN
@@ -731,8 +714,6 @@ def load_disjoint_archetypes(where: str = 'TRUE', order_by: str | None = None, l
              archetype_closure AS aca ON a.id = aca.descendant AND aca.depth = 1
         LEFT JOIN
             total_count AS tc ON TRUE
-        LEFT JOIN
-            season_ranks AS sr ON a.id = sr.archetype_id
         WHERE
             ({where}) AND ({season_query})
         GROUP BY

--- a/shared_web/static/js/metagamegrid.jsx
+++ b/shared_web/static/js/metagamegrid.jsx
@@ -35,7 +35,7 @@ const renderItem = (grid, archetype) => (
                 </span>
                 <span className="additional">
                     <span title="Number of Decks">
-                        🃏{n(archetype.numDecks)}
+                        #{n(archetype.numDecks)}
                     </span>
                     <span title="Number of Matches">
                         ⚔{n(archetype.numMatches)}
@@ -62,9 +62,6 @@ const renderItem = (grid, archetype) => (
                     <span title={sortExplanations.quality}>
                         <span className="quality-star">★</span>{Number(archetype.qualityScore * 100).toFixed(0)}
                     </span>
-                    {archetype.qualityRank && (
-                        <span title="Quality Rank in Season" className="quality-rank">#{archetype.qualityRank}</span>
-                    )}
                 </div>
             )}
         </div>


### PR DESCRIPTION
## Summary

- remove the season quality rank added by #15115 from the query and metagame tiles
- keep the existing starred quality score as the single quality indicator
- restore `#` as the deck-count marker, reverting the visual change from #15067
- add a browser regression check for both decisions

The rank mostly duplicated the default quality ordering and the displayed quality score. Its only extra information appeared after filtering or sorting by something else, which did not justify another number or the additional ranking query.

## Test plan

- `npm run build`
- `PD_BROWSER_TESTS=1 uv run --frozen pytest decksite/browser_test.py` — 7 passed
- `uv run --frozen python dev.py mypy decksite/data/archetype.py decksite/browser_test.py`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py jslint`
- `uv run --frozen pytest decksite/data/archetype_test.py` — 27 passed; 2 unrelated failures from duplicate rows in the persistent local test database