### PR TITLE
Return 404 for missing API resources

### DIFF
--- a/decksite/controllers/api_test.py
+++ b/decksite/controllers/api_test.py
@@ -58,3 +58,10 @@ def test_archetypes2_serializes_win_percent_as_number_or_null(monkeypatch: pytes
     assert data['objects'][0]['winPercent'] == 50.0
     assert isinstance(data['objects'][0]['winPercent'], float)
     assert data['objects'][1]['winPercent'] is None
+
+
+def test_card_api_returns_not_found_for_unknown_card() -> None:
+    response = APP.test_client().get('/api/card/DefinitelyNotARealCard/')
+
+    assert response.status_code == 404
+    assert response.get_json()['code'] == 'NOTFOUND'

--- a/logsite/api.py
+++ b/logsite/api.py
@@ -27,9 +27,9 @@ def person_status() -> Response:
     }
     return return_json(r)
 
-@APP.route('/api/matchExists/<int:match_id>')
-@APP.route('/api/matchExists/<int:match_id>/')
-def match_exists(match_id: int) -> Response:
+@APP.route('/api/matchExists/<match_id>')
+@APP.route('/api/matchExists/<match_id>/')
+def match_exists(match_id: str) -> Response:
     return return_json(match.get_match(match_id) is not None)
 
 @APP.route('/api/person/<person>')
@@ -37,14 +37,14 @@ def match_exists(match_id: int) -> Response:
 def person_data(person: str) -> Response:
     return return_json(list(match.Match.query.filter(match.Match.players.any(db.User.name == person))))
 
-@APP.route('/api/match/<int:match_id>')
-@APP.route('/api/match/<int:match_id>/')
-def match_data(match_id: int) -> Response:
+@APP.route('/api/match/<match_id>')
+@APP.route('/api/match/<match_id>/')
+def match_data(match_id: str) -> Response:
     return return_json(match.load_match(match_id))
 
-@APP.route('/api/game/<int:game_id>')
-@APP.route('/api/game/<int:game_id>/')
-def game_data(game_id: int) -> Response:
+@APP.route('/api/game/<game_id>')
+@APP.route('/api/game/<game_id>/')
+def game_data(game_id: str) -> Response:
     return return_json(game.load_game(game_id))
 
 @APP.route('/api/upload', methods=['POST'])
@@ -65,15 +65,15 @@ def upload() -> Response:
             importing.import_from_pdbot(match_id)
         start_time = int(request.form['start_time_utc'])
         end_time = int(request.form['end_time_utc'])
-        match.load_match(match_id).set_times(start_time, end_time)
+        match.get_match(match_id).set_times(start_time, end_time)
     except InvalidDataException as e:
         repo.create_issue('Error uploading match', 'logsite', 'logsite', 'PennyDreadfulMTG/perf-reports', exception=e)
 
     return return_json({'success': True})
 
-@APP.route('/export/<int:match_id>')
-@APP.route('/export/<int:match_id>/')
-def export(match_id: int) -> tuple[str, int, dict[str, str]]:
+@APP.route('/export/<match_id>')
+@APP.route('/export/<match_id>/')
+def export(match_id: str) -> tuple[str, int, dict[str, str]]:
     local = match.load_match(match_id)
     text = '{format}\n{comment}\n{mods}\n{players}\n\n'.format(
         format=local.format.name,

--- a/logsite/api.py
+++ b/logsite/api.py
@@ -89,5 +89,5 @@ def export(match_id: str) -> tuple[str, int, dict[str, str]]:
     text = text.replace('\n', '\r\n')
     return (text, 200, {
         'Content-type': 'text/plain; charset=utf-8',
-        'Content-Disposition': f'attachment; filename={match_id}.txt',
+        'Content-Disposition': f'attachment; filename={local.id}.txt',
     })

--- a/logsite/api.py
+++ b/logsite/api.py
@@ -27,8 +27,8 @@ def person_status() -> Response:
     }
     return return_json(r)
 
