### PR TITLE
Use emoji names only as a metadata fallback

### DIFF
--- a/decksite/view.py
+++ b/decksite/view.py
@@ -137,15 +137,17 @@ class View(BaseView):
         return url_for('favicon', rest='-152.png')
 
     def title(self) -> str:
-        if not self.page_title():
+        page_title = self.page_title()
+        if not page_title:
             return 'pennydreadfulmagic.com'
+        page_title = text.replace_emoji_with_text(page_title)
         if get_season_id() == seasons.current_season_num():
             season = ''
         elif get_season_id() == 0:
             season = ' - All Time'
         else:
             season = f' - Season {get_season_id()}'
-        return text.replace_emoji_with_text(f'{self.page_title()}{season} – pennydreadfulmagic.com')
+        return f'{page_title}{season} – pennydreadfulmagic.com'
 
     # Site-wide notice in a banner at the top of every page, for very important things only!
     def notice_html(self) -> str:

--- a/decksite/views/archetype.py
+++ b/decksite/views/archetype.py
@@ -103,7 +103,7 @@ class Archetype(View):
         return url_for('.archetype', archetype_id=self.archetype.id, _external=True)
 
     def og_description(self) -> str:
-        return text.replace_emoji_with_text(f'Penny Dreadful {self.archetype.name} archetype')
+        return f'Penny Dreadful {text.replace_emoji_with_text(self.archetype.name)} archetype'
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self.archetype, attr)

--- a/decksite/views/deck.py
+++ b/decksite/views/deck.py
@@ -73,10 +73,10 @@ class Deck(View):
     def og_description(self) -> str:
         if self.public() and self.archetype_name and self.reviewed:
             p = inflect.engine()
-            archetype_s = titlecase.titlecase(p.a(self.archetype_name))
+            archetype_s = titlecase.titlecase(p.a(text.replace_emoji_with_text(self.archetype_name)))
         else:
             archetype_s = 'A'
-        return text.replace_emoji_with_text(f'{archetype_s} deck by {self.person}')
+        return f'{archetype_s} deck by {text.replace_emoji_with_text(self.person)}'
 
     def oembed_url(self) -> str:
         return url_for('deck_embed', deck_id=self.deck.id, _external=True)

--- a/decksite/views/metadata_test.py
+++ b/decksite/views/metadata_test.py
@@ -4,7 +4,7 @@ from decksite.views.deck import Deck as DeckView
 from shared.container import Container
 
 
