### PR TITLE
Add Scryfall link to card details page

### DIFF
--- a/decksite/templates/card.mustache
+++ b/decksite/templates/card.mustache
@@ -11,6 +11,7 @@
     {{#bugs}}
         <p class="bug-desc {{card_img_class}}"><b>{{classification}} bug</b> {{description}}</p>
     {{/bugs}}
+    <p><a class="external" href="{{scryfall_url}}">View on Scryfall</a></p>
 </section>
 {{#played_competitively}}
     {{> stats}}

--- a/decksite/views/card.py
+++ b/decksite/views/card.py
@@ -1,3 +1,4 @@
+import urllib.parse
 from typing import Any
 
 from flask import url_for
@@ -28,6 +29,7 @@ class Card(View):
                 card.preferred_printing = str(printing.set_code)
                 card.preferred_printing_system_id = str(printing.system_id)
         self.toggle_results_url = url_for('.card', name=self.display_name, deck_type=None if tournament_only else DeckType.TOURNAMENT.value)
+        self.scryfall_url = f'https://scryfall.com/search?{urllib.parse.urlencode({"q": f"!\"{self.display_name}\""})}'
         self.card = card
         self.cards = [self.card]
 

--- a/decksite/views/card_test.py
+++ b/decksite/views/card_test.py
@@ -6,6 +6,25 @@ from magic import oracle, seasons
 from magic.models import Card, Printing
 
 
+def test_card_page_links_to_exact_scryfall_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
+    card = Card({
+        'name': 'Wear // Tear',
+        'layout': 'split',
+        'legalities': None,
+        'played_competitively': False,
+        'bugs': None,
+    })
+
+    with APP.test_request_context('/cards/Wear%20//%20Tear/'):
+        content = CardView(card).render_content()
+
+    assert (
+        '<a class="external" href="https://scryfall.com/search?q=%21%22Wear+%2F%2F+Tear%22">'
+        'View on Scryfall</a>'
+    ) in content
+
+
 def test_alternate_card_page_uses_alternate_name_and_printing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(seasons, 'current_season_name', lambda: 'Penny Dreadful TST')
     printing = Printing({'set_code': 'om1', 'system_id': 'd62cf4f8-36a2-4d9f-9d52-53ea18a52760'})


### PR DESCRIPTION
Fixes #6886

## Summary
- add a visible View on Scryfall link beneath the card image
- use an exact, URL-encoded card-name search so canonical, alternate-printing, and split-card pages resolve correctly
- add a focused rendering regression test

## Validation
- `uv run --frozen pytest -q decksite/views/card_test.py`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- `npm run build`
- browser-verified canonical and alternate-printing card pages

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/ca7b0be3-b6d2-417f-8219-fbd4d56dc293)
