### PR TITLE
Normalize integer-valued database results

### DIFF
--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -158,6 +158,29 @@ def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: 
     assert not collector.problems, '\n'.join(collector.problems)
 
 
+def test_card_stats_are_numbers_and_locale_formatted(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site, locale='en-US')
+    with page.expect_response(lambda response: '/api/cards2/' in response.url) as response_info:
+        page.goto('/seasons/all/cards/')
+    assert not wait_for_live_tables(page)
+
+    data = response_info.value.json()
+    assert data['objects']
+    card = data['objects'][0]
+    fields = ['numDecks', 'wins', 'losses', 'draws', 'record', 'perfectRuns', 'tournamentWins', 'tournamentTop8s']
+    for field in fields:
+        assert isinstance(card[field], int) and not isinstance(card[field], bool), f'{field} was {type(card[field]).__name__}'
+
+    row = page.locator('.cardtable tbody tr').first
+    numeric_cells = row.locator('td.n')
+    expected_num_decks = page.evaluate('(value) => value.toLocaleString()', card['numDecks'])
+    record = [card['wins'], card['losses']] + ([card['draws']] if card['draws'] > 0 else [])
+    expected_record = page.evaluate('(values) => values.map(value => value.toLocaleString()).join("–")', record)
+    expect(numeric_cells.nth(0)).to_have_text(expected_num_decks)
+    expect(numeric_cells.nth(1)).to_have_text(expected_record)
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
 def submenu_items(page: 'Page') -> 'Locator':
     return page.locator('.menu > li:has(.submenu):visible')
 

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -158,7 +158,7 @@ def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: 
     assert not collector.problems, '\n'.join(collector.problems)
 
 
-def test_card_stats_are_numbers_and_locale_formatted(browser: 'Browser', site: Container) -> None:
+def test_card_stats_are_numbers_and_card_summaries_are_locale_formatted(browser: 'Browser', site: Container) -> None:
     page, collector = new_page(browser, site, locale='en-US')
     with page.expect_response(lambda response: '/api/cards2/' in response.url) as response_info:
         page.goto('/seasons/all/cards/')
