### PR TITLE
Report unavailable card data accurately

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -688,7 +688,14 @@ def hide_intro() -> Response:
 @auth.load_person
 def person_status() -> Response:
     username = auth.mtgo_username()
-    stale_card_information_age = magic_database.stale_card_information_age()
+    if not magic_database.card_information_is_available():
+        card_information_warning = 'Card data is unavailable'
+    else:
+        stale_card_information_age = magic_database.stale_card_information_age()
+        if stale_card_information_age is not None:
+            card_information_warning = f'Card data last updated {dtutil.display_time(stale_card_information_age.total_seconds(), 1)} ago'
+        else:
+            card_information_warning = ''
     r = {
         'mtgo_username': username,
         'discord_id': auth.discord_id(),
@@ -696,7 +703,7 @@ def person_status() -> Response:
         'demimod': session.get('demimod', False),
         'hide_intro': request.cookies.get('hide_intro', False) or auth.hide_intro() or username or auth.discord_id(),
         'in_guild': session.get('in_guild', False),
-        'card_information_warning': f'Card data last updated {dtutil.display_time(stale_card_information_age.total_seconds(), 1)} ago' if stale_card_information_age is not None else '',
+        'card_information_warning': card_information_warning,
     }
     if username:
         d = guarantee_at_most_one_or_retire(league.active_decks_by(username))

--- a/decksite/controllers/api_test.py
+++ b/decksite/controllers/api_test.py
@@ -9,6 +9,7 @@ from shared.container import Container
 
 
 def test_status_includes_stale_card_information_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api.magic_database, 'card_information_is_available', lambda: True)
     monkeypatch.setattr(api.magic_database, 'stale_card_information_age', lambda: api.datetime.timedelta(days=4))
     monkeypatch.setattr(api.league, 'active_league', lambda: None)
 
@@ -19,6 +20,7 @@ def test_status_includes_stale_card_information_warning(monkeypatch: pytest.Monk
     assert data['card_information_warning'] == 'Card data last updated 4 days ago'
 
 def test_status_omits_recent_card_information_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api.magic_database, 'card_information_is_available', lambda: True)
     monkeypatch.setattr(api.magic_database, 'stale_card_information_age', lambda: None)
     monkeypatch.setattr(api.league, 'active_league', lambda: None)
 
@@ -27,6 +29,16 @@ def test_status_omits_recent_card_information_warning(monkeypatch: pytest.Monkey
 
     data = json.loads(response.get_data(as_text=True))
     assert data['card_information_warning'] == ''
+
+def test_status_reports_unavailable_card_information(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api.magic_database, 'card_information_is_available', lambda: False)
+    monkeypatch.setattr(api.league, 'active_league', lambda: None)
+
+    with APP.test_request_context('/api/status'):
+        response = cast(Any, api.person_status).__wrapped__()
+
+    data = json.loads(response.get_data(as_text=True))
+    assert data['card_information_warning'] == 'Card data is unavailable'
 
 
 def test_archetypes2_serializes_win_percent_as_number_or_null(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/discordbot/command.py
+++ b/discordbot/command.py
@@ -156,6 +156,8 @@ async def post_nothing(channel: PrefixedContext | InteractionContext | TYPE_MESS
     await message.add_reaction('❎')
 
 def stale_card_information_warning() -> str:
+    if not database.card_information_is_available():
+        return '\nWARNING: card information is unavailable'
     age = database.stale_card_information_age()
     if age is not None:
         return f'\nWARNING: card information is {dtutil.display_time(age.total_seconds(), 1)} old'

--- a/discordbot/command_test.py
+++ b/discordbot/command_test.py
@@ -175,14 +175,21 @@ def test_escape_underscores() -> None:
     assert r == 'Adamaro, First to Desire :white_check_mark:'
 
 def test_no_warning_for_recent_card_information(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command.database, 'card_information_is_available', lambda: True)
     monkeypatch.setattr(command.database, 'stale_card_information_age', lambda: None)
 
     assert command.stale_card_information_warning() == ''
 
 def test_warning_for_stale_card_information(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command.database, 'card_information_is_available', lambda: True)
     monkeypatch.setattr(command.database, 'stale_card_information_age', lambda: datetime.timedelta(days=29))
 
     assert command.stale_card_information_warning() == '\nWARNING: card information is 4 weeks old'
+
+def test_warning_when_card_information_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command.database, 'card_information_is_available', lambda: False)
+
+    assert command.stale_card_information_warning() == '\nWARNING: card information is unavailable'
 
 @pytest.mark.asyncio
 async def test_card_converter_uses_buttons_for_ambiguous_names(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/magic/database.py
+++ b/magic/database.py
@@ -35,8 +35,14 @@ def init() -> None:
 def last_updated() -> datetime.datetime:
     return dtutil.ts2dt(db().value('SELECT last_updated FROM scryfall_version', [], 0))
 
+def card_information_is_available() -> bool:
+    return last_updated() > dtutil.ts2dt(0)
+
 def stale_card_information_age() -> datetime.timedelta | None:
-    age = dtutil.now() - last_updated()
+    updated = last_updated()
+    if updated <= dtutil.ts2dt(0):
+        return None
+    age = dtutil.now() - updated
     return age if age > MAX_CARD_INFORMATION_AGE else None
 
 def db_version() -> int:

--- a/magic/database_test.py
+++ b/magic/database_test.py
@@ -19,3 +19,9 @@ def test_card_information_older_than_maximum_age_is_stale(monkeypatch: pytest.Mo
     monkeypatch.setattr(database, 'last_updated', lambda: now - age)
 
     assert database.stale_card_information_age() == age
+
+def test_card_information_is_unavailable_without_a_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(database, 'last_updated', lambda: database.dtutil.ts2dt(0))
+
+    assert not database.card_information_is_available()
+    assert database.stale_card_information_age() is None


### PR DESCRIPTION
## Summary
- distinguish missing card data from stale card data
- report missing data as unavailable in the site status and Discord bot
- avoid displaying an epoch-derived age such as 2957 weeks

## Tests
- `uv run pytest magic/database_test.py decksite/controllers/api_test.py discordbot/command_test.py`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/9d8bc0e1-5f58-4274-9033-62c9edb4cb8c)
