### PR TITLE
Add initial rules when creating archetypes

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -108,18 +108,36 @@ def post_archetypes() -> wrappers.Response:
         archs.update_description(cast_int(request.form.get('archetype_id')), cast(str, request.form.get('new_description')))
     elif request.form.getlist('archetype_id') is not None and len(request.form.getlist('archetype_id')) == 2:
         archs.move(int(request.form.getlist('archetype_id')[0]), int(request.form.getlist('archetype_id')[1]))
-    elif request.form.get('parent') is not None:
-        if len(request.form.get('name', '')) > 0:
-            include = request.form.get('include', '')
-            exclude = request.form.get('exclude', '')
-            try:
-                included_cards, excluded_cards = rs.parse_cards_raw(include, exclude)
-            except InvalidDataException as e:
-                return edit_archetypes(add_errors=[str(e)], add_values=request.form)
-            archetype_id = archs.add(cast(str, request.form.get('name')), cast_int(request.form.get('parent')), cast(str, request.form.get('description')))
-            if included_cards or excluded_cards:
-                rule_id = rs.add_rule(archetype_id)
-                rs.update_cards(rule_id, included_cards, excluded_cards)
+    elif request.form.get('create_archetype') is not None or request.form.get('parent') is not None:
+        errors = []
+        parent_id = None
+        parent = request.form.get('parent', '').strip()
+        name = request.form.get('name', '').strip()
+        include = request.form.get('include', '')
+        exclude = request.form.get('exclude', '')
+        try:
+            parent_id = int(parent)
+        except ValueError:
+            errors.append('Please select a valid parent archetype.')
+        else:
+            if not archs.archetype_exists(parent_id):
+                errors.append('Please select a valid parent archetype.')
+        if not name:
+            errors.append('Please enter a name.')
+        elif archs.name_exists(name):
+            errors.append(f'An archetype named {name} already exists.')
+        try:
+            included_cards, excluded_cards = rs.parse_cards_raw(include, exclude)
+        except InvalidDataException as e:
+            errors.append(str(e))
+            included_cards, excluded_cards = [], []
+        if errors:
+            return edit_archetypes(add_errors=errors, add_values=request.form)
+        assert parent_id is not None
+        archetype_id = archs.add(name, parent_id, request.form.get('description', '').strip())
+        if included_cards or excluded_cards:
+            rule_id = rs.add_rule(archetype_id)
+            rs.update_cards(rule_id, included_cards, excluded_cards)
     else:
         raise InvalidArgumentException(f'Did not find any of the expected keys in POST to /admin/archetypes: {request.form}')
     if search_results:

--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Any, cast
 
 import titlecase
@@ -61,8 +62,8 @@ def post_aliases(person_id: int | None = None, alias: str | None = None) -> str 
 
 @APP.route('/admin/archetypes/')
 @auth.demimod_required
-def edit_archetypes(q: str = '', notq: str = '', query_errors: list[str] | None = None, notquery_errors: list[str] | None = None) -> wrappers.Response:
-    view = EditArchetypes(archs.load_archetypes(order_by='a.name'), q, notq, query_errors, notquery_errors)
+def edit_archetypes(q: str = '', notq: str = '', query_errors: list[str] | None = None, notquery_errors: list[str] | None = None, add_errors: list[str] | None = None, add_values: Mapping[str, str] | None = None) -> wrappers.Response:
+    view = EditArchetypes(archs.load_archetypes(order_by='a.name'), q, notq, query_errors, notquery_errors, add_errors, add_values)
     return view.response()
 
 def validate_card_names(raw_names: str) -> tuple[list[str], list[str]]:
@@ -109,9 +110,16 @@ def post_archetypes() -> wrappers.Response:
         archs.move(int(request.form.getlist('archetype_id')[0]), int(request.form.getlist('archetype_id')[1]))
     elif request.form.get('parent') is not None:
         if len(request.form.get('name', '')) > 0:
+            include = request.form.get('include', '')
+            exclude = request.form.get('exclude', '')
+            try:
+                included_cards, excluded_cards = rs.parse_cards_raw(include, exclude)
+            except InvalidDataException as e:
+                return edit_archetypes(add_errors=[str(e)], add_values=request.form)
             archetype_id = archs.add(cast(str, request.form.get('name')), cast_int(request.form.get('parent')), cast(str, request.form.get('description')))