@@ -172,12 +172,19 @@ def test_card_stats_are_numbers_and_locale_formatted(browser: 'Browser', site: C
         assert isinstance(card[field], int) and not isinstance(card[field], bool), f'{field} was {type(card[field]).__name__}'
 
     row = page.locator('.cardtable tbody tr').first
-    numeric_cells = row.locator('td.n')
     expected_num_decks = page.evaluate('(value) => value.toLocaleString()', card['numDecks'])
+    expected_win_percent = page.evaluate('(value) => value.toLocaleString([], {minimumFractionDigits: 1, maximumFractionDigits: 1})', card['winPercent'])
     record = [card['wins'], card['losses']] + ([card['draws']] if card['draws'] > 0 else [])
     expected_record = page.evaluate('(values) => values.map(value => value.toLocaleString()).join("–")', record)
-    expect(numeric_cells.nth(0)).to_have_text(expected_num_decks)
-    expect(numeric_cells.nth(1)).to_have_text(expected_record)
+    expect(row.locator('.num-decks')).to_have_text(expected_num_decks)
+    expect(row.locator('.win-percent')).to_have_text(expected_win_percent)
+    expect(row.locator('.win-percent span')).to_have_attribute('title', f'Record: {expected_record}')
+    assert re.fullmatch(r'.*[.,]\d', row.locator('.win-percent').inner_text())
+
+    page.goto('/')
+    top_cards = page.locator('section').filter(has=page.get_by_role('heading', name='Top Cards'))
+    assert top_cards.locator('th').all_text_contents() == ['Card', '# Decks', 'Win %']
+    expect(top_cards.locator('tbody tr').first.locator('td').nth(2)).to_have_attribute('title', re.compile(r'^Record: [\d,.]+–[\d,.]+'))
     assert not collector.problems, '\n'.join(collector.problems)
 
 

--- a/decksite/controllers/api_test.py
+++ b/decksite/controllers/api_test.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 import pytest
 
 from decksite.controllers import api
+from decksite.database import db
 from decksite.main import APP
 from shared.container import Container
 
@@ -65,3 +66,35 @@ def test_card_api_returns_not_found_for_unknown_card() -> None:
 
     assert response.status_code == 404
     assert response.get_json()['code'] == 'NOTFOUND'
+
+
+@pytest.mark.functional
+def test_aggregate_apis_serialize_integer_stats_as_numbers(seeded_db: Container) -> None:
+    season_id = db().value('SELECT season_id FROM deck_cache LIMIT 1')
+    cases = [
+        ('/api/cards2/', {
+            'deckType': 'all', 'page': 0, 'pageSize': 1, 'seasonId': 'all', 'sortBy': 'numDecks', 'sortOrder': 'DESC',
+        }, ['numDecks', 'wins', 'losses', 'draws', 'record', 'perfectRuns', 'tournamentWins', 'tournamentTop8s']),
+        ('/api/people/', {
+            'page': 0, 'pageSize': 1, 'seasonId': 'all', 'sortBy': 'numDecks', 'sortOrder': 'DESC',
+        }, ['numDecks', 'wins', 'losses', 'draws', 'record', 'perfectRuns', 'tournamentWins', 'tournamentTop8s', 'numCompetitions']),
+        ('/api/archetypes2/', {
+            'deckType': 'all', 'page': 0, 'pageSize': 1, 'seasonId': season_id, 'sortBy': 'quality', 'sortOrder': 'AUTO',
+        }, ['numDecks', 'numMatches', 'wins', 'losses', 'draws', 'record', 'perfectRuns', 'tournamentWins', 'tournamentTop8s']),
+        ('/api/leaderboards/', {
+            'page': 0, 'pageSize': 1, 'seasonId': season_id, 'sortBy': 'points', 'sortOrder': 'DESC',
+        }, ['numDecks', 'wins', 'points']),
+        ('/api/h2h/', {
+            'page': 0, 'pageSize': 1, 'personId': seeded_db.person_id, 'seasonId': season_id, 'sortBy': 'numMatches', 'sortOrder': 'DESC',
+        }, ['numMatches', 'wins', 'losses', 'draws', 'record']),
+    ]
+
+    client = APP.test_client()
+    for path, query_string, fields in cases:
+        response = client.get(path, query_string=query_string)
+        assert response.status_code == 200, path
+        data = response.get_json()
+        assert data['objects'], path
+        for field in fields:
+            value = data['objects'][0][field]
+            assert isinstance(value, int) and not isinstance(value, bool), f'{path} {field} was {type(value).__name__}'

--- a/decksite/data/card.py
+++ b/decksite/data/card.py
@@ -309,7 +309,7 @@ def load_cards_with_total(
             SUM(IFNULL(wins, 0)) AS wins,
             SUM(IFNULL(losses, 0)) AS losses,
             SUM(IFNULL(draws, 0)) AS draws,
-            SUM(IFNULL(wins, 0) - losses) AS record,
+            SUM(IFNULL(wins, 0) - IFNULL(losses, 0)) AS record,
             SUM(IFNULL(perfect_runs, 0)) AS perfect_runs,
             SUM(IFNULL(tournament_wins, 0)) AS tournament_wins,
             SUM(IFNULL(tournament_top8s, 0)) AS tournament_top8s,

--- a/decksite/data/card_test.py
+++ b/decksite/data/card_test.py
@@ -1,7 +1,20 @@
 import pytest
 
 from decksite.data import card
+from decksite.database import db
 from shared import perf
+from shared.container import Container
+
+INTEGER_STAT_FIELDS = [
+    'num_decks',
+    'wins',
+    'losses',
+    'draws',
+    'record',
+    'perfect_runs',
+    'tournament_wins',
+    'tournament_top8s',
+]
 
 
 @pytest.mark.perf
@@ -13,6 +26,35 @@ def test_load_cards_season() -> None:
 @pytest.mark.perf
 def test_load_cards_all() -> None:
     perf.test(card.load_cards, 5)
+
+
+@pytest.mark.functional
+def test_load_cards_returns_integer_stats(seeded_db: Container) -> None:
+    results = [
+        card.load_cards_with_total(limit='LIMIT 1', season_id='all'),
+        card.load_cards_with_total(limit='LIMIT 1', competition_id=seeded_db.competition_id),
+    ]
+    for cards, total in results:
+        assert cards
+        assert isinstance(total, int)
+        for field in INTEGER_STAT_FIELDS:
+            assert isinstance(cards[0][field], int), f'{field} was {type(cards[0][field]).__name__}'
+
+
+@pytest.mark.functional
+def test_load_all_legal_cards_returns_zero_integer_stats_for_unplayed_cards(seeded_db: Container) -> None:
+    season_id = db().value('SELECT season_id FROM deck_cache LIMIT 1')
+    db().execute('CREATE TABLE _legal_cards (season_id INT NOT NULL, name VARCHAR(190) NOT NULL, PRIMARY KEY (season_id, name))')
+    db().execute("INSERT INTO _legal_cards (season_id, name) VALUES (%s, 'Plains')", [season_id])
+
+    cards, total = card.load_cards_with_total(season_id=season_id, all_legal=True)
+
+    assert total == 1
+    assert len(cards) == 1
+    for field in INTEGER_STAT_FIELDS:
+        assert cards[0][field] == 0
+        assert isinstance(cards[0][field], int)
+
 
 def test_trailblazer_cards_include_season(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeDatabase:

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -38,16 +38,14 @@
             <thead>
                 <th>Card</th>
                 <th># Decks</th>
-                <th>Record</th>
                 <th>Win %</th>
             </thead>
             <tbody>
                 {{#top_cards}}
                     <tr data-href="{{url}}" class="clickable">
                         <td>{{> singlecard}}</td>
-                        <td class="n">{{num_decks}}</td>
-                        <td class="n">{{wins}}–{{losses}}{{#draws}}–{{draws}}{{/draws}}</td>
-                        <td class="n">{{win_percent}}</td>
+                        <td class="n">{{num_decks_display}}</td>
+                        <td class="n" title="Record: {{record_display}}" aria-label="{{win_percent_display}}%; record {{record_display}}">{{win_percent_display}}</td>
                     </tr>
                 {{/top_cards}}
             </tbody>

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -1,5 +1,5 @@
 from flask import url_for
-from flask_babel import gettext
+from flask_babel import format_decimal, gettext
 
 from decksite.data.archetype import WINDOW_DAYS, Archetype
 from decksite.view import View
@@ -91,6 +91,11 @@ class Home(View):
     def setup_cards(self, cards: list[Card]) -> None:
         cards = [c for c in cards if 'Basic' not in c.type_line]
         self.top_cards = cards[0:8]
+        for card in self.top_cards:
+            card.num_decks_display = format_decimal(card.num_decks)
+            record = [card.wins, card.losses] + ([card.draws] if card.draws else [])
+            card.record_display = '–'.join(format_decimal(n) for n in record)
+            card.win_percent_display = format_decimal(card.win_percent, format='#,##0.0')
         self.has_top_cards = len(cards) > 0
         self.cards = self.top_cards  # To get prepare_card treatment
         self.cards_url = url_for('.cards')

--- a/shared/database.py
+++ b/shared/database.py
@@ -1,14 +1,17 @@
 import warnings
 from collections.abc import Iterable
+from decimal import Decimal
 from typing import Any, cast
 
 import MySQLdb
 from MySQLdb import OperationalError
+from MySQLdb.constants import FIELD_TYPE
 
 from shared import configuration, perf
 from shared.pd_exception import DatabaseConnectionRefusedException, DatabaseException, DatabaseMissingException, DatabaseNoSuchTableException, InvalidArgumentException, LockNotAcquiredException
 
 ValidSqlArgumentDescription = Any
+DECIMAL_FIELD_TYPES = {FIELD_TYPE.DECIMAL, FIELD_TYPE.NEWDECIMAL}
 
 class Database:
     def __init__(self, db: str) -> None:
@@ -72,6 +75,13 @@ class Database:
                 perf.check(p, 'slow_query', (f'```{sql}```', f'```{args}```'), 'mysql')
                 if fetch_rows:
                     rows = self.cursor.fetchall()
+                    # MariaDB returns SUM(integer) and DECIMAL(..., 0) as Decimal. The DB-API scale metadata lets us
+                    # restore their integer semantics without converting genuinely fractional Decimals to float.
+                    scale_zero_columns = [field[0] for field in self.cursor.description if field[1] in DECIMAL_FIELD_TYPES and field[5] == 0]
+                    for row in rows:
+                        for column in scale_zero_columns:
+                            if isinstance(row[column], Decimal):
+                                row[column] = int(row[column])
                     result = (n, rows)
                 else:
                     result = (n, [])

--- a/shared/database_test.py
+++ b/shared/database_test.py
@@ -1,7 +1,9 @@
+from decimal import Decimal
 from unittest.mock import Mock, patch
 
 import pytest
 from MySQLdb import OperationalError
+from MySQLdb.constants import FIELD_TYPE
 
 from shared.database import Database, sqlescape, sqllikeescape
 from shared.pd_exception import DatabaseException, InvalidArgumentException
@@ -31,6 +33,35 @@ def test_execute_does_not_retry_when_server_goes_away_during_transaction() -> No
     connect.assert_called_once_with()
     assert db.cursor.execute.call_count == 1
     assert db.open_transactions == []
+
+def test_execute_converts_scale_zero_decimals_to_integers() -> None:
+    db = Database.__new__(Database)
+    db.cursor = Mock()
+    db.cursor.execute.return_value = 1
+    db.cursor.fetchall.return_value = [{
+        'integer_decimal': Decimal('123456789012345678901234567890123'),
+        'integer': 7,
+        'nullable': None,
+        'fractional_decimal': Decimal('10.00'),
+    }]
+    db.cursor.description = (
+        ('integer_decimal', FIELD_TYPE.NEWDECIMAL, 33, 33, 33, 0, False),
+        ('integer', FIELD_TYPE.LONGLONG, 1, 21, 21, 0, False),
+        ('nullable', FIELD_TYPE.NEWDECIMAL, None, 33, 33, 0, True),
+        ('fractional_decimal', FIELD_TYPE.NEWDECIMAL, 5, 22, 22, 2, False),
+    )
+    db.open_transactions = []
+
+    _, rows = db.execute_with_reconnect('SELECT results', fetch_rows=True)
+
+    assert rows == [{
+        'integer_decimal': 123456789012345678901234567890123,
+        'integer': 7,
+        'nullable': None,
+        'fractional_decimal': Decimal('10.00'),
+    }]
+    assert isinstance(rows[0]['integer_decimal'], int)
+    assert isinstance(rows[0]['fractional_decimal'], Decimal)
 
 
 def test_sqlescape() -> None:

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1373,13 +1373,6 @@ Force a consistent size of each column in react tables otherwise things "jump" a
     max-width: 5em;
 }
 
-/* We use the name 'card-record' for this rule not 'record' because Deck Table already has a .record.
-Although it displays a similar thing that maxes out around 7-1-1 for a long tournament run but a card's all time record size is unbounded. */
-.live .card-record {
-    min-width: 8em;
-    max-width: 8em;
-}
-
 .live .win-percent {
     min-width: 3em;
     max-width: 3em;

--- a/shared_web/static/js/cardtable.jsx
+++ b/shared_web/static/js/cardtable.jsx
@@ -6,7 +6,6 @@ const renderHeaderRow = (table) => (
     <tr>
         <th className="name" onClick={table.sort.bind(table, "name", "ASC")}>Card</th>
         <th className="n num-decks" onClick={table.sort.bind(table, "numDecks", "DESC")}># Decks</th>
-        <th className="n card-record" onClick={table.sort.bind(table, "record", "DESC")}>Record</th>
         <th className="n win-percent" onClick={table.sort.bind(table, "winPercent", "DESC")}>Win %</th>
         { table.props.leagueOnly
             ? null
@@ -30,32 +29,38 @@ const renderHeaderRow = (table) => (
 const renderRow = (table, card) => (
     <tr key={card.name} className="clickable">
         <td className="name">{renderCard(card)}</td>
-        <td className="n">{card.numDecks.toLocaleString()}</td>
-        <td className="n">{renderRecord(card)}</td>
-        <td className="n">{renderWinPercent(card)}</td>
+        <td className="n num-decks">{card.numDecks.toLocaleString()}</td>
+        <td className="n win-percent">
+            <span
+                title={`Record: ${renderRecord(card)}`}
+                aria-label={`${renderWinPercent(card)}%; record ${renderRecord(card)}`}
+            >
+                {renderWinPercent(card)}
+            </span>
+        </td>
         { table.props.leagueOnly
             ? null
-            : <td className="n">
+            : <td className="n tournament-wins">
                 { card.tournamentWins > 0
-                    ? card.tournamentWins
+                    ? card.tournamentWins.toLocaleString()
                     : ""
                 }
             </td>
         }
         { table.props.leagueOnly
             ? null
-            : <td className="n">
+            : <td className="n tournament-top-8s">
                 { card.tournamentTop8s > 0
-                    ? card.tournamentTop8s
+                    ? card.tournamentTop8s.toLocaleString()
                     : ""
                 }
             </td>
         }
         { table.props.tournamentOnly
             ? null
-            : <td className="n">
+            : <td className="n perfect-runs">
                 { card.perfectRuns > 0
-                    ? card.perfectRuns
+                    ? card.perfectRuns.toLocaleString()
                     : ""
                 }
             </td>

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -104,9 +104,10 @@ export const renderRecord = (object) => {
 };
 
 export const renderWinPercent = (object) => {
-    if (object.showRecord) {
-        return object.winPercent;
+    if (object.showRecord && Number.isFinite(object.winPercent)) {
+        return object.winPercent.toLocaleString([], {minimumFractionDigits: 1, maximumFractionDigits: 1});
     }
+    return "";
 };
 
 export const renderCard = (card) => (


### PR DESCRIPTION
## Why it is broken

PR #15122 added locale formatting in the browser for issue #12509, but aggregate statistics were commonly supplied as JSON strings. MariaDB returns `SUM(INT)` as `DECIMAL(..., 0)`; mysqlclient preserves that as Python `Decimal`; and our generic JSON serializer deliberately preserves `Decimal` precision by serializing it as a string. JavaScript `String.prototype.toLocaleString()` returns the string unchanged, so the separators never appeared.

This was not card-specific. People, archetypes, leaderboards, head-to-head records, and matchup statistics had the same type mismatch wherever they summed integer columns.

## What broke it

#15122 did not regress previously working behavior; it shipped a browser-side fix that could not work with the existing API response type. Its validation covered lint only and did not inspect a real API response or rendered page.

## Original ask

#12509 asked for commas (or the localized equivalent) in the large numbers on `/seasons/all/cards` and noted that the deck-count column might need to be wider on narrow screens.

## Why this fix

Normalize the type once at the database boundary using standard cursor result metadata:

- MariaDB/mysqlclient reports `SUM(integer)` as `DECIMAL` with scale zero.
- After fetching a result set, the database wrapper converts only Decimal-valued columns whose declared scale is zero to Python `int`.
- True fractional Decimals, such as `DECIMAL(..., 2)` and calculated ratios, remain Decimal and retain their precision.
- `COUNT` and ordinary integer columns already arrive as `int` and are untouched.

This makes integer semantics automatic for cards, people, archetypes, leaderboards, head-to-head records, matchups, stored `DECIMAL(..., 0)` columns, and future `SUM(integer)` queries. It avoids query-by-query converter lists, column-name guesses, and unsafe global Decimal-to-float conversion.

The conversion list is computed once from cursor metadata and normally contains only aggregate Decimal columns. Work is proportional to returned rows, not the underlying tournament/deck dataset.

The card query also now defines an unplayed legal card's record as zero in SQL rather than allowing `NULL` through one side of the subtraction.

## Card-table presentation

Localizing every part of `W–L–D` made the exact values legible but left the table as a dense, uneven block of digits. Replacing it with Matches was tidier, but Matches and # Decks are almost duplicate signals: among all-time cards with at least 100 decks their correlation is 0.99973.

Card summary tables therefore show **# Decks** and **Win %**, with the exact localized record preserved in the Win % tooltip and accessibility label. Win percentages always render with one localized decimal place, including values such as `52.0`; the shared formatter also makes People and Head-to-Head consistent. Tournament wins, Top 8s, and 5–0s remain fully legible and sortable, and their values are localized consistently.

The server-rendered homepage Top Cards table now uses the same reduced columns and localized display instead of retaining a separate W–L–D presentation.

## Validation

- Central database test covers a 33-digit `DECIMAL(..., 0)`, existing integer and null values, and a `DECIMAL(..., 2)` that must remain Decimal.
- Aggregate API test covers cards, people, archetypes, leaderboards, and head-to-head statistics.
- 42 focused clause, card-data, view, and API tests pass.
- All 9 Playwright browser tests pass against the running preview, including assertions for API types, localized deck counts, fixed-width win percentages, exact-record tooltips, and the homepage summary.
- The existing all-seasons card performance test completes in about 1.2 seconds (limit: 5 seconds).
- Ruff, mypy, jslint, and the production JavaScript build pass.
- The forwarded preview was verified from the Mac with HTTP 200.

Follow-up to #15122 and #12509.
