### PR TITLE
Test optional Table class names in the browser

### DIFF
--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -144,6 +144,17 @@ def test_metagame_uses_number_sign_for_deck_count_without_quality_rank(browser: 
     assert not collector.problems, '\n'.join(collector.problems)
 
 
+def test_table_without_optional_class_name_omits_it(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site)
+    page.goto('/cards/')
+    assert not wait_for_live_tables(page)
+    table_container = page.locator('.cardtable > div.live')
+    expect(table_container).to_have_attribute('class', 'live')
+    expect(table_container.locator('table')).to_have_attribute('class', 'live')
+    expect(page.locator('.cardtable .undefined')).to_have_count(0)
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
 def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: Container) -> None:
     page, collector = new_page(browser, site)
     page.goto('/metagame/')


### PR DESCRIPTION
## Context

Follow-up to #15069 / #12598.

#15069 correctly fixed `Table` rendering `class="live undefined"` when its optional `className` prop was omitted, but its stated Python-suite validation did not render the React component and therefore could not catch a regression.

## Change

Add a focused browser test using the card table, which intentionally omits `className`. After the React table loads, assert:

- the rendered container is exactly `class="live"`;
- the inner table is exactly `class="live"`;
- no element under the card table has an `undefined` class;
- the page produced no JavaScript, console, or request failures.

The test was also run against the pre-#15069 expression and failed with the exact actual value `live undefined`, demonstrating that it covers the original defect.

## Verification

- `npm run build`
- `PD_BROWSER_TESTS=1 PD_BROWSER_CHANNEL=chrome uv run --frozen pytest --no-cov -p no:cacheprovider decksite/browser_test.py` — 10 passed
- `uv run --frozen python dev.py mypy` — 375 files clean
- `uv run --frozen python dev.py lint` — clean
