### PR TITLE
Speed up deck sorting with integer ranks

### DIFF
--- a/magic/oracle.py
+++ b/magic/oracle.py
@@ -14,12 +14,14 @@ from shared.pd_exception import DatabaseException, DoesNotExistException, Invali
 
 LEGAL_CARDS: list[str] = []
 CARDS_BY_NAME: dict[str, Card] = {}
+DECK_SORT_RANK_BY_NAME: dict[str, int] = {}
 OMENPATHS_SET_CODE = 'om1'
 
 def init(force: bool = False) -> None:
     if len(CARDS_BY_NAME) == 0 or force:
+        cards = load_cards()
         CARDS_BY_NAME.clear()
-        for c in load_cards():
+        for c in cards:
             CARDS_BY_NAME[c.name] = c
         for c in load_cards_with_flavor_names():
             for fn in c.flavor_names.split('|'):
@@ -27,6 +29,7 @@ def init(force: bool = False) -> None:
                 if existing is not None and existing.name != c.name:
                     continue
                 CARDS_BY_NAME[fn] = c
+        _rebuild_deck_sort_ranks(cards)
 
 def valid_name(name: str) -> str:
     if name in CARDS_BY_NAME:
@@ -162,7 +165,7 @@ def get_set(set_id: int) -> Container:
     rs = db().select('SELECT ' + (', '.join(property for property in card.set_properties())) + ' FROM `set` WHERE id = %s', [set_id])
     return guarantee.exactly_one([Container(r) for r in rs])
 
-def deck_sort(c: Card) -> str:
+def _deck_sort_key(c: Card) -> str:
     s = ''
     if c.is_creature():
         s += 'A'
@@ -178,6 +181,14 @@ def deck_sort(c: Card) -> str:
     s += str(c.cmc).zfill(10)
     s += c.name
     return s
+
+def _rebuild_deck_sort_ranks(cards: Iterable[Card]) -> None:
+    DECK_SORT_RANK_BY_NAME.clear()
+    for rank, c in enumerate(sorted(cards, key=_deck_sort_key)):
+        DECK_SORT_RANK_BY_NAME[c.name] = rank
+
+def deck_sort(c: Card) -> int:
+    return DECK_SORT_RANK_BY_NAME[c.name]
 
 async def scryfall_import_async(name: str) -> bool:
     sfcard = await fetch_tools.fetch_json_async(f'https://api.scryfall.com/cards/named?fuzzy={name}')
@@ -260,3 +271,4 @@ async def add_cards_and_update_async(printings: list[CardDescription]) -> None:
     whoosh_write.reindex_specific_cards(cs)
     for c in cs:
         CARDS_BY_NAME[c.name] = c
+    _rebuild_deck_sort_ranks(set(CARDS_BY_NAME.values()))

--- a/magic/oracle_test.py
+++ b/magic/oracle_test.py
@@ -96,9 +96,10 @@ def test_preferred_printing_uses_omenpaths_fallback(monkeypatch: pytest.MonkeyPa
     assert printing.system_id == 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'
 
 def test_init_rebuilds_names_and_ignores_alias_collisions(monkeypatch: pytest.MonkeyPatch) -> None:
-    canonical = Card({'name': 'Shared Name'})
-    aliased = Card({'name': 'Other Card', 'flavor_names': 'Shared Name|Alternate Name'})
+    canonical = Card({'name': 'Shared Name', 'type_line': 'Creature', 'mana_cost': None, 'cmc': 0})
+    aliased = Card({'name': 'Other Card', 'type_line': 'Creature', 'mana_cost': None, 'cmc': 0, 'flavor_names': 'Shared Name|Alternate Name'})
     monkeypatch.setattr(oracle, 'CARDS_BY_NAME', {'Stale Alias': aliased})
+    monkeypatch.setattr(oracle, 'DECK_SORT_RANK_BY_NAME', {})
     monkeypatch.setattr(oracle, 'load_cards', lambda: [canonical, aliased])
     monkeypatch.setattr(oracle, 'load_cards_with_flavor_names', lambda: [aliased])
 
@@ -107,6 +108,7 @@ def test_init_rebuilds_names_and_ignores_alias_collisions(monkeypatch: pytest.Mo
     assert 'Stale Alias' not in oracle.CARDS_BY_NAME
     assert oracle.CARDS_BY_NAME['Shared Name'] is canonical
     assert oracle.CARDS_BY_NAME['Alternate Name'] is aliased
+    assert oracle.deck_sort(aliased) < oracle.deck_sort(canonical)
 
 def test_load_cards() -> None:
     cards = oracle.load_cards(['Think Twice', 'Swamp'])
@@ -122,6 +124,7 @@ def test_deck_sort_x_last() -> None:
     cards = oracle.load_cards(['Ghitu Fire', 'Flash of Insight', 'Frantic Search'])
     assert len(cards) == 3
     cards_by_name = {c.name: c for c in cards}
+    assert all(isinstance(oracle.deck_sort(c), int) for c in cards)
     assert oracle.deck_sort(cards_by_name['Ghitu Fire']) < oracle.deck_sort(cards_by_name['Flash of Insight'])
     assert oracle.deck_sort(cards_by_name['Ghitu Fire']) > oracle.deck_sort(cards_by_name['Frantic Search'])
 


### PR DESCRIPTION
Closes #6689.

Precompute an integer deck-sort rank for every known card during oracle initialization, preserving the existing creature/spell/land, X-cost, mana-value, and name ordering. Rebuild the ranks after card imports so hot-path deck sorting performs a dictionary lookup and compares integers instead of constructing composite strings.

Performance on the cloud workspace production-card snapshot:
- 84,435 key calls: 0.452s -> 0.042s median
- 3,449 representative deck sorts / 103,470 entries: 0.617s -> 0.071s median
- Incremental live memory: 1.83 MiB; one-time rebuild: about 0.21s

Validation:
- `uv run --frozen pytest magic/oracle_test.py -q` (17 passed)
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- Exact old/new ordering match across all 34,248 cards in the local production snapshot

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a97be2c1-c81c-4704-b189-c8b0af6ba4cf)