-@APP.route('/api/matchExists/<match_id>')
-@APP.route('/api/matchExists/<match_id>/')
+@APP.route('/api/matchExists/<int:match_id>')
+@APP.route('/api/matchExists/<int:match_id>/')
 def match_exists(match_id: int) -> Response:
     return return_json(match.get_match(match_id) is not None)
 
@@ -37,15 +37,15 @@ def match_exists(match_id: int) -> Response:
 def person_data(person: str) -> Response:
     return return_json(list(match.Match.query.filter(match.Match.players.any(db.User.name == person))))
 
-@APP.route('/api/match/<match_id>')
-@APP.route('/api/match/<match_id>/')
+@APP.route('/api/match/<int:match_id>')
+@APP.route('/api/match/<int:match_id>/')
 def match_data(match_id: int) -> Response:
-    return return_json(match.get_match(match_id))
+    return return_json(match.load_match(match_id))
 
-@APP.route('/api/game/<game_id>')
-@APP.route('/api/game/<game_id>/')
+@APP.route('/api/game/<int:game_id>')
+@APP.route('/api/game/<int:game_id>/')
 def game_data(game_id: int) -> Response:
-    return return_json(game.get_game(game_id))
+    return return_json(game.load_game(game_id))
 
 @APP.route('/api/upload', methods=['POST'])
 @APP.route('/api/upload/', methods=['POST'])
@@ -65,18 +65,16 @@ def upload() -> Response:
             importing.import_from_pdbot(match_id)
         start_time = int(request.form['start_time_utc'])
         end_time = int(request.form['end_time_utc'])
-        match.get_match(match_id).set_times(start_time, end_time)
+        match.load_match(match_id).set_times(start_time, end_time)
     except InvalidDataException as e:
         repo.create_issue('Error uploading match', 'logsite', 'logsite', 'PennyDreadfulMTG/perf-reports', exception=e)
 
     return return_json({'success': True})
 
-@APP.route('/export/<match_id>')
-@APP.route('/export/<match_id>/')
+@APP.route('/export/<int:match_id>')
+@APP.route('/export/<int:match_id>/')
 def export(match_id: int) -> tuple[str, int, dict[str, str]]:
-    local = match.get_match(match_id)
-    if local is None:
-        return return_json({'success': False})
+    local = match.load_match(match_id)
     text = '{format}\n{comment}\n{mods}\n{players}\n\n'.format(
         format=local.format.name,
         comment=local.comment,

--- a/logsite/api_test.py
+++ b/logsite/api_test.py
@@ -11,12 +11,22 @@ def test_missing_match_resources_return_not_found(monkeypatch: pytest.MonkeyPatc
 
     response = APP.test_client().get(path)
     assert response.status_code == 404
+    if path.startswith('/api/'):
+        assert response.get_json()['code'] == 'NOTFOUND'
 
 
 def test_missing_game_resource_returns_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(api.game, 'get_game', lambda _game_id: None)
 
     response = APP.test_client().get('/api/game/2147483647/')
+    assert response.status_code == 404
+    assert response.get_json()['code'] == 'NOTFOUND'
+
+
+@pytest.mark.parametrize('path', ['/api/match/not-a-match/', '/api/game/not-a-game/', '/export/not-a-match/'])
+def test_non_numeric_resource_ids_return_not_found(path: str) -> None:
+    response = APP.test_client().get(path)
+
     assert response.status_code == 404
 
 

--- a/logsite/api_test.py
+++ b/logsite/api_test.py
@@ -1,0 +1,29 @@
+# type: ignore
+
+import pytest
+
+from logsite import APP, api
+
+
+@pytest.mark.parametrize('path', ['/api/match/2147483647/', '/export/2147483647/'])
+def test_missing_match_resources_return_not_found(monkeypatch: pytest.MonkeyPatch, path: str) -> None:
+    monkeypatch.setattr(api.match, 'get_match', lambda _match_id: None)
+
+    response = APP.test_client().get(path)
+    assert response.status_code == 404
+
+
+def test_missing_game_resource_returns_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api.game, 'get_game', lambda _game_id: None)
+
+    response = APP.test_client().get('/api/game/2147483647/')
+    assert response.status_code == 404
+
+
+def test_match_exists_returns_false_for_missing_match(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(api.match, 'get_match', lambda _match_id: None)
+
+    response = APP.test_client().get('/api/matchExists/2147483647/')
+
+    assert response.status_code == 200
+    assert response.get_json() is False

--- a/logsite/api_test.py
+++ b/logsite/api_test.py
@@ -1,5 +1,7 @@
 # type: ignore
 
+from types import SimpleNamespace
+
 import pytest
 
 from logsite import APP, api
@@ -28,6 +30,23 @@ def test_non_numeric_resource_ids_return_not_found(path: str) -> None:
     response = APP.test_client().get(path)
 
     assert response.status_code == 404
+
+
+def test_export_filename_uses_loaded_match_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    loaded = SimpleNamespace(
+        id=123,
+        format=SimpleNamespace(name='PennyDreadful'),
+        comment='',
+        modules=[],
+        players=[],
+        games=[],
+    )
+    monkeypatch.setattr(api.match, 'get_match', lambda _match_id: loaded)
+
+    response = APP.test_client().get('/export/000123/')
+
+    assert response.status_code == 200
+    assert response.headers['Content-Disposition'] == 'attachment; filename=123.txt'
 
 
 def test_match_exists_returns_false_for_missing_match(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/logsite/data/game.py
+++ b/logsite/data/game.py
@@ -41,10 +41,14 @@ def insert_game(game_id: int, match_id: int, game_lines: str) -> None:
     db.merge(local)  # This will replace an old version of the game, if one exists.
     db.commit()
 
-def get_game(game_id: int) -> Game | None:
+def get_game(game_id: int | str) -> Game | None:
+    try:
+        game_id = int(game_id)
+    except (TypeError, ValueError):
+        return None
     return Game.query.filter_by(id=game_id).one_or_none()
 
-def load_game(game_id: int) -> Game:
+def load_game(game_id: int | str) -> Game:
     local = get_game(game_id)
     if local is None:
         raise DoesNotExistException(f'Did not find game `{game_id}`')

--- a/logsite/data/game.py
+++ b/logsite/data/game.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import sqlalchemy as sa
 
+from shared.pd_exception import DoesNotExistException
+
 from .. import db
 from ..db import DB as fsa
 
@@ -39,8 +41,14 @@ def insert_game(game_id: int, match_id: int, game_lines: str) -> None:
     db.merge(local)  # This will replace an old version of the game, if one exists.
     db.commit()
 
-def get_game(game_id: int) -> Game:
+def get_game(game_id: int) -> Game | None:
     return Game.query.filter_by(id=game_id).one_or_none()
+
+def load_game(game_id: int) -> Game:
+    local = get_game(game_id)
+    if local is None:
+        raise DoesNotExistException(f'Did not find game `{game_id}`')
+    return local
 
 class Line(fsa.Model):
     id = sa.Column(fsa.Integer, primary_key=True, autoincrement=True)

--- a/logsite/data/match.py
+++ b/logsite/data/match.py
@@ -8,6 +8,7 @@ import sqlalchemy as sa
 from flask import url_for
 
 from shared import dtutil
+from shared.pd_exception import DoesNotExistException
 
 from .. import db
 from ..db import DB as fsa
@@ -92,8 +93,14 @@ def create_match(match_id: int, format_name: str, comment: str, modules: list[st
     db.commit()
     return local
 
-def get_match(match_id: int) -> Match:
+def get_match(match_id: int) -> Match | None:
     return Match.query.filter_by(id=match_id).one_or_none()
+
+def load_match(match_id: int) -> Match:
+    local = get_match(match_id)
+    if local is None:
+        raise DoesNotExistException(f'Did not find match `{match_id}`')
+    return local
 
 def get_recent_matches() -> Any:
     return Match.query.order_by(Match.id.desc())

--- a/logsite/data/match.py
+++ b/logsite/data/match.py
@@ -93,10 +93,14 @@ def create_match(match_id: int, format_name: str, comment: str, modules: list[st
     db.commit()
     return local
 
-def get_match(match_id: int) -> Match | None:
+def get_match(match_id: int | str) -> Match | None:
+    try:
+        match_id = int(match_id)
+    except (TypeError, ValueError):
+        return None
     return Match.query.filter_by(id=match_id).one_or_none()
 
-def load_match(match_id: int) -> Match:
+def load_match(match_id: int | str) -> Match:
     local = get_match(match_id)
     if local is None:
         raise DoesNotExistException(f'Did not find match `{match_id}`')

--- a/logsite/views/match_view.py
+++ b/logsite/views/match_view.py
@@ -14,7 +14,7 @@ from ..view import View
 
 @APP.route('/match/<int:match_id>/')
 def show_match(match_id: int) -> str:
-    view = Match(match.get_match(match_id))
+    view = Match(match.load_match(match_id))
     return view.page()
 
 class Match(View):

--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -8,7 +8,7 @@ from magic.models import Card, Printing
 from shared import configuration, fetch_tools, guarantee
 from shared.container import Container
 from shared.database import sqlescape, sqllikeescape
-from shared.pd_exception import DatabaseException, InvalidArgumentException, InvalidDataException, TooFewItemsException
+from shared.pd_exception import DatabaseException, DoesNotExistException, InvalidArgumentException, InvalidDataException, TooFewItemsException
 
 # Primary public interface to the magic package. Call `oracle.init()` after setting up application context and before using any methods.
 
@@ -52,7 +52,13 @@ def canonical_name_or_self(name: str) -> str:
         return name
 
 def load_card(name: str) -> Card:
-    return CARDS_BY_NAME.get(name) or load_cards([name])[0]
+    cached = CARDS_BY_NAME.get(name)
+    if cached is not None:
+        return cached
+    try:
+        return load_cards([name])[0]
+    except TooFewItemsException as e:
+        raise DoesNotExistException(f'Did not find card `{name}`') from e
 
 def load_cards(names: Iterable[str] | None = None, where: str | None = None) -> list[Card]:
     if names is not None:

--- a/magic/oracle_test.py
+++ b/magic/oracle_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from magic import oracle, seasons
 from magic.models import Card, Printing
-from shared.pd_exception import DatabaseException, InvalidDataException
+from shared.pd_exception import DatabaseException, DoesNotExistException, InvalidDataException
 
 
 def test_legality() -> None:
@@ -24,6 +24,10 @@ def test_legality() -> None:
     assert card.legalities['Legacy'] == 'Banned'
     assert card.legalities['Vintage'] == 'Restricted'
     assert season_name not in card.legalities.keys()
+
+def test_load_card_raises_for_unknown_name() -> None:
+    with pytest.raises(DoesNotExistException, match='Did not find card `Definitely Not a Card`'):
+        oracle.load_card('Definitely Not a Card')
 
 def test_valid_name() -> None:
     assert oracle.valid_name('Dark Ritual') == 'Dark Ritual'


### PR DESCRIPTION
## Summary
- translate unknown card names into `DoesNotExistException` so the card API returns a clean 404
- add strict match and game loaders for resource endpoints while keeping the existence probe optional
- return 404 for missing logsite match pages, match/game API resources, and exports

## Verification
- `uv run --frozen pytest magic/oracle_test.py decksite/controllers/api_test.py logsite/api_test.py -q` (25 passed)
- `uv run --frozen python dev.py mypy` (375 files clean)
- `uv run --frozen python dev.py lint`
- `git diff --check`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/54c4c860-4edf-4729-8169-6ecbcdc014c3)