-def test_deck_open_graph_metadata_replaces_emoji_with_words() -> None:
+def test_deck_open_graph_metadata_removes_emoji_from_mixed_text() -> None:
     view = DeckView.__new__(DeckView)
     view.deck = Container({
         'name': '🃏🔥',
@@ -16,12 +16,30 @@ def test_deck_open_graph_metadata_replaces_emoji_with_words() -> None:
     view.person_id = None
 
     assert view.og_title() == 'black joker fire'
-    assert view.og_description() == 'A deck by Pilot raised hand'
+    assert view.og_description() == 'A deck by Pilot'
 
 
-def test_archetype_open_graph_metadata_replaces_emoji_with_words() -> None:
+def test_archetype_open_graph_metadata_removes_emoji_from_mixed_text() -> None:
     view = ArchetypeView.__new__(ArchetypeView)
     view.archetype = Archetype(name='Burn🔥')
 
-    assert view.og_title() == 'Burn fire'
-    assert view.og_description() == 'Penny Dreadful Burn fire archetype'
+    assert view.og_title() == 'Burn'
+    assert view.og_description() == 'Penny Dreadful Burn archetype'
+
+
+def test_open_graph_metadata_uses_words_for_emoji_only_fields() -> None:
+    deck_view = DeckView.__new__(DeckView)
+    deck_view.deck = Container({
+        'name': '🔥',
+        'archetype_name': None,
+        'reviewed': False,
+        'person': '🐟',
+    })
+    deck_view.is_in_current_run = False
+    deck_view.person_id = None
+    archetype_view = ArchetypeView.__new__(ArchetypeView)
+    archetype_view.archetype = Archetype(name='🔥')
+
+    assert deck_view.og_title() == 'fire'
+    assert deck_view.og_description() == 'A deck by fish'
+    assert archetype_view.og_description() == 'Penny Dreadful fire archetype'

--- a/shared/text.py
+++ b/shared/text.py
@@ -18,8 +18,30 @@ def sanitize(s: str) -> str:
     return html.unescape(s)
 
 def replace_emoji_with_text(s: str) -> str:
-    """Replace emoji sequences with readable text while preserving other Unicode."""
+    """Remove pictographic emoji from text, with names as an emoji-only fallback.
+
+    Unicode characters with text presentation, such as © and ♥, are preserved.
+    """
+    found_emoji = False
+
+    def remove(chars: str, data: dict[str, Any]) -> str:
+        nonlocal found_emoji
+        if data.get('status') == emoji.STATUS['unqualified']:
+            return chars
+        found_emoji = True
+        return ' '
+
+    without_emoji = emoji.replace_emoji(s, replace=remove)
+    if not found_emoji:
+        return s
+
+    without_emoji = re.sub(r'\s+', ' ', without_emoji).strip()
+    if any(c.isalnum() for c in without_emoji):
+        return without_emoji
+
     def replace(chars: str, data: dict[str, Any]) -> str:
+        if data.get('status') == emoji.STATUS['unqualified']:
+            return chars
         replacement = anyascii(chars)
         if not replacement or replacement == chars:
             replacement = str(data.get('en', ''))

--- a/shared/text_test.py
+++ b/shared/text_test.py
@@ -7,18 +7,26 @@ def test_sanitize() -> None:
     assert text.sanitize('Kongming, &quot;Sleeping Dragon&quot;') == 'Kongming, "Sleeping Dragon"'
     assert text.sanitize('Ratonhnhaké꞉ton') == 'Ratonhnhaké꞉ton'
 
-def test_replace_emoji_with_text() -> None:
-    assert text.replace_emoji_with_text('Stop That✋') == 'Stop That raised hand'
+def test_replace_emoji_with_text_removes_emoji_from_mixed_text() -> None:
+    assert text.replace_emoji_with_text('Stop That✋') == 'Stop That'
+    assert text.replace_emoji_with_text('No More Meming 👮👮👮') == 'No More Meming'
+    assert text.replace_emoji_with_text('We Do Be Meming 😎😎😎') == 'We Do Be Meming'
+    assert text.replace_emoji_with_text('Parish Is the 🔪') == 'Parish Is the'
+    assert text.replace_emoji_with_text('Hall👻wed Haunting') == 'Hall wed Haunting'
+    assert text.replace_emoji_with_text('Thumb 👍🏾 Test') == 'Thumb Test'
+    assert text.replace_emoji_with_text('Developer 👩‍💻') == 'Developer'
+    assert text.replace_emoji_with_text('Number 1️⃣') == 'Number'
+
+def test_replace_emoji_with_text_uses_words_for_emoji_only_text() -> None:
     assert text.replace_emoji_with_text('🃏🔥') == 'black joker fire'
-    assert text.replace_emoji_with_text('Thumb 👍🏾 Test') == 'Thumb thumbsup Test'
-    assert text.replace_emoji_with_text('Developer 👩‍💻') == 'Developer woman computer'
-    assert text.replace_emoji_with_text('Number 1️⃣') == 'Number 1'
     assert text.replace_emoji_with_text('🇬🇧') == 'GB'
-    assert text.replace_emoji_with_text('©') == '(C)'
+    assert text.replace_emoji_with_text('🔥🐟') == 'fire fish'
 
 def test_replace_emoji_with_text_preserves_non_emoji_symbols_and_unicode() -> None:
     assert text.replace_emoji_with_text('Costs $1 + tax = 2*') == 'Costs $1 + tax = 2*'
     assert text.replace_emoji_with_text('日本語 / Ελληνικά / Кириллица') == '日本語 / Ελληνικά / Кириллица'
+    assert text.replace_emoji_with_text('© ™ ↔ ♥ ☀') == '© ™ ↔ ♥ ☀'
+    assert text.replace_emoji_with_text('日本語　 Ελληνικά') == '日本語　 Ελληνικά'
 
 def test_unambiguous_prefixes() -> None:
     assert text.unambiguous_prefixes(['hello']) == ['h', 'he', 'hel', 'hell']


### PR DESCRIPTION
## Context

Follow-up to #15063 and #12580.

#12580 asked us not to emit large, colorful emoji in `<title>` and social metadata, without broadly stripping Japanese, Chinese, or other safe Unicode. The initial implementation in #15063 removed every Unicode symbol; its merged follow-up instead converted every emoji to its English name.

That solved the rendering problem, but made ordinary deck titles noisy (`No More Meming 👮👮👮` became `No More Meming police officer police officer police officer`) and also rewrote text-presentation symbols such as `™`, `©`, and `♥`.

## Change

Use a predictable hybrid policy:

- Mixed text: remove emoji (`No More Meming 👮👮👮` → `No More Meming`).
- Emoji-only fields: retain the readable fallback (`🔥🐟` → `fire fish`) so titles never become blank.
- Text-presentation Unicode: preserve it exactly (`A Different Jund™ Pile` stays unchanged).
- Process user-provided names before adding fixed metadata text, so an emoji-only name is still recognized as emoji-only.
- Preserve whitespace exactly when no emoji was removed.

There is no reliable general heuristic for distinguishing a semantic rebus such as `Parish Is the 🔪` from decorative emoji, so this intentionally favors a consistent rule over a growing exception list.

## Verification

- `uv run pytest shared/text_test.py decksite/view_test.py decksite/views/metadata_test.py` (17 passed)
- `uv run --frozen python dev.py mypy` (375 files, clean)
- `uv run --frozen python dev.py lint` (clean)
- Headless Chrome against real local deck pages confirmed mixed titles are cleaned, emoji-only titles retain word fallbacks, and `™` remains unchanged.
