### PR TITLE
Restore all-time deck routes

### DIFF
--- a/decksite/main.py
+++ b/decksite/main.py
@@ -108,8 +108,6 @@ def before_request() -> wrappers.Response | None:
         return None  # Let flask do the redirect-routes-not-ending-in-slashes thing before we interfere with routing. Avoids #8277.
     if request.path.startswith('/seasons') and len(request.path) > len('/seasons/') and get_season_id() >= seasons.current_season_num():
         return redirect(re.sub('/seasons/[^/]*', '', request.path))
-    if re.match(r'^/seasons/all/decks(/.*)?$', request.path):
-        return redirect(re.sub(r'^/seasons/all', '', request.path))
     if request.path.startswith('/seasons/0'):
         return redirect(request.path.replace('/seasons/0', '/seasons/all'))
     sentry_sdk.set_user({'id': auth.discord_id(), 'username': auth.mtgo_username(), 'ip_address': '{{auto}}'})

--- a/decksite/main_test.py
+++ b/decksite/main_test.py
@@ -91,6 +91,14 @@ def test_image_requests_do_not_touch_the_session(monkeypatch: pytest.MonkeyPatch
         assert main.before_request() is None
 
 
+@pytest.mark.parametrize('path', ['/seasons/all/decks/', '/seasons/all/decks/league/'])
+def test_all_time_deck_requests_are_not_redirected(path: str) -> None:
+    with main.APP.test_request_context(path):
+        g.season_id = 0
+
+        assert main.before_request() is None
+
+
 def test_image_teardown_closes_only_the_database_it_used() -> None:
     magic_database = Mock()
 


### PR DESCRIPTION
## Why it is broken

The Decks season chooser still offers **All**, but `/seasons/all/decks/` and `/seasons/all/decks/league/` redirect to the corresponding current-season pages. A user explicitly choosing all-time data therefore receives different data with no explanation.

## What broke it

#15118 added a special-case redirect for every all-time deck-list route.

## Original ask

#12524 was titled “`/seasons/all/decks/` is slow to load the first page and not interesting.” It identified a slow query and questioned the usefulness of its default view; it did not ask for all-time deck browsing to silently become current-season browsing.

## Why this fix

Remove #15118's two-line special case in full. All-time deck URLs once again use the normal season routing and return all-time data. Work elsewhere is making the underlying query faster, so retaining a behavior-changing redirect would both conceal that improvement and leave the season chooser dishonest.

The existing canonical redirect for explicitly current-season URLs and the `/seasons/0` compatibility redirect are unchanged.

## Validation

- Added regression coverage for both `/seasons/all/decks/` and `/seasons/all/decks/league/` at the request-hook boundary, avoiding execution of the known slow query.
- All 13 `decksite/main_test.py` tests pass.
- Ruff and mypy pass for the changed files.

Reverts the behavior introduced by #15118. Follow-up to #12524.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
