### PR TITLE
Revert ineffective compact jslint formatter

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -307,7 +307,7 @@ def pull_request(argv: list[str]) -> None:
 def do_jslint(fix: bool) -> None:
     print('>>>> Linting javascript')
     files = find_files(file_extension='js', exclude=['shared_web/static/js/tipped.min.js']) + find_files(file_extension='jsx')
-    cmd = [os.path.join('.', 'node_modules', '.bin', 'eslint'), '--format', 'compact']
+    cmd = [os.path.join('.', 'node_modules', '.bin', 'eslint')]
     if fix:
         cmd.append('--fix')
     subprocess.check_call(cmd + files, shell=ON_WINDOWS)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "babel-loader": "^10.1.1",
         "css-loader": "^7.1.5",
         "eslint": "^9.39.2",
-        "eslint-formatter-compact": "^9.0.1",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^17.7.0",
         "react": "^19.2.6",
@@ -3318,16 +3317,6 @@
         "jiti": {
           "optional": true
         }
-      }
-    },
-    "node_modules/eslint-formatter-compact": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-compact/-/eslint-formatter-compact-9.0.1.tgz",
-      "integrity": "sha512-mBAti2tb403dQGMyilQTYHU80stem3N7jdtKW+tmn5gj3JNF7ki0rgCZtJFw4iMayTH862FTUIqCdp70ug0S0Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint-plugin-react": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "babel-loader": "^10.1.1",
     "css-loader": "^7.1.5",
     "eslint": "^9.39.2",
-    "eslint-formatter-compact": "^9.0.1",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.7.0",
     "react": "^19.2.6",


### PR DESCRIPTION
## Why this is being reverted

PR #15060 claimed ESLint's default `stylish` formatter emits four to six lines per problem and that `compact` would materially reduce the roughly 1,000-line failure output reported in #12584. That diagnosis is not borne out by the formatter behavior.

With 100 deliberate lint errors against the repository configuration:

- `stylish`: 105 lines, 8,167 bytes
- `compact`: 103 lines, 17,262 bytes

Compact repeats the absolute path on every diagnostic, so it saves only two lines while producing more than twice as much output.

## What this changes

- Restore ESLint's default formatter.
- Remove the unnecessary `eslint-formatter-compact` development dependency and lockfile entry.
- Reopen #12584 so the actual source of the noisy output can be captured and addressed.

The standalone formatter is a valid ESLint v9 package; this revert is about it not solving the ticket, not package correctness.

## Validation

- Clean `npm ci`: 452 packages, 0 vulnerabilities
- `uv run --frozen python dev.py jslint`: passed
- `uv run --frozen python dev.py lint`: passed
- `git diff --check`: passed

Reverts #15060.
Reopens #12584.