### PR TITLE
Add Open Graph metadata to marquee pages

### DIFF
--- a/decksite/view.py
+++ b/decksite/view.py
@@ -174,6 +174,15 @@ class View(BaseView):
     def page_title(self) -> str | None:
         pass
 
+    def og_title(self) -> str:
+        return text.replace_emoji_with_text(self.page_title() or 'Penny Dreadful Magic')
+
+    def og_url(self) -> str:
+        return request.base_url
+
+    def og_description(self) -> str:
+        return 'Penny Dreadful is an ultra-budget Magic Online format with thousands of legal cards, free weekly tournaments, a free league, and quarterly rotations.'
+
     def num_tournaments(self) -> str:
         r = inflect.engine().number_to_words(str(len(tournaments.all_series_info())))
         return cast(str, r)

--- a/decksite/views/about.py
+++ b/decksite/views/about.py
@@ -22,6 +22,9 @@ class About(View):
     def page_title(self) -> str:
         return 'About Penny Dreadful'
 
+    def og_description(self) -> str:
+        return 'Discover Penny Dreadful, an ultra-budget Magic Online format with thousands of legal cards, quarterly rotations, free events, and a friendly community.'
+
 def exciting_cards() -> list[Card]:
     cards = fancy_cards()
     random.shuffle(cards)

--- a/decksite/views/competitions.py
+++ b/decksite/views/competitions.py
@@ -10,3 +10,6 @@ class Competitions(View):
 
     def page_title(self) -> str:
         return 'Competitions'
+
+    def og_description(self) -> str:
+        return 'Browse Penny Dreadful tournament and league results, standings, decklists, and match records from the current season and past seasons.'

--- a/decksite/views/league_info.py
+++ b/decksite/views/league_info.py
@@ -20,6 +20,9 @@ class LeagueInfo(View):
     def page_title(self) -> str:
         return 'Cardhoarder League'
 
+    def og_description(self) -> str:
+        return 'Join the free, play-anytime Penny Dreadful league on Magic Online, play five-match runs, and compete for monthly Cardhoarder prizes.'
+
     def discord_url(self) -> str:
         return 'https://discord.gg/Yekrz3s'  # Invite directly into #league channel
 

--- a/decksite/views/metadata_test.py
+++ b/decksite/views/metadata_test.py
@@ -1,6 +1,9 @@
 from decksite.data.archetype import Archetype
+from decksite.main import APP
 from decksite.views.archetype import Archetype as ArchetypeView
 from decksite.views.deck import Deck as DeckView
+from decksite.views.home import Home
+from decksite.views.tournaments import Tournaments
 from shared.container import Container
 
 
@@ -43,3 +46,18 @@ def test_open_graph_metadata_uses_words_for_emoji_only_fields() -> None:
     assert deck_view.og_title() == 'fire'
     assert deck_view.og_description() == 'A deck by fish'
     assert archetype_view.og_description() == 'Penny Dreadful fire archetype'
+
+
+def test_marquee_pages_have_default_open_graph_metadata() -> None:
+    with APP.test_request_context('/tournaments/', base_url='https://pennydreadfulmagic.com/'):
+        tournaments_view = Tournaments.__new__(Tournaments)
+
+        assert tournaments_view.og_title() == 'Cardhoarder Tournaments'
+        assert tournaments_view.og_url() == 'https://pennydreadfulmagic.com/tournaments/'
+        assert tournaments_view.og_description() == 'Penny Dreadful is an ultra-budget Magic Online format with thousands of legal cards, free weekly tournaments, a free league, and quarterly rotations.'
+
+    with APP.test_request_context('/', base_url='https://pennydreadfulmagic.com/'):
+        home_view = Home.__new__(Home)
+
+        assert home_view.og_title() == 'Penny Dreadful Magic'
+        assert home_view.og_url() == 'https://pennydreadfulmagic.com/'

--- a/decksite/views/metadata_test.py
+++ b/decksite/views/metadata_test.py
@@ -1,8 +1,13 @@
 from decksite.data.archetype import Archetype
 from decksite.main import APP
+from decksite.views.about import About
 from decksite.views.archetype import Archetype as ArchetypeView
+from decksite.views.competitions import Competitions
 from decksite.views.deck import Deck as DeckView
 from decksite.views.home import Home
