### PR TITLE
Revert incomplete deck search API

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -117,11 +117,10 @@ def decks_api() -> Response:
         {
             'achievementKey': <str?>,
             'archetypeId': <int?>,
-            'cardName': <str?>,  # Repeat for multiple cards; deck must contain all named cards
+            'cardName': <str?>,
             'competitionId': <int?>,
             'competitionFlagId': <int?>,
             'deckType': <'league'|'tournament'|'all'>,
-            'minWinRate': <float?>,  # Minimum win percentage (0-100), e.g. 50 for >50%
             'page': <int>,
             'pageSize': <int>,
             'personId': <int?>,

--- a/decksite/data/clauses.py
+++ b/decksite/data/clauses.py
@@ -315,18 +315,8 @@ def decks_where(args: dict[str, str], is_admin: bool, viewer_id: int | None) -> 
         parts.append(archetype_where(archetype_id))
     if args.get('personId'):
         person_id = int(args.get('personId', ''))
-    raw_card_names = args.getlist('cardName') if hasattr(args, 'getlist') else [args.get('cardName')]
-    card_names = [name for name in raw_card_names if name]
-    if card_names:
-        parts.append(cards_where(card_names))
-    if args.get('minWinRate'):
-        try:
-            min_win_rate = float(args.get('minWinRate', ''))
-        except ValueError as e:
-            raise InvalidArgumentException('minWinRate must be a number') from e
-        if not 0 <= min_win_rate <= 100:
-            raise InvalidArgumentException('minWinRate must be between 0 and 100')
-        parts.append(f'(cache.wins / NULLIF(cache.wins + cache.losses, 0)) * 100 >= {min_win_rate}')
+    if args.get('cardName'):
+        parts.append(card_where(args.get('cardName', '')))
     if args.get('competitionFlagId'):
         competition_flag_id = CompetitionFlag(int(args.get('competitionFlagId', ''))).value
         parts.append(f'c.competition_flag_id = {competition_flag_id} AND d.finish = 1')
@@ -366,22 +356,6 @@ def card_where(name: str) -> str:
     except InvalidDataException:
         return 'FALSE'
     return f'd.id IN (SELECT deck_id FROM deck_card WHERE card = {sqlescape(name)})'
-
-def cards_where(names: list[str]) -> str:
-    validated = []
-    for name in names:
-        try:
-            validated.append(oracle.valid_name(name))
-        except InvalidDataException:
-            return 'FALSE'
-    if len(validated) == 1:
-        return f'd.id IN (SELECT deck_id FROM deck_card WHERE card = {sqlescape(validated[0])})'
-    return """d.id IN (
-        SELECT deck_id FROM deck_card
-        WHERE card IN ({names})
-        GROUP BY deck_id
-        HAVING COUNT(DISTINCT card) = {n})""".format(
-        names=', '.join(map(sqlescape, validated)), n=len(validated))
 
 # Returns two values, a SQL WHERE clause and a message about that clause (possibly an error message) suitable for display.
 def card_search_where(q: str, base_query: str | None = None, column_name: str = 'name') -> tuple[str, str]:

--- a/decksite/data/clauses_test.py
+++ b/decksite/data/clauses_test.py
@@ -121,43 +121,6 @@ def test_only_top8_order_uses_swiss_tiebreakers() -> None:
     assert not clauses.decks_order_uses_swiss_tiebreakers('date', '123')
     assert not clauses.decks_order_uses_swiss_tiebreakers(None, None)
 
-def test_cards_where_single(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(clauses.oracle, 'valid_name', lambda name: name)
-    result = clauses.cards_where(['Hive Mind'])
-    assert "deck_card WHERE card = 'Hive Mind'" in result
-
-def test_cards_where_multiple(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(clauses.oracle, 'valid_name', lambda name: name)
-    result = clauses.cards_where(['Hive Mind', 'Lake of the Dead'])
-    assert 'HAVING COUNT(DISTINCT card) = 2' in result
-    assert "'Hive Mind'" in result
-    assert "'Lake of the Dead'" in result
-
-def test_cards_where_rejects_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
-    def invalid_name(_name: str) -> str:
-        raise clauses.InvalidDataException()
-
-    monkeypatch.setattr(clauses.oracle, 'valid_name', invalid_name)
-    assert clauses.cards_where(['Not a Card']) == 'FALSE'
-
-def test_decks_where_min_win_rate() -> None:
-    args: dict[str, str] = {'minWinRate': '50'}
-    result = clauses.decks_where(args, True, None)
-    assert 'cache.wins' in result
-    assert '50.0' in result
-
-def test_decks_where_min_win_rate_invalid() -> None:
-    from shared.pd_exception import InvalidArgumentException
-    args: dict[str, str] = {'minWinRate': 'abc'}
-    with pytest.raises(InvalidArgumentException):
-        clauses.decks_where(args, True, None)
-
-def test_decks_where_min_win_rate_out_of_range() -> None:
-    from shared.pd_exception import InvalidArgumentException
-    args: dict[str, str] = {'minWinRate': '150'}
-    with pytest.raises(InvalidArgumentException):
-        clauses.decks_where(args, True, None)
-
 def test_limit() -> None:
     args = {'page': '1', 'pageSize': '150'}
     assert clauses.pagination(args) == (1, 150, 'LIMIT 150, 150')


### PR DESCRIPTION
## Why it is broken

#15112 closed a user-facing Deck Search request after adding only backend query parameters. The `/decks/` table has search disabled, no browser code sends repeated `cardName` parameters, and no browser code sends `minWinRate`, so site users cannot use either feature.

The unused API implementation is also incorrect at its edges:

- Two aliases of one card canonicalize to the same database name but are still counted as two requirements, producing a `COUNT(DISTINCT card) = 2` condition that can never match.
- The issue requested win rate greater than 50%, while the implementation uses greater-than-or-equal and describes that as greater-than.

## Original ask

#12550 asks for an actual Deck Search experience where a non-admin can find decks containing multiple cards and restrict results by win rate. It also asks how that search should fit with cards, archetypes, and matchups.

## Why revert

The implementation is not connected to that experience and has been deployed for only a few days. Keeping an incomplete, defective API indefinitely makes the future product work harder without giving current site users anything.

This reverts #15112 in full:

- Restore the established single-card `cardName` path used by card-detail deck lists.
- Remove the unconsumed repeated-card and `minWinRate` API behavior.
- Remove tests that covered only generated SQL and missed the integration defects.

#12550 has been reopened so the real feature remains visible and can be designed and implemented end to end.

## Validation

- 28 clause and live-table contract tests pass, including the card-page single-card filter.
- Ruff and mypy pass for all changed files.

Reverts #15112. Leaves #12550 open.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/77d8da68-ed55-413e-9120-8aa846263357)
