### PR TITLE
Keep pointer cursor on titled interactive elements

### DIFF
--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -144,6 +144,20 @@ def test_metagame_uses_number_sign_for_deck_count_without_quality_rank(browser: 
     assert not collector.problems, '\n'.join(collector.problems)
 
 
+def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site)
+    page.goto('/metagame/')
+    assert not wait_for_live_tables(page)
+    expect(page.locator('[title="Number of Decks"]').first).to_have_css('cursor', 'pointer')
+
+    page.goto('/decks/league/')
+    expect(page.locator('th.omw')).to_have_css('cursor', 'pointer')
+
+    page.locator('main').evaluate("element => { element.insertAdjacentHTML('beforeend', '<li class=button id=informational-title title=Details>Achievement</li>'); }")
+    expect(page.locator('#informational-title')).to_have_css('cursor', 'help')
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
 def submenu_items(page: 'Page') -> 'Locator':
     return page.locator('.menu > li:has(.submenu):visible')
 

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -3256,7 +3256,25 @@ A reasonable amount has been cut which we'll need to restore if we ever want dif
     cursor: help;
 }
 
-[title]:not(a) {
+[title]:not(
+    a,
+    a *,
+    button,
+    button *,
+    input,
+    label,
+    label *,
+    select,
+    summary,
+    summary *,
+    textarea,
+    th,
+    th *,
+    [role="button"],
+    [role="button"] *,
+    .clickable,
+    .clickable *
+) {
     cursor: help;
 }
 


### PR DESCRIPTION
## Why it is broken

PR #15114 added a global `[title]:not(a) { cursor: help; }` rule for #12537. The original request was about informational elements such as achievements, where the help cursor correctly signals a hover explanation.

The selector also matches interactive elements and titled descendants of links. Because `cursor` is resolved on the element under the pointer, this overrides the pointer cursor in places such as:

- titled statistics inside clickable metagame tiles
- the titled, sortable OMW table header
- titled buttons, form controls, and clickable rows

Those elements still click, but their cursor advertises help rather than their primary action.

## Fix

Keep the general help-cursor behavior for informational titled elements, but exclude interactive elements and their descendants: links, buttons, form controls, sortable table headers, ARIA buttons, and `.clickable` components.

This preserves the requested help cursor on achievement-style `<li title>` elements while restoring the pointer cursor wherever clicking is the primary behavior.

Follow-up to #15114 and #12537.

## Validation

Added a browser regression test covering all three important cases:

- title inside a clickable metagame tile: `pointer`
- titled sortable OMW header: `pointer`
- informational achievement-style title: `help`

All 8 browser tests pass in Google Chrome, and Python lint passes.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
