### PR TITLE
Return 404 for missing archetype IDs

### DIFF
--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -69,9 +69,12 @@ def load_archetype(archetype: int | str) -> Archetype:
         if not found:
             raise DoesNotExistException(f'Did not find archetype with name of `{titlecase.titlecase(archetype)}`') from c
         archetype_id = found
+    name = db().value('SELECT name FROM archetype WHERE id = %s', [archetype_id])
+    if name is None:
+        raise DoesNotExistException(f'Did not find archetype with id `{archetype_id}`')
     arch = Archetype()
     arch.id = int(archetype_id)
-    arch.name = db().value('SELECT name FROM archetype WHERE id = %s', [archetype_id])
+    arch.name = name
     return arch
 
 def load_competition_archetypes(competition_id: int) -> list[Archetype]:

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -247,3 +247,10 @@ def test_load_archetype_raises_for_unknown_name() -> None:
 
     with pytest.raises(DoesNotExistException):
         archetype.load_archetype(merge_slashes('Arrive // Fortune Midrange'))
+
+
+@with_test_db
+@pytest.mark.functional
+def test_load_archetype_raises_for_unknown_id() -> None:
+    with pytest.raises(DoesNotExistException, match=r'Did not find archetype with id `2147483647`'):
+        archetype.load_archetype(2147483647)


### PR DESCRIPTION
## Summary

- reject numeric archetype IDs that no longer exist
- route stale archetype URLs through the existing 404 handler
- add regression coverage for a missing numeric ID

## Verification

- exact reported route `/seasons/32/archetypes/545/` returns 404 against the cloud snapshot
- `uv run --frozen pytest decksite/data/archetype_test.py::test_load_archetype_raises_for_unknown_id -q`
- `uv run --frozen pytest decksite/views/metadata_test.py -q`
- `uv run --frozen python dev.py mypy decksite/data/archetype.py decksite/data/archetype_test.py`
- `uv run --frozen python dev.py lint`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/54c4c860-4edf-4729-8169-6ecbcdc014c3)