-            rule_id = rs.add_rule(archetype_id)
-            rs.update_cards_raw(rule_id, request.form.get('include', ''), request.form.get('exclude', ''))
+            if included_cards or excluded_cards:
+                rule_id = rs.add_rule(archetype_id)
+                rs.update_cards(rule_id, included_cards, excluded_cards)
     else:
         raise InvalidArgumentException(f'Did not find any of the expected keys in POST to /admin/archetypes: {request.form}')
     if search_results:
@@ -132,8 +140,13 @@ def edit_rules(errors: list[str] | None = None) -> wrappers.Response:
 @auth.demimod_required
 def post_rules() -> wrappers.Response:
     if request.form.get('archetype_id'):
-        rule_id = rs.add_rule(cast_int(request.form.get('archetype_id')))
-        rs.update_cards_raw(rule_id, request.form.get('include', ''), request.form.get('exclude', ''))
+        try:
+            included_cards, excluded_cards = rs.parse_cards_raw(request.form.get('include', ''), request.form.get('exclude', ''))
+        except InvalidDataException as e:
+            return edit_rules([str(e)])
+        if included_cards or excluded_cards:
+            rule_id = rs.add_rule(cast_int(request.form.get('archetype_id')))
+            rs.update_cards(rule_id, included_cards, excluded_cards)
     else:
         return edit_rules(['Please select an archetype.'])
     return edit_rules()

--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -109,7 +109,9 @@ def post_archetypes() -> wrappers.Response:
         archs.move(int(request.form.getlist('archetype_id')[0]), int(request.form.getlist('archetype_id')[1]))
     elif request.form.get('parent') is not None:
         if len(request.form.get('name', '')) > 0:
-            archs.add(cast(str, request.form.get('name')), cast_int(request.form.get('parent')), cast(str, request.form.get('description')))
+            archetype_id = archs.add(cast(str, request.form.get('name')), cast_int(request.form.get('parent')), cast(str, request.form.get('description')))
+            rule_id = rs.add_rule(archetype_id)
+            rs.update_cards_raw(rule_id, request.form.get('include', ''), request.form.get('exclude', ''))
     else:
         raise InvalidArgumentException(f'Did not find any of the expected keys in POST to /admin/archetypes: {request.form}')
     if search_results:

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -47,6 +47,58 @@ def test_validate_card_names_canonicalizes_and_ignores_blank_lines(monkeypatch: 
     assert errors == ['Card not found: Not a Card']
 
 
+def test_post_archetypes_creates_rule_with_new_archetype(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[Any, ...]] = []
+
+    def add_archetype(name: str, parent: int, description: str) -> int:
+        calls.append(('archetype', name, parent, description))
+        return 42
+
+    def add_rule(archetype_id: int) -> int:
+        calls.append(('rule', archetype_id))
+        return 99
+
+    def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, str]:
+        calls.append(('cards', rule_id, include, exclude))
+        return True, ''
+
+    monkeypatch.setattr(admin.archs, 'add', add_archetype)
+    monkeypatch.setattr(admin.rs, 'add_rule', add_rule)
+    monkeypatch.setattr(admin.rs, 'update_cards_raw', update_cards_raw)
+    monkeypatch.setattr(admin, 'edit_archetypes', lambda *args: 'done')
+
+    data = {
+        'parent': '7',
+        'name': 'Tempo Spells',
+        'description': 'Cheap threats backed by interaction.',
+        'include': '4 Delver of Secrets',
+        'exclude': '1 Tolarian Terror',
+    }
+    with APP.test_request_context('/admin/archetypes/', method='POST', data=data):
+        response = cast(Any, admin.post_archetypes).__wrapped__()
+
+    assert response == 'done'
+    assert calls == [
+        ('archetype', 'Tempo Spells', 7, 'Cheap threats backed by interaction.'),
+        ('rule', 42),
+        ('cards', 99, '4 Delver of Secrets', '1 Tolarian Terror'),
+    ]
+
+
+def test_edit_archetypes_add_form_includes_rule_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: [])
+    monkeypatch.setattr(deck, 'load_queue_similarity', lambda decks: None)
+
+    with APP.test_request_context('/admin/archetypes/'):
+        html = EditArchetypes([], '', '').render_content()
+
+    assert '<label for="description">Description</label>' in html
+    assert '<label for="include">Must include</label>' in html
+    assert '<textarea name="include" id="include"></textarea>' in html
+    assert '<label for="exclude">Must not include</label>' in html
+    assert '<textarea name="exclude" id="exclude"></textarea>' in html
+
+
 def test_admin_menu_hides_admin_only_items_from_demimod() -> None:
     with APP.test_request_context('/admin/'):
         with APP.test_request_context('/admin/', environ_base={'HTTP_HOST': 'localhost'}):

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -58,13 +58,17 @@ def test_post_archetypes_creates_rule_with_new_archetype(monkeypatch: pytest.Mon
         calls.append(('rule', archetype_id))
         return 99
 
-    def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, str]:
+    def parse_cards_raw(include: str, exclude: str) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
+        calls.append(('parse', include, exclude))
+        return [(4, 'Delver of Secrets')], [(1, 'Tolarian Terror')]
+
+    def update_cards(rule_id: int, include: list[tuple[int, str]], exclude: list[tuple[int, str]]) -> None:
         calls.append(('cards', rule_id, include, exclude))
