### PR TITLE
Show competition season and exact dates

### DIFF
--- a/decksite/templates/subtitle.mustache
+++ b/decksite/templates/subtitle.mustache
@@ -1,15 +1,27 @@
-{{#competition_ends}}
+{{#competition_season_name}}
     <div class="subtitle">
-        Ends {{competition_ends}}
+        <a href="{{competition_season_url}}">{{competition_season_name}}</a>
     </div>
-{{/competition_ends}}
-{{^competition_ends}}
-    {{#date}}
+{{/competition_season_name}}
+{{#competition_dates}}
+    <div class="subtitle">
+        {{competition_dates}}
+    </div>
+{{/competition_dates}}
+{{^competition_dates}}
+    {{#competition_ends}}
         <div class="subtitle">
-            {{date}}
+            Ends {{competition_ends}}
         </div>
-    {{/date}}
-{{/competition_ends}}
+    {{/competition_ends}}
+    {{^competition_ends}}
+        {{#date}}
+            <div class="subtitle">
+                {{date}}
+            </div>
+        {{/date}}
+    {{/competition_ends}}
+{{/competition_dates}}
 {{#is_deck_page}}
     <div class="subtitle">
         {{#public}}{{#reviewed}}<a href="{{archetype_url}}">{{archetype_name}}</a>{{/reviewed}}{{/public}}

--- a/decksite/templates/subtitle.mustache
+++ b/decksite/templates/subtitle.mustache
@@ -1,13 +1,15 @@
 {{#competition_season_name}}
     <div class="subtitle">
-        <a href="{{competition_season_url}}">{{competition_season_name}}</a>
+        <a href="{{competition_season_url}}">{{competition_season_name}}</a>{{#competition_dates}} · {{competition_dates}}{{/competition_dates}}
     </div>
 {{/competition_season_name}}
-{{#competition_dates}}
-    <div class="subtitle">
-        {{competition_dates}}
-    </div>
-{{/competition_dates}}
+{{^competition_season_name}}
+    {{#competition_dates}}
+        <div class="subtitle">
+            {{competition_dates}}
+        </div>
+    {{/competition_dates}}
+{{/competition_season_name}}
 {{^competition_dates}}
     {{#competition_ends}}
         <div class="subtitle">

--- a/decksite/views/competition.py
+++ b/decksite/views/competition.py
@@ -1,10 +1,18 @@
+import datetime
 from typing import Any
+
+from flask import url_for
 
 from decksite.data.archetype import Archetype
 from decksite.view import View
-from magic import tournaments
+from magic import seasons, tournaments
 from magic.models import Competition as Comp
 from shared import dtutil
+
+
+def _exact_date(date: datetime.datetime) -> str:
+    display = f'{date.astimezone(dtutil.WOTC_TZ):%b _%d_, %Y}'
+    return dtutil.replace_day_with_ordinal(display)
 
 
 class Competition(View):
@@ -15,12 +23,17 @@ class Competition(View):
         self.competition_id = self.competition.id
         self.hide_source = True
         self.has_external_source = competition.type != 'League'
+        self.competition_dates = _exact_date(competition.start_date)
         if competition.type == 'League':
             self.skinny_leaderboard = True  # Try and bunch it up on the right of decks table if at all possible.
             self.show_omw = True
             self.hide_top8 = True
             self.has_leaderboard = True
+            self.competition_dates = f'{self.competition_dates} – {_exact_date(competition.end_date)}'
         self.date = dtutil.display_date(competition.start_date)
+        if competition.season_id:
+            self.competition_season_name = seasons.season_name(competition.season_id)
+            self.competition_season_url = url_for('seasons.competitions', season_id=competition.season_id)
         self.archetypes = archetypes
         self.show_archetype_tree = len(self.archetypes) > 0
         self.hide_perfect_runs = self.tournament_only = competition.type != 'League'
@@ -29,6 +42,9 @@ class Competition(View):
 
     def __getattr__(self, attr: str) -> Any:
         return getattr(self.competition, attr)
+
+    def season_id(self) -> int:
+        return self.competition.season_id or super().season_id()
 
     def page_title(self) -> str:
         return self.competition.name

--- a/decksite/views/competition_test.py
+++ b/decksite/views/competition_test.py
@@ -21,8 +21,9 @@ def test_competition_subtitle_shows_season() -> None:
         view = Competition(competition, [])
         rendered = template.render_name('subtitle', view)
 
-    assert '<a href="/seasons/14/competitions/">Season 14</a>' in rendered
-    assert 'Oct 10th, 2019' in rendered
+    compact_rendered = ' '.join(rendered.split())
+    assert rendered.count('<div class="subtitle">') == 1
+    assert '<a href="/seasons/14/competitions/">Season 14</a> · Oct 10th, 2019' in compact_rendered
     assert view.season_id() == 14
 
 
@@ -39,4 +40,6 @@ def test_league_subtitle_shows_exact_date_range() -> None:
     with APP.test_request_context('/competitions/2/'):
         rendered = template.render_name('subtitle', Competition(competition, []))
 
-    assert 'Oct 4th, 2019 – Nov 1st, 2019' in rendered
+    compact_rendered = ' '.join(rendered.split())
+    assert rendered.count('<div class="subtitle">') == 1
+    assert '<a href="/seasons/14/competitions/">Season 14</a> · Oct 4th, 2019 – Nov 1st, 2019' in compact_rendered

--- a/decksite/views/competition_test.py
+++ b/decksite/views/competition_test.py
@@ -1,0 +1,42 @@
+import datetime
+
+from decksite.main import APP
+from decksite.views.competition import Competition
+from magic.models import Competition as CompetitionModel
+from shared import dtutil
+from shared_web import template
+
+
+def test_competition_subtitle_shows_season() -> None:
+    competition = CompetitionModel({
+        'id': 1,
+        'name': 'Penny Dreadful Thursdays 14.01',
+        'type': 'Gatherling',
+        'season_id': 14,
+        'start_date': dtutil.GATHERLING_TZ.localize(datetime.datetime(2019, 10, 10, 19)),
+        'end_date': dtutil.GATHERLING_TZ.localize(datetime.datetime(2019, 10, 10, 23)),
+    })
+
+    with APP.test_request_context('/competitions/1/'):
+        view = Competition(competition, [])
+        rendered = template.render_name('subtitle', view)
+
+    assert '<a href="/seasons/14/competitions/">Season 14</a>' in rendered
+    assert 'Oct 10th, 2019' in rendered
+    assert view.season_id() == 14
+
+
+def test_league_subtitle_shows_exact_date_range() -> None:
+    competition = CompetitionModel({
+        'id': 2,
+        'name': 'League October 2019',
+        'type': 'League',
+        'season_id': 14,
+        'start_date': dtutil.WOTC_TZ.localize(datetime.datetime(2019, 10, 4)),
+        'end_date': dtutil.WOTC_TZ.localize(datetime.datetime(2019, 11, 1, 23, 59, 59)),
+    })
+
+    with APP.test_request_context('/competitions/2/'):
+        rendered = template.render_name('subtitle', Competition(competition, []))
+
+    assert 'Oct 4th, 2019 – Nov 1st, 2019' in rendered


### PR DESCRIPTION
Fixes #6906.

## Summary
- show the linked season on competition pages
- show exact tournament dates and league date ranges
- keep season and dates on one compact metadata line
- use the competition season for historical page theming

## Validation
- `uv run --frozen pytest decksite/views/competition_test.py decksite/view_test.py -q`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- browser-verified tournament, league, and historical competition pages

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ca83e848-afdf-4dbc-bb59-c21ba2067b83)
