### PR TITLE
Order tied top 8 finishes by Swiss tiebreakers

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -136,12 +136,28 @@ def decks_api() -> Response:
             'total': <int>
         }
     """
-    order_by = clauses.decks_order_by(request.args.get('sortBy'), request.args.get('sortOrder'), request.args.get('competitionId'))
+    sort_by = request.args.get('sortBy')
+    competition_id = request.args.get('competitionId')
+    order_by = clauses.decks_order_by(sort_by, request.args.get('sortOrder'), competition_id)
     page, page_size, limit = pagination(request.args)
+    use_swiss_tiebreakers = clauses.decks_order_uses_swiss_tiebreakers(sort_by, competition_id)
+    page_start = page * page_size
+    query_start = page_start
+    if use_swiss_tiebreakers:
+        # A tied elimination group contains at most four quarterfinalists. Include enough rows
+        # on both sides of the requested page to order a group that crosses a page boundary.
+        buffer_size = deck.MAX_TIED_ELIMINATION_FINISH_SIZE - 1
+        query_start = max(0, page_start - buffer_size)
+        query_end = page_start + page_size + buffer_size
+        limit = f'LIMIT {query_start}, {query_end - query_start}'
     # Don't restrict by season if we're loading something with a date by its id.
-    season_id = 'all' if request.args.get('competitionId') else seasons.season_id(str(request.args.get('seasonId')), None)
+    season_id = 'all' if competition_id else seasons.season_id(str(request.args.get('seasonId')), None)
     where = clauses.decks_where(request.args, cast(bool, session.get('admin')), cast(int, session.get('person_id')))
     ds, total = deck.load_decks_with_total(where=where, order_by=order_by, limit=limit, season_id=season_id)
+    if use_swiss_tiebreakers:
+        ds = deck.order_decks_by_swiss_tiebreakers(ds)
+        result_start = page_start - query_start
+        ds = ds[result_start:result_start + page_size]
     prepare_decks(ds)
     r = {'page': page, 'total': total, 'objects': ds}
     resp = return_camelized_json(r)

--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -64,11 +64,16 @@ def decks_order_by(sort_by: str | None, sort_order: str | None, competition_id: 
         'sourceName': 's.name',
         'record': f'(cache.wins - cache.losses) {sort_order}, cache.wins',
         'omw': 'cache.omw IS NOT NULL DESC, cache.omw',
-        'top8': 'd.finish IS NOT NULL DESC, d.finish',
+        'top8': f'd.finish IS NOT NULL DESC, d.finish {sort_order}, IF(d.finish IS NULL, cache.active_date, c.start_date) DESC, d.competition_id ASC, d.person_id ASC',
         'date': 'cache.active_date',
         'season': 'cache.active_date',
     }
+    if sort_by == 'top8':
+        return sort_options[sort_by]
     return sort_options[sort_by] + f' {sort_order}, d.finish ASC, cache.active_date DESC'
+
+def decks_order_uses_swiss_tiebreakers(sort_by: str | None, competition_id: str | None) -> bool:
+    return sort_by == 'top8' or (not sort_by and bool(competition_id))
 
 def cards_order_by(sort_by: str | None, sort_order: str | None) -> str:
     if not sort_by:

--- a/decksite/data/clauses_test.py
+++ b/decksite/data/clauses_test.py
@@ -107,6 +107,20 @@ def test_order_by_auto() -> None:
     assert 'DESC' in clauses.archetype_order_by('quality', 'AUTO')
     assert 'ASC' in clauses.archetype_order_by('name', 'AUTO')
 
+def test_top8_order_groups_tied_finishes_by_competition_for_application_tiebreaking() -> None:
+    order_by = clauses.decks_order_by('top8', 'AUTO', None)
+
+    assert order_by.index('d.finish ASC') < order_by.index('c.start_date) DESC')
+    assert order_by.index('c.start_date) DESC') < order_by.index('d.competition_id ASC')
+    assert order_by.index('d.competition_id ASC') < order_by.index('d.person_id ASC')
+    assert 'deck_match' not in order_by
+
+def test_only_top8_order_uses_swiss_tiebreakers() -> None:
+    assert clauses.decks_order_uses_swiss_tiebreakers('top8', None)
+    assert clauses.decks_order_uses_swiss_tiebreakers(None, '123')
+    assert not clauses.decks_order_uses_swiss_tiebreakers('date', '123')
+    assert not clauses.decks_order_uses_swiss_tiebreakers(None, None)
+
 def test_cards_where_single(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(clauses.oracle, 'valid_name', lambda name: name)
     result = clauses.cards_where(['Hive Mind'])

--- a/decksite/data/deck.py
+++ b/decksite/data/deck.py
@@ -17,6 +17,16 @@ from shared.database import sqlescape
 from shared.pd_exception import DatabaseException, InvalidDataException, LockNotAcquiredException
 from shared_web import fonts
 
+MAX_TIED_ELIMINATION_FINISH_SIZE = 4
+
+
+class SwissRecord(TypedDict):
+    match_points: int
+    matches_played: int
+    games_won: int
+    games_played: int
+    opponents: list[int]
+
 
 def latest_decks(season_id: str | int | None = None) -> list[Deck]:
     return load_decks(where='d.created_date > UNIX_TIMESTAMP(NOW() - INTERVAL 30 DAY)', limit='LIMIT 500', season_id=season_id)
@@ -154,6 +164,95 @@ def deserialize_deck(sdeck: Container) -> Deck:
     deck.maindeck = [CardRef(ref['name'], ref['n']) for ref in deck.maindeck]
     deck.sideboard = [CardRef(ref['name'], ref['n']) for ref in deck.sideboard]
     return deck
+
+def order_decks_by_swiss_tiebreakers(decks: list[Deck]) -> list[Deck]:
+    """Order tied top-four/top-eight groups without turning their shared finish into fake individual places."""
+    tied_groups: list[tuple[int, int]] = []
+    group_start = 0
+    while group_start < len(decks):
+        group_key = (decks[group_start].competition_id, decks[group_start].finish)
+        group_end = group_start + 1
+        while group_end < len(decks) and (decks[group_end].competition_id, decks[group_end].finish) == group_key:
+            group_end += 1
+        if group_key[1] in [3, 5] and group_end - group_start > 1:
+            tied_groups.append((group_start, group_end))
+        group_start = group_end
+    if not tied_groups:
+        return decks
+
+    competition_ids = {decks[start].competition_id for start, _ in tied_groups}
+    ids = ', '.join(str(int(competition_id)) for competition_id in competition_ids)
+    rows = db().select(f"""
+        SELECT
+            player_dm.deck_id,
+            opponent_dm.deck_id AS opponent_deck_id,
+            player_dm.games,
+            opponent_dm.games AS opponent_games
+        FROM
+            deck_match AS player_dm
+        INNER JOIN
+            deck AS player_deck ON player_deck.id = player_dm.deck_id
+        INNER JOIN
+            `match` AS player_match ON player_match.id = player_dm.match_id
+        LEFT JOIN
+            deck_match AS opponent_dm ON opponent_dm.match_id = player_dm.match_id AND opponent_dm.deck_id <> player_dm.deck_id
+        WHERE
+            player_deck.competition_id IN ({ids}) AND player_match.elimination = 0
+    """)
+    records: dict[int, SwissRecord] = {}
+    for row in rows:
+        deck_id = int(row['deck_id'])
+        record = records.setdefault(deck_id, {'match_points': 0, 'matches_played': 0, 'games_won': 0, 'games_played': 0, 'opponents': []})
+        opponent_id = row['opponent_deck_id']
+        opponent_games = int(row['opponent_games'] or 0)
+        games = int(row['games'])
+        record['matches_played'] += 1
+        if games > opponent_games:
+            record['match_points'] += 3
+        elif games == opponent_games:
+            record['match_points'] += 1
+        if opponent_id is not None:
+            record['games_won'] += games
+            record['games_played'] += games + opponent_games
+            record['opponents'].append(int(opponent_id))
+
+    def percentage(numerator: int, denominator: int) -> float | None:
+        return numerator / denominator if denominator else None
+
+    def average(values: list[float]) -> float | None:
+        return sum(values) / len(values) if values else None
+
+    def metrics(deck_id: int) -> tuple[float | None, float | None, float | None, float | None]:
+        record = records.get(deck_id)
+        if record is None:
+            return None, None, None, None
+        opponent_match_win_percentages = []
+        opponent_game_win_percentages = []
+        for opponent_id in record['opponents']:
+            opponent = records[opponent_id]
+            opponent_match_win_percentage = percentage(opponent['match_points'], opponent['matches_played'] * 3)
+            if opponent_match_win_percentage is not None:
+                opponent_match_win_percentages.append(max(0.33, opponent_match_win_percentage))
+            opponent_game_win_percentage = percentage(opponent['games_won'], opponent['games_played'])
+            if opponent_game_win_percentage is not None:
+                opponent_game_win_percentages.append(max(0.33, opponent_game_win_percentage))
+        return (
+            float(record['match_points']),
+            average(opponent_match_win_percentages),
+            percentage(record['games_won'], record['games_played']),
+            average(opponent_game_win_percentages),
+        )
+
+    def descending(value: float | None) -> float:
+        return -value if value is not None else float('inf')
+
+    ordered = list(decks)
+    for start, end in tied_groups:
+        ordered[start:end] = sorted(
+            ordered[start:end],
+            key=lambda d: tuple(descending(value) for value in metrics(d.id)) + (str(d.person).casefold(),),
+        )
+    return ordered
 
 def load_decks_heavy(where: str = 'TRUE',
                      having: str = 'TRUE',

--- a/decksite/data/deck_test.py
+++ b/decksite/data/deck_test.py
@@ -33,6 +33,43 @@ def test_maybe_regenerate_symbols_font_ignores_latin_1() -> None:
     regenerate_symbols_font.assert_not_called()
 
 
+def test_order_decks_by_swiss_tiebreakers_uses_opponents_match_win_percentage() -> None:
+    def result(deck_id: int, opponent_id: int, games: int, opponent_games: int) -> dict[str, int]:
+        return {'deck_id': deck_id, 'opponent_deck_id': opponent_id, 'games': games, 'opponent_games': opponent_games}
+
+    # Both quarterfinalists won their only match in this compact sample. Alpha's opponent
+    # then won twice, while Beta's opponent lost twice, so OMW% separates the tied players.
+    rows = [
+        result(1, 3, 2, 0), result(3, 1, 0, 2),
+        result(2, 4, 2, 0), result(4, 2, 0, 2),
+        result(3, 5, 2, 0), result(5, 3, 0, 2),
+        result(3, 6, 2, 0), result(6, 3, 0, 2),
+        result(4, 5, 0, 2), result(5, 4, 2, 0),
+        result(4, 6, 0, 2), result(6, 4, 2, 0),
+    ]
+    alpha = Deck({'id': 1, 'competition_id': 10, 'finish': 5, 'person': 'Alpha'})
+    beta = Deck({'id': 2, 'competition_id': 10, 'finish': 5, 'person': 'Beta'})
+
+    with mock.patch.object(deck, 'db') as database:
+        database.return_value.select.return_value = rows
+        ordered = deck.order_decks_by_swiss_tiebreakers([beta, alpha])
+
+    assert [d.id for d in ordered] == [1, 2]
+    sql = database.return_value.select.call_args.args[0]
+    assert 'player_match.elimination = 0' in sql
+
+
+def test_order_decks_by_swiss_tiebreakers_does_no_extra_query_without_visible_tie() -> None:
+    winner = Deck({'id': 1, 'competition_id': 10, 'finish': 1, 'person': 'Winner'})
+    semifinalist = Deck({'id': 2, 'competition_id': 10, 'finish': 3, 'person': 'Semifinalist'})
+
+    with mock.patch.object(deck, 'db') as database:
+        ordered = deck.order_decks_by_swiss_tiebreakers([winner, semifinalist])
+
+    assert ordered == [winner, semifinalist]
+    database.assert_not_called()
+
+
 def test_set_colors() -> None:
     def card(name: str, mana_cost: str, oracle_text: str = '') -> Card:
         return Card({


### PR DESCRIPTION
## Why it is broken

Losing semifinalists are all stored with `finish = 3`, and losing quarterfinalists with `finish = 5`. That is intentional: they tied for 3rd–4th or 5th–8th rather than earning distinct places.

The Top 8 query only ordered those decks by finish and date, so rows inside each tied group had no meaningful or stable order.

## Previous fix

PR #15108 attempted to stabilize the result by appending `d.id` to the data layer's default deck ordering. The competition API always passes an explicit ordering from `decks_order_by`, so that default is bypassed on the affected page. Even where used, insertion order is not a tournament tiebreaker.

This is a follow-up to #15108 and the original request in #12571.

## Fix

When Top 8 ordering is active, keep `3/3` and `5/5/5/5` as tied finishes but order each tied competition group by the Swiss standings chain already present in our match data:

1. Match points
2. Opponents' match-win percentage
3. Game-win percentage
4. Opponents' game-win percentage

Elimination matches are excluded. Byes count for match points but not game percentage. Exact ties fall back to player name for stable display without claiming a different finish.

The API over-fetches three rows on either side of a page boundary—the largest tied group has four decks—then calculates tiebreakers only for tied semifinalists or quarterfinalists visible in that bounded result. Every explicit Top 8 sort gets the behavior; other sorts do no extra work.

## Performance

- Largest historical Gatherling tournament (128 decks): about 6 ms of tiebreaker work
- Full competition API response used for browser verification: about 26 ms
- All Time → Top 8: remains around its existing 1.3–1.4 seconds; it does not calculate every historical tournament

The historical `Penny Dreadful Sundays 19.05` fixture produces the same semifinalist and quarterfinalist ordering as Gatherling's stored standings.

## Validation

- 45 focused Python/functional tests passed
- 7 browser tests passed in Google Chrome
- mypy passed
- Python lint passed
- JavaScript lint passed
- production JavaScript build passed

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