-        return True, ''
 
     monkeypatch.setattr(admin.archs, 'add', add_archetype)
     monkeypatch.setattr(admin.rs, 'add_rule', add_rule)
-    monkeypatch.setattr(admin.rs, 'update_cards_raw', update_cards_raw)
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', parse_cards_raw)
+    monkeypatch.setattr(admin.rs, 'update_cards', update_cards)
     monkeypatch.setattr(admin, 'edit_archetypes', lambda *args: 'done')
 
     data = {
@@ -79,10 +83,54 @@ def test_post_archetypes_creates_rule_with_new_archetype(monkeypatch: pytest.Mon
 
     assert response == 'done'
     assert calls == [
+        ('parse', '4 Delver of Secrets', '1 Tolarian Terror'),
         ('archetype', 'Tempo Spells', 7, 'Cheap threats backed by interaction.'),
         ('rule', 42),
-        ('cards', 99, '4 Delver of Secrets', '1 Tolarian Terror'),
+        ('cards', 99, [(4, 'Delver of Secrets')], [(1, 'Tolarian Terror')]),
     ]
+
+
+def test_post_archetypes_does_not_create_empty_rule(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', lambda include, exclude: ([], []))
+    monkeypatch.setattr(admin.archs, 'add', lambda name, parent, description: 42)
+    monkeypatch.setattr(admin.rs, 'add_rule', lambda archetype_id: pytest.fail('Should not create an empty rule'))
+    monkeypatch.setattr(admin, 'edit_archetypes', lambda *args: 'done')
+
+    with APP.test_request_context('/admin/archetypes/', method='POST', data={'parent': '7', 'name': 'Tempo Spells', 'description': 'Description'}):
+        response = cast(Any, admin.post_archetypes).__wrapped__()
+
+    assert response == 'done'
+
+
+def test_post_archetypes_validates_rule_before_creating_archetype(monkeypatch: pytest.MonkeyPatch) -> None:
+    def parse_cards_raw(include: str, exclude: str) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
+        raise InvalidDataException('Card not found in any deck: 4 Not a Card')
+
+    def edit_archetypes(q: str = '', notq: str = '', query_errors: list[str] | None = None, notquery_errors: list[str] | None = None, add_errors: list[str] | None = None, add_values: dict[str, str] | None = None) -> str:
+        return EditArchetypes([], q, notq, query_errors, notquery_errors, add_errors, add_values).render_content()
+
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', parse_cards_raw)
+    monkeypatch.setattr(admin.archs, 'add', lambda *args: pytest.fail('Should not create an archetype with an invalid rule'))
+    monkeypatch.setattr(admin.rs, 'add_rule', lambda archetype_id: pytest.fail('Should not create an invalid rule'))
+    monkeypatch.setattr(admin, 'edit_archetypes', edit_archetypes)
+    monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: [])
+    monkeypatch.setattr(deck, 'load_queue_similarity', lambda decks: None)
+    data = {
+        'parent': '7',
+        'name': 'Tempo Spells',
+        'description': 'Cheap threats backed by interaction.',
+        'include': '4 Not a Card',
+        'exclude': '1 Tolarian Terror',
+    }
+
+    with APP.test_request_context('/admin/archetypes/', method='POST', data=data):
+        response = cast(Any, admin.post_archetypes).__wrapped__()
+
+    assert 'Card not found in any deck: 4 Not a Card' in response
+    assert 'value="Tempo Spells"' in response
+    assert 'value="Cheap threats backed by interaction."' in response
+    assert '>4 Not a Card</textarea>' in response
+    assert '>1 Tolarian Terror</textarea>' in response
 
 
 def test_edit_archetypes_add_form_includes_rule_fields(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -135,6 +183,34 @@ def test_post_rules_requires_archetype(monkeypatch: pytest.MonkeyPatch) -> None:
         response = cast(Any, admin.post_rules).__wrapped__()
     assert 'Please select an archetype.' in response
     assert '<select name="archetype_id" required class="error" aria-describedby="archetype-error">' in response
+
+
+def test_post_rules_validates_before_creating_rule(monkeypatch: pytest.MonkeyPatch) -> None:
+    def edit_rules(errors: list[str] | None = None) -> str:
+        return EditRules(0, 0, [], [], [], [], [], [], errors).render_content()
+
+    def parse_cards_raw(include: str, exclude: str) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
+        raise InvalidDataException('Card not found in any deck: 4 Not a Card')
+
+    monkeypatch.setattr(admin, 'edit_rules', edit_rules)
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', parse_cards_raw)
+    monkeypatch.setattr(admin.rs, 'add_rule', lambda archetype_id: pytest.fail('Should not create an invalid rule'))
+
+    with APP.test_request_context('/admin/rules/', method='POST', data={'archetype_id': '7', 'include': '4 Not a Card'}):
+        response = cast(Any, admin.post_rules).__wrapped__()
+
+    assert 'Card not found in any deck: 4 Not a Card' in response
+
+
+def test_post_rules_does_not_create_empty_rule(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admin, 'edit_rules', lambda errors=None: 'done')
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', lambda include, exclude: ([], []))
+    monkeypatch.setattr(admin.rs, 'add_rule', lambda archetype_id: pytest.fail('Should not create an empty rule'))
+
+    with APP.test_request_context('/admin/rules/', method='POST', data={'archetype_id': '7'}):
+        response = cast(Any, admin.post_rules).__wrapped__()
+
+    assert response == 'done'
 
 
 @pytest.mark.parametrize('action', ['add', 'change'])

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -66,6 +66,8 @@ def test_post_archetypes_creates_rule_with_new_archetype(monkeypatch: pytest.Mon
         calls.append(('cards', rule_id, include, exclude))
 
     monkeypatch.setattr(admin.archs, 'add', add_archetype)
+    monkeypatch.setattr(admin.archs, 'archetype_exists', lambda archetype_id: True)
+    monkeypatch.setattr(admin.archs, 'name_exists', lambda name: False)
     monkeypatch.setattr(admin.rs, 'add_rule', add_rule)
     monkeypatch.setattr(admin.rs, 'parse_cards_raw', parse_cards_raw)
     monkeypatch.setattr(admin.rs, 'update_cards', update_cards)
@@ -92,6 +94,8 @@ def test_post_archetypes_creates_rule_with_new_archetype(monkeypatch: pytest.Mon
 
 def test_post_archetypes_does_not_create_empty_rule(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(admin.rs, 'parse_cards_raw', lambda include, exclude: ([], []))
+    monkeypatch.setattr(admin.archs, 'archetype_exists', lambda archetype_id: True)
+    monkeypatch.setattr(admin.archs, 'name_exists', lambda name: False)
     monkeypatch.setattr(admin.archs, 'add', lambda name, parent, description: 42)
     monkeypatch.setattr(admin.rs, 'add_rule', lambda archetype_id: pytest.fail('Should not create an empty rule'))
     monkeypatch.setattr(admin, 'edit_archetypes', lambda *args: 'done')
@@ -110,6 +114,8 @@ def test_post_archetypes_validates_rule_before_creating_archetype(monkeypatch: p
         return EditArchetypes([], q, notq, query_errors, notquery_errors, add_errors, add_values).render_content()
 
     monkeypatch.setattr(admin.rs, 'parse_cards_raw', parse_cards_raw)
+    monkeypatch.setattr(admin.archs, 'archetype_exists', lambda archetype_id: True)
+    monkeypatch.setattr(admin.archs, 'name_exists', lambda name: False)
     monkeypatch.setattr(admin.archs, 'add', lambda *args: pytest.fail('Should not create an archetype with an invalid rule'))
     monkeypatch.setattr(admin.rs, 'add_rule', lambda archetype_id: pytest.fail('Should not create an invalid rule'))
     monkeypatch.setattr(admin, 'edit_archetypes', edit_archetypes)
@@ -133,6 +139,51 @@ def test_post_archetypes_validates_rule_before_creating_archetype(monkeypatch: p
     assert '>1 Tolarian Terror</textarea>' in response
 
 
+@pytest.mark.parametrize('parent', ['', 'not-an-id', '999999'])
+def test_post_archetypes_reports_invalid_parent_without_writing(monkeypatch: pytest.MonkeyPatch, parent: str) -> None:
+    def edit_archetypes(q: str = '', notq: str = '', query_errors: list[str] | None = None, notquery_errors: list[str] | None = None, add_errors: list[str] | None = None, add_values: dict[str, str] | None = None) -> str:
+        assert add_values is not None
+        assert add_values.get('name') == 'Tempo Spells'
+        return '\n'.join(add_errors or [])
+
+    monkeypatch.setattr(admin.archs, 'archetype_exists', lambda archetype_id: False)
+    monkeypatch.setattr(admin.archs, 'name_exists', lambda name: False)
+    monkeypatch.setattr(admin.archs, 'add', lambda *args: pytest.fail('Should not create an archetype with an invalid parent'))
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', lambda include, exclude: ([], []))
+    monkeypatch.setattr(admin, 'edit_archetypes', edit_archetypes)
+
+    with APP.test_request_context('/admin/archetypes/', method='POST', data={'create_archetype': '1', 'parent': parent, 'name': 'Tempo Spells'}):
+        response = cast(Any, admin.post_archetypes).__wrapped__()
+
+    assert response == 'Please select a valid parent archetype.'
+
+
+def test_post_archetypes_reports_blank_name_without_writing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admin.archs, 'archetype_exists', lambda archetype_id: True)
+    monkeypatch.setattr(admin.archs, 'name_exists', lambda name: pytest.fail('Should not check a blank name'))
+    monkeypatch.setattr(admin.archs, 'add', lambda *args: pytest.fail('Should not create an unnamed archetype'))
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', lambda include, exclude: ([], []))
+    monkeypatch.setattr(admin, 'edit_archetypes', lambda *args, **kwargs: '\n'.join(kwargs.get('add_errors') or []))
+
+    with APP.test_request_context('/admin/archetypes/', method='POST', data={'create_archetype': '1', 'parent': '7', 'name': '   '}):
+        response = cast(Any, admin.post_archetypes).__wrapped__()
+
+    assert response == 'Please enter a name.'
+
+
+def test_post_archetypes_reports_duplicate_name_without_writing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admin.archs, 'archetype_exists', lambda archetype_id: True)
+    monkeypatch.setattr(admin.archs, 'name_exists', lambda name: True)
+    monkeypatch.setattr(admin.archs, 'add', lambda *args: pytest.fail('Should not create a duplicate archetype'))
+    monkeypatch.setattr(admin.rs, 'parse_cards_raw', lambda include, exclude: ([], []))
+    monkeypatch.setattr(admin, 'edit_archetypes', lambda *args, **kwargs: '\n'.join(kwargs.get('add_errors') or []))
+
+    with APP.test_request_context('/admin/archetypes/', method='POST', data={'create_archetype': '1', 'parent': '7', 'name': 'Delver'}):
+        response = cast(Any, admin.post_archetypes).__wrapped__()
+
+    assert response == 'An archetype named Delver already exists.'
+
+
 def test_edit_archetypes_add_form_includes_rule_fields(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: [])
     monkeypatch.setattr(deck, 'load_queue_similarity', lambda decks: None)
@@ -143,6 +194,9 @@ def test_edit_archetypes_add_form_includes_rule_fields(monkeypatch: pytest.Monke
     assert '<label for="description">Description</label>' in html
     assert '<section id="add-archetype">' in html
     assert '<form method="post" action="#add-archetype">' in html
+    assert '<input type="hidden" name="create_archetype" value="1">' in html
+    assert '<select name="parent" id="parent" required>' in html
+    assert '<input type="text" name="name" id="name" value="" required>' in html
     assert '<label for="include">Must include</label>' in html
     assert '<textarea name="include" id="include"></textarea>' in html
     assert '<label for="exclude">Must not include</label>' in html

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -141,6 +141,8 @@ def test_edit_archetypes_add_form_includes_rule_fields(monkeypatch: pytest.Monke
         html = EditArchetypes([], '', '').render_content()
 
     assert '<label for="description">Description</label>' in html
+    assert '<section id="add-archetype">' in html
+    assert '<form method="post" action="#add-archetype">' in html
     assert '<label for="include">Must include</label>' in html
     assert '<textarea name="include" id="include"></textarea>' in html
     assert '<label for="exclude">Must not include</label>' in html

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -154,7 +154,7 @@ def season_stats(archetype_id: int, tournament_only: bool = False) -> list[Seaso
         for row in db().select(sql, [archetype_id])
     ]
 
-def add(name: str, parent: int, description: str) -> None:
+def add(name: str, parent: int, description: str) -> int:
     archetype_id = db().insert('INSERT INTO archetype (name, description) VALUES (%s, %s)', [name, description])
     ancestors = db().select('SELECT ancestor, depth FROM archetype_closure WHERE descendant = %s', [parent])
     sql = 'INSERT INTO archetype_closure (ancestor, descendant, depth) VALUES '
@@ -162,6 +162,7 @@ def add(name: str, parent: int, description: str) -> None:
         sql += '({ancestor}, {descendant}, {depth}), '.format(ancestor=sqlescape(a['ancestor']), descendant=archetype_id, depth=int(a['depth']) + 1)
     sql += f'({archetype_id}, {archetype_id}, 0)'
     db().execute(sql)
+    return archetype_id
 
 def assign(deck_id: int, archetype_id: int, person_id: int | None, reviewed: bool = True, similarity: int | None = None) -> None:
     db().begin('assign_archetype')

--- a/decksite/data/archetype.py
+++ b/decksite/data/archetype.py
@@ -61,6 +61,12 @@ def archetype_id_from_name(name: str) -> int | None:
             return int(r['id'])
     return None
 
+def archetype_exists(archetype_id: int) -> bool:
+    return bool(db().value('SELECT EXISTS(SELECT 1 FROM archetype WHERE id = %s)', [archetype_id]))
+
+def name_exists(name: str) -> bool:
+    return bool(db().value('SELECT EXISTS(SELECT 1 FROM archetype WHERE name = %s)', [name]))
+
 def load_archetype(archetype: int | str) -> Archetype:
     try:
         archetype_id = int(archetype)

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -51,6 +51,21 @@ def test_assign_clears_cached_deck_after_committing(monkeypatch: pytest.MonkeyPa
     clear.assert_called_once_with('decksite:deck:42')
 
 
+def test_add_returns_new_archetype_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    database = mock.Mock()
+    database.insert.return_value = 42
+    database.select.return_value = []
+    monkeypatch.setattr(archetype, 'db', lambda: database)
+
+    archetype_id = archetype.add('Tempo Spells', 7, 'Cheap threats backed by interaction.')
+
+    assert archetype_id == 42
+    database.insert.assert_called_once_with(
+        'INSERT INTO archetype (name, description) VALUES (%s, %s)',
+        ['Tempo Spells', 'Cheap threats backed by interaction.'],
+    )
+
+
 @with_test_db
 @pytest.mark.functional
 def test_missing_movers_preaggregate_returns_no_data_during_a_web_request() -> None:

--- a/decksite/data/archetype_test.py
+++ b/decksite/data/archetype_test.py
@@ -66,6 +66,24 @@ def test_add_returns_new_archetype_id(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+def test_archetype_exists_checks_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    database = mock.Mock()
+    database.value.return_value = 1
+    monkeypatch.setattr(archetype, 'db', lambda: database)
+
+    assert archetype.archetype_exists(42)
+    database.value.assert_called_once_with('SELECT EXISTS(SELECT 1 FROM archetype WHERE id = %s)', [42])
+
+
+def test_name_exists_checks_database_name_equality(monkeypatch: pytest.MonkeyPatch) -> None:
+    database = mock.Mock()
+    database.value.return_value = 0
+    monkeypatch.setattr(archetype, 'db', lambda: database)
+
+    assert not archetype.name_exists('Tempo Spells')
+    database.value.assert_called_once_with('SELECT EXISTS(SELECT 1 FROM archetype WHERE name = %s)', ['Tempo Spells'])
+
+
 @with_test_db
 @pytest.mark.functional
 def test_missing_movers_preaggregate_returns_no_data_during_a_web_request() -> None:

--- a/decksite/data/rule.py
+++ b/decksite/data/rule.py
@@ -214,7 +214,7 @@ def add_rule(archetype_id: int) -> int:
     sql = 'INSERT INTO rule (archetype_id) VALUES (%s)'
     return db().insert(sql, [archetype_id])
 
-def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, str]:
+def parse_cards_raw(include: str, exclude: str) -> tuple[list[tuple[int, str]], list[tuple[int, str]]]:
     inc = []
     exc = []
     cards = set()
@@ -222,26 +222,33 @@ def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, st
         try:
             inc.append(parse_line(line))
         except InvalidDataException:
-            return False, f"Couldn't find a card count and name on line: {line}"
+            raise InvalidDataException(f"Couldn't find a card count and name on line: {line}") from None
         if not card.card_exists(inc[-1][1]):
-            return False, f'Card not found in any deck: {line}'
+            raise InvalidDataException(f'Card not found in any deck: {line}')
         canonical_name = oracle.valid_name(inc[-1][1])
         if canonical_name in cards:
-            return False, f'Card appears more than once in rule: {canonical_name}'
+            raise InvalidDataException(f'Card appears more than once in rule: {canonical_name}')
         cards.add(canonical_name)
         inc[-1] = (inc[-1][0], canonical_name)
     for line in exclude.strip().splitlines():
         try:
             exc.append(parse_line(line))
         except InvalidDataException:
-            return False, f"Couldn't find a card count and name on line: {line}"
+            raise InvalidDataException(f"Couldn't find a card count and name on line: {line}") from None
         if not card.card_exists(exc[-1][1]):
-            return False, f'Card not found in any deck {line}'
+            raise InvalidDataException(f'Card not found in any deck {line}')
         canonical_name = oracle.valid_name(exc[-1][1])
         if canonical_name in cards:
-            return False, f'Card appears more than once in rule: {canonical_name}'
+            raise InvalidDataException(f'Card appears more than once in rule: {canonical_name}')
         cards.add(canonical_name)
         exc[-1] = (exc[-1][0], canonical_name)
+    return inc, exc
+
+def update_cards_raw(rule_id: int, include: str, exclude: str) -> tuple[bool, str]:
+    try:
+        inc, exc = parse_cards_raw(include, exclude)
+    except InvalidDataException as e:
+        return False, str(e)
     update_cards(rule_id, inc, exc)
     return True, ''
 

--- a/decksite/data/rule_test.py
+++ b/decksite/data/rule_test.py
@@ -35,3 +35,17 @@ def test_update_cards_raw_updates_distinct_cards(monkeypatch: pytest.MonkeyPatch
     assert success
     assert message == ''
     assert updates == [(1, [(4, 'Lightning Bolt')], [(1, 'Counterspell')])]
+
+
+@pytest.mark.parametrize(
+    ('include', 'exclude', 'expected'),
+    [
+        ('4 lightning bolt', '', ([(4, 'Lightning Bolt')], [])),
+        ('', '1 counterspell', ([], [(1, 'Counterspell')])),
+    ],
+)
+def test_parse_cards_raw_accepts_one_sided_rules(monkeypatch: pytest.MonkeyPatch, include: str, exclude: str, expected: tuple[list[tuple[int, str]], list[tuple[int, str]]]) -> None:
+    monkeypatch.setattr(rule.card, 'card_exists', lambda name: True)
+    monkeypatch.setattr(rule.oracle, 'valid_name', lambda name: name.title())
+
+    assert rule.parse_cards_raw(include, exclude) == expected

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -145,6 +145,14 @@
             <input type="text" name="description">
         </div>
         <div>
+            <label for="include">Must include</label>
+            <textarea name="include" id="include"></textarea>
+        </div>
+        <div>
+            <label for="exclude">Must not include</label>
+            <textarea name="exclude" id="exclude"></textarea>
+        </div>
+        <div>
             <button type="submit">Add</button>
         </div>
     </form>

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -126,31 +126,34 @@
 </section>
 <section>
     <h2>Add Archetype</h2>
+    {{#add_errors}}
+        <p class="error">{{.}}</p>
+    {{/add_errors}}
     <form method="post">
         <div>
             <label for="parent">Parent</label>
             <select name="parent">
                 <option value="">[Select]</option>
-                {{#archetypes}}
-                    <option value="{{id}}">{{name}}</option>
-                {{/archetypes}}
+                {{#add_archetypes}}
+                    <option value="{{id}}"{{#selected}} selected{{/selected}}>{{name}}</option>
+                {{/add_archetypes}}
             </select>
         </div>
         <div>
             <label for="name">Name</label>
-            <input type="text" name="name">
+            <input type="text" name="name" value="{{add_name}}">
         </div>
         <div>
             <label for="description">Description</label>
-            <input type="text" name="description">
+            <input type="text" name="description" value="{{add_description}}">
         </div>
         <div>
             <label for="include">Must include</label>
-            <textarea name="include" id="include"></textarea>
+            <textarea name="include" id="include">{{add_include}}</textarea>
         </div>
         <div>
             <label for="exclude">Must not include</label>
-            <textarea name="exclude" id="exclude"></textarea>
+            <textarea name="exclude" id="exclude">{{add_exclude}}</textarea>
         </div>
         <div>
             <button type="submit">Add</button>

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -124,12 +124,12 @@
         {{/archetypes_preordered}}
     </table>
 </section>
-<section>
+<section id="add-archetype">
     <h2>Add Archetype</h2>
     {{#add_errors}}
         <p class="error">{{.}}</p>
     {{/add_errors}}
-    <form method="post">
+    <form method="post" action="#add-archetype">
         <div>
             <label for="parent">Parent</label>
             <select name="parent">

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -126,13 +126,18 @@
 </section>
 <section id="add-archetype">
     <h2>Add Archetype</h2>
-    {{#add_errors}}
-        <p class="error">{{.}}</p>
-    {{/add_errors}}
+    {{#has_add_errors}}
+        <div id="add-archetype-errors" role="alert">
+            {{#add_errors}}
+                <p class="error">{{.}}</p>
+            {{/add_errors}}
+        </div>
+    {{/has_add_errors}}
     <form method="post" action="#add-archetype">
+        <input type="hidden" name="create_archetype" value="1">
         <div>
             <label for="parent">Parent</label>
-            <select name="parent">
+            <select name="parent" id="parent" required>
                 <option value="">[Select]</option>
                 {{#add_archetypes}}
                     <option value="{{id}}"{{#selected}} selected{{/selected}}>{{name}}</option>
@@ -141,11 +146,11 @@
         </div>
         <div>
             <label for="name">Name</label>
-            <input type="text" name="name" value="{{add_name}}">
+            <input type="text" name="name" id="name" value="{{add_name}}" required>
         </div>
         <div>
             <label for="description">Description</label>
-            <input type="text" name="description" value="{{add_description}}">
+            <input type="text" name="description" id="description" value="{{add_description}}">
         </div>
         <div>
             <label for="include">Must include</label>

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from flask import url_for
 
 from decksite import prepare
@@ -7,7 +9,7 @@ from decksite.view import View
 
 
 class EditArchetypes(View):
-    def __init__(self, archetypes: list[Archetype], q: str, notq: str, query_errors: list[str] | None = None, notquery_errors: list[str] | None = None) -> None:
+    def __init__(self, archetypes: list[Archetype], q: str, notq: str, query_errors: list[str] | None = None, notquery_errors: list[str] | None = None, add_errors: list[str] | None = None, add_values: Mapping[str, str] | None = None) -> None:
         super().__init__()
         self.archetypes = archetypes
         self.archetypes_preordered = archetype.preorder(archetypes)
@@ -39,6 +41,13 @@ class EditArchetypes(View):
         self.notquery_errors = notquery_errors or []
         self.has_query_errors = bool(self.query_errors)
         self.has_notquery_errors = bool(self.notquery_errors)
+        self.add_errors = add_errors or []
+        values = add_values or {}
+        self.add_archetypes = [{'id': a.id, 'name': a.name, 'selected': str(a.id) == values.get('parent')} for a in archetypes]
+        self.add_name = values.get('name', '')
+        self.add_description = values.get('description', '')
+        self.add_include = values.get('include', '')
+        self.add_exclude = values.get('exclude', '')
 
     def page_title(self) -> str:
         return 'Edit Archetypes'

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -42,6 +42,7 @@ class EditArchetypes(View):
         self.has_query_errors = bool(self.query_errors)
         self.has_notquery_errors = bool(self.notquery_errors)
         self.add_errors = add_errors or []
+        self.has_add_errors = bool(self.add_errors)
         values = add_values or {}
         self.add_archetypes = [{'id': a.id, 'name': a.name, 'selected': str(a.id) == values.get('parent')} for a in archetypes]
         self.add_name = values.get('name', '')


### PR DESCRIPTION
Fixes #6091

## Summary
- add description and include/exclude rule fields to archetype creation
- share card-rule parsing with the rules page and avoid inserting empty rules
- validate parents, names, duplicates, and malformed rules before writing
- preserve submitted values and keep validation errors in view

## Validation
- `uv run --frozen pytest decksite/controllers/admin_test.py decksite/data/rule_test.py decksite/data/archetype_test.py -k "not test_load_archetype_finds_accented_name_spelled_without_accents and not test_load_archetype_still_finds_names_with_dashes_around_slashes" -q`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- `npm run build`
- browser-verified empty-parent, duplicate-name, and malformed-rule errors

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/829a59a4-5bc6-416f-9c08-ff92b1d42c89)