+from decksite.views.league_info import LeagueInfo
+from decksite.views.metagame import Metagame
+from decksite.views.resources import Resources
 from decksite.views.tournaments import Tournaments
 from shared.container import Container
 
@@ -48,16 +53,25 @@ def test_open_graph_metadata_uses_words_for_emoji_only_fields() -> None:
     assert archetype_view.og_description() == 'Penny Dreadful fire archetype'
 
 
-def test_marquee_pages_have_default_open_graph_metadata() -> None:
+def test_marquee_pages_have_open_graph_metadata() -> None:
     with APP.test_request_context('/tournaments/', base_url='https://pennydreadfulmagic.com/'):
         tournaments_view = Tournaments.__new__(Tournaments)
 
         assert tournaments_view.og_title() == 'Cardhoarder Tournaments'
         assert tournaments_view.og_url() == 'https://pennydreadfulmagic.com/tournaments/'
-        assert tournaments_view.og_description() == 'Penny Dreadful is an ultra-budget Magic Online format with thousands of legal cards, free weekly tournaments, a free league, and quarterly rotations.'
+        assert tournaments_view.og_description() == 'Play in free weekly Penny Dreadful tournaments on Magic Online, with Cardhoarder prizes and events scheduled across multiple time zones.'
 
     with APP.test_request_context('/', base_url='https://pennydreadfulmagic.com/'):
         home_view = Home.__new__(Home)
 
         assert home_view.og_title() == 'Penny Dreadful Magic'
         assert home_view.og_url() == 'https://pennydreadfulmagic.com/'
+        assert home_view.og_description() == 'Penny Dreadful is an ultra-budget Magic Online format with thousands of legal cards, free weekly tournaments, a free league, and quarterly rotations.'
+
+
+def test_other_marquee_pages_have_specific_open_graph_descriptions() -> None:
+    assert LeagueInfo.__new__(LeagueInfo).og_description() == 'Join the free, play-anytime Penny Dreadful league on Magic Online, play five-match runs, and compete for monthly Cardhoarder prizes.'
+    assert Metagame.__new__(Metagame).og_description() == 'Explore the Penny Dreadful metagame, including popular archetypes, matchups, and successful decklists from recent leagues and tournaments.'
+    assert Competitions.__new__(Competitions).og_description() == 'Browse Penny Dreadful tournament and league results, standings, decklists, and match records from the current season and past seasons.'
+    assert Resources.__new__(Resources).og_description() == 'Find Penny Dreadful tools and community resources, including deck checks, rotation information, Discord, and useful external links.'
+    assert About.__new__(About).og_description() == 'Discover Penny Dreadful, an ultra-budget Magic Online format with thousands of legal cards, quarterly rotations, free events, and a friendly community.'

--- a/decksite/views/metagame.py
+++ b/decksite/views/metagame.py
@@ -15,3 +15,6 @@ class Metagame(View):
 
     def page_title(self) -> str:
         return 'Metagame'
+
+    def og_description(self) -> str:
+        return 'Explore the Penny Dreadful metagame, including popular archetypes, matchups, and successful decklists from recent leagues and tournaments.'

--- a/decksite/views/resources.py
+++ b/decksite/views/resources.py
@@ -26,3 +26,6 @@ class Resources(View):
 
     def page_title(self) -> str:
         return 'Resources'
+
+    def og_description(self) -> str:
+        return 'Find Penny Dreadful tools and community resources, including deck checks, rotation information, Discord, and useful external links.'

--- a/decksite/views/tournaments.py
+++ b/decksite/views/tournaments.py
@@ -17,3 +17,6 @@ class Tournaments(View):
 
     def page_title(self) -> str:
         return 'Cardhoarder Tournaments'
+
+    def og_description(self) -> str:
+        return 'Play in free weekly Penny Dreadful tournaments on Magic Online, with Cardhoarder prizes and events scheduled across multiple time zones.'


### PR DESCRIPTION
## Summary

- add shared Open Graph defaults for non-deck pages
- add useful page-specific descriptions for tournaments and other top-level public pages
- preserve existing deck and archetype metadata overrides

## Validation

- `uv run pytest decksite/views/metadata_test.py decksite/view_test.py decksite/smoke_test.py -q`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- browser-verified rendered metadata and assets in the cloud preview

Fixes #5066

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/8db05b5f-67f7-4664-bc9d-8708da1dc61a)
