### PR TITLE
Add first and last page pagination controls

### DIFF
--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -167,15 +167,15 @@ def test_pagination_shows_page_number_and_jumps_to_ends(browser: 'Browser', site
     assert match
     last_page = int(match.group(1))
     assert last_page > 1
-    expect(pagination.locator('.first')).to_have_class(re.compile(r'\binactive\b'))
+    expect(pagination.get_by_role('button', name='First page')).to_be_disabled()
 
     with page.expect_response(lambda response: '/api/decks/' in response.url and f'page={last_page - 1}' in response.url):
-        pagination.locator('a.last').click()
+        pagination.get_by_role('button', name='Last page').click()
     expect(page_number).to_have_text(f'Page {last_page} of {last_page}')
-    expect(pagination.locator('.last')).to_have_class(re.compile(r'\binactive\b'))
+    expect(pagination.get_by_role('button', name='Last page')).to_be_disabled()
 
     with page.expect_response(lambda response: '/api/decks/' in response.url and 'page=0' in response.url):
-        pagination.locator('a.first').click()
+        pagination.get_by_role('button', name='First page').click()
     expect(page_number).to_have_text(f'Page 1 of {last_page}')
     assert not collector.problems, '\n'.join(collector.problems)
 

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -30,7 +30,7 @@ ENABLED = bool(BASE_URL) or os.environ.get('PD_BROWSER_TESTS') == '1'
 pytestmark = [pytest.mark.browser, pytest.mark.skipif(not ENABLED, reason='Set PD_BROWSER_TESTS=1 or PD_BROWSER_BASE_URL to run browser tests')]
 
 if ENABLED:
-    from playwright.sync_api import Browser, Locator, Page, expect, sync_playwright
+    from playwright.sync_api import Browser, Locator, Page, Route, expect, sync_playwright
 
 # Fixed entry points. More pages are discovered from the links on these so the test needs no knowledge of what data the site has.
 PAGES = ['/', '/decks/', '/people/', '/cards/', '/metagame/', '/competitions/', '/tournaments/leaderboards/', '/resources/', '/about/']
@@ -157,6 +157,14 @@ def test_table_without_optional_class_name_omits_it(browser: 'Browser', site: Co
 
 def test_pagination_shows_page_number_and_jumps_to_ends(browser: 'Browser', site: Container) -> None:
     page, collector = new_page(browser, site)
+
+    def force_multiple_pages(route: 'Route') -> None:
+        response = route.fetch()
+        data = response.json()
+        data['total'] = 41
+        route.fulfill(response=response, json=data)
+
+    page.route('**/api/decks/**', force_multiple_pages)
     page.goto('/decks/')
     assert not wait_for_live_tables(page)
     pagination = page.locator('.decktable .pagination')

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -155,6 +155,31 @@ def test_table_without_optional_class_name_omits_it(browser: 'Browser', site: Co
     assert not collector.problems, '\n'.join(collector.problems)
 
 
+def test_pagination_shows_page_number_and_jumps_to_ends(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site)
+    page.goto('/decks/')
+    assert not wait_for_live_tables(page)
+    pagination = page.locator('.decktable .pagination')
+
+    page_number = pagination.locator('.page-number')
+    expect(page_number).to_have_text(re.compile(r'Page 1 of \d+'))
+    match = re.fullmatch(r'Page 1 of (\d+)', page_number.inner_text())
+    assert match
+    last_page = int(match.group(1))
+    assert last_page > 1
+    expect(pagination.locator('.first')).to_have_class(re.compile(r'\binactive\b'))
+
+    with page.expect_response(lambda response: '/api/decks/' in response.url and f'page={last_page - 1}' in response.url):
+        pagination.locator('a.last').click()
+    expect(page_number).to_have_text(f'Page {last_page} of {last_page}')
+    expect(pagination.locator('.last')).to_have_class(re.compile(r'\binactive\b'))
+
+    with page.expect_response(lambda response: '/api/decks/' in response.url and 'page=0' in response.url):
+        pagination.locator('a.first').click()
+    expect(page_number).to_have_text(f'Page 1 of {last_page}')
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
 def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: Container) -> None:
     page, collector = new_page(browser, site)
     page.goto('/metagame/')

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1490,6 +1490,15 @@ Some pages still send giant tables of data but logsite and deck table have pagin
     width: 8em;
 }
 
+.pagination .page-number {
+    display: inline-block;
+    font-size: var(--table-font-size);
+    line-height: 1.777;
+    min-width: 7em;
+    text-align: center;
+    vertical-align: top;
+}
+
 .pagination a, .pagination .inactive {
     padding: 0.75rem; /* rem because font-size is larger for arrows than page-size. */
 }

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1464,25 +1464,22 @@ Some pages still send giant tables of data but logsite and deck table have pagin
 */
 
 .pagination {
+    align-items: center;
     display: flex;
     font-size: var(--table-font-size);
     font-variant-numeric: oldstyle-nums;
+    flex-wrap: wrap;
+    gap: 0 1em;
     justify-content: flex-end;
-    line-height: 1.777; /* So that the smaller (font-size: 0.75rem) text lines up vertically with the larger (font-size: 1rem) arrows which have line-height 1.333 (the base line height) = 1.333 / 0.75 */
+    line-height: 1.333;
 }
 
 .pagination .section {
-    margin-right: 1em;
     white-space: nowrap;
 }
 
-.pagination .section:last-child {
-    margin-right: 0;
-}
-
 .pagination .links {
-    font-size: var(--reading-font-size);
-    line-height: var(--reading-line-height);
+    display: flex;
 }
 
 .pagination .pages {
@@ -1491,16 +1488,44 @@ Some pages still send giant tables of data but logsite and deck table have pagin
 }
 
 .pagination .page-number {
-    display: inline-block;
-    font-size: var(--table-font-size);
-    line-height: 1.777;
     min-width: 7em;
     text-align: center;
-    vertical-align: top;
 }
 
 .pagination a, .pagination .inactive {
     padding: 0.75rem; /* rem because font-size is larger for arrows than page-size. */
+}
+
+.pagination button.paginate {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    color: inherit;
+    display: flex;
+    height: 2.2rem;
+    justify-content: center;
+    margin: 0;
+    max-width: none;
+    padding: 0;
+    width: 2.2rem;
+}
+
+.pagination button.paginate:not(:disabled) {
+    cursor: pointer;
+}
+
+.pagination button.paginate:not(:disabled):hover {
+    background-color: var(--highlight);
+    border-radius: var(--button-rounded-corners);
+}
+
+.pagination button.paginate:disabled {
+    color: var(--inactive);
+}
+
+.pagination button.paginate svg {
+    height: 0.8rem;
+    width: 0.8rem;
 }
 
 .page-size {

--- a/shared_web/static/js/datamanager.jsx
+++ b/shared_web/static/js/datamanager.jsx
@@ -113,7 +113,9 @@ export class DataManager extends React.Component {
         const start = objects.length === 0 ? 0 : page * this.state.pageSize + 1;
         const end = Math.min(start + this.state.pageSize - 1, this.state.total);
         const total = this.state.total;
-        return { start, end, total };
+        const pageCount = Math.ceil(total / this.state.pageSize);
+        const pageNumber = total === 0 ? 0 : page + 1;
+        return { start, end, pageCount, pageNumber, total };
     }
 
     movePage(page) {

--- a/shared_web/static/js/grid.jsx
+++ b/shared_web/static/js/grid.jsx
@@ -1,4 +1,5 @@
 import { DataManager } from "./datamanager";
+import { Pagination } from "./pagination";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -77,35 +78,7 @@ export class Grid extends DataManager {
     }
 
     renderPagination() {
-        const { start, end, pageCount, pageNumber, total } = super.preRenderPagination();
-        const firstPage = 0;
-        const lastPage = pageCount - 1;
-        return (
-            <div className="pagination">
-                <span className="pages section">
-                    {start}-{end} of {total}
-                </span>
-                <span className="links section">
-                    { this.state.page > firstPage
-                        ? <a aria-label="First page" className="first paginate" title="First page" onClick={this.movePage.bind(this, firstPage)}>⇤</a>
-                        : <span aria-label="First page" className="inactive first paginate" title="First page">⇤</span>
-                    }
-                    { this.state.page > 0
-                        ? <a aria-label="Previous page" className="prev paginate" title="Previous page" onClick={this.movePage.bind(this, this.state.page - 1)}>←</a>
-                        : <span aria-label="Previous page" className="inactive prev paginate" title="Previous page">←</span>
-                    }
-                    <span className="page-number">Page {pageNumber} of {pageCount}</span>
-                    { end < this.state.total
-                        ? <a aria-label="Next page" className="next paginate" title="Next page" onClick={this.movePage.bind(this, this.state.page + 1)}>→</a>
-                        : <span aria-label="Next page" className="inactive next paginate" title="Next page">→</span>
-                    }
-                    { this.state.page < lastPage
-                        ? <a aria-label="Last page" className="last paginate" title="Last page" onClick={this.movePage.bind(this, lastPage)}>⇥</a>
-                        : <span aria-label="Last page" className="inactive last paginate" title="Last page">⇥</span>
-                    }
-                </span>
-            </div>
-        );
+        return <Pagination {...super.preRenderPagination()} page={this.state.page} onPageChange={this.movePage.bind(this)}/>;
     }
 }
 

--- a/shared_web/static/js/grid.jsx
+++ b/shared_web/static/js/grid.jsx
@@ -77,20 +77,31 @@ export class Grid extends DataManager {
     }
 
     renderPagination() {
-        const { start, end, total } = super.preRenderPagination();
+        const { start, end, pageCount, pageNumber, total } = super.preRenderPagination();
+        const firstPage = 0;
+        const lastPage = pageCount - 1;
         return (
             <div className="pagination">
                 <span className="pages section">
                     {start}-{end} of {total}
                 </span>
                 <span className="links section">
-                    { this.state.page > 0
-                        ? <a className="prev paginate" onClick={this.movePage.bind(this, this.state.page - 1)}>←</a>
-                        : <span className="inactive prev paginate">←</span>
+                    { this.state.page > firstPage
+                        ? <a aria-label="First page" className="first paginate" title="First page" onClick={this.movePage.bind(this, firstPage)}>⇤</a>
+                        : <span aria-label="First page" className="inactive first paginate" title="First page">⇤</span>
                     }
+                    { this.state.page > 0
+                        ? <a aria-label="Previous page" className="prev paginate" title="Previous page" onClick={this.movePage.bind(this, this.state.page - 1)}>←</a>
+                        : <span aria-label="Previous page" className="inactive prev paginate" title="Previous page">←</span>
+                    }
+                    <span className="page-number">Page {pageNumber} of {pageCount}</span>
                     { end < this.state.total
-                        ? <a className="next paginate" onClick={this.movePage.bind(this, this.state.page + 1)}>→</a>
-                        : <span className="inactive next paginate">→</span>
+                        ? <a aria-label="Next page" className="next paginate" title="Next page" onClick={this.movePage.bind(this, this.state.page + 1)}>→</a>
+                        : <span aria-label="Next page" className="inactive next paginate" title="Next page">→</span>
+                    }
+                    { this.state.page < lastPage
+                        ? <a aria-label="Last page" className="last paginate" title="Last page" onClick={this.movePage.bind(this, lastPage)}>⇥</a>
+                        : <span aria-label="Last page" className="inactive last paginate" title="Last page">⇥</span>
                     }
                 </span>
             </div>

--- a/shared_web/static/js/pagination.jsx
+++ b/shared_web/static/js/pagination.jsx
@@ -1,0 +1,64 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+const PageIcon = ({ type }) => {
+    const paths = {
+        first: "M17 6l-6 6 6 6M7 6v12",
+        last: "M7 6l6 6-6 6M17 6v12",
+        next: "M9 6l6 6-6 6",
+        previous: "M15 6l-6 6 6 6"
+    };
+    return (
+        <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+            <path d={paths[type]} fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"/>
+        </svg>
+    );
+};
+
+PageIcon.propTypes = {
+    "type": PropTypes.oneOf(["first", "last", "next", "previous"]).isRequired
+};
+
+const PageButton = ({ disabled, label, onClick, type }) => (
+    <button aria-label={label} className={`paginate ${type}`} disabled={disabled} title={label} type="button" onClick={onClick}>
+        <PageIcon type={type}/>
+    </button>
+);
+
+PageButton.propTypes = {
+    "disabled": PropTypes.bool.isRequired,
+    "label": PropTypes.string.isRequired,
+    "onClick": PropTypes.func.isRequired,
+    "type": PropTypes.oneOf(["first", "last", "next", "previous"]).isRequired
+};
+
+export const Pagination = ({ end, onPageChange, page, pageCount, pageNumber, start, total }) => {
+    const firstPage = 0;
+    const lastPage = pageCount - 1;
+    return (
+        <div aria-label="Pagination" className="pagination" role="navigation">
+            <span className="pages section">
+                {start.toLocaleString()}–{end.toLocaleString()} of {total.toLocaleString()}
+            </span>
+            <span aria-live="polite" className="page-number section">
+                Page {pageNumber.toLocaleString()} of {pageCount.toLocaleString()}
+            </span>
+            <span className="links section">
+                <PageButton disabled={page === firstPage} label="First page" type="first" onClick={() => onPageChange(firstPage)}/>
+                <PageButton disabled={page === firstPage} label="Previous page" type="previous" onClick={() => onPageChange(page - 1)}/>
+                <PageButton disabled={page === lastPage || lastPage < firstPage} label="Next page" type="next" onClick={() => onPageChange(page + 1)}/>
+                <PageButton disabled={page === lastPage || lastPage < firstPage} label="Last page" type="last" onClick={() => onPageChange(lastPage)}/>
+            </span>
+        </div>
+    );
+};
+
+Pagination.propTypes = {
+    "end": PropTypes.number.isRequired,
+    "onPageChange": PropTypes.func.isRequired,
+    "page": PropTypes.number.isRequired,
+    "pageCount": PropTypes.number.isRequired,
+    "pageNumber": PropTypes.number.isRequired,
+    "start": PropTypes.number.isRequired,
+    "total": PropTypes.number.isRequired
+};

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -1,4 +1,5 @@
 import { DataManager } from "./datamanager";
+import { Pagination } from "./pagination";
 import PropTypes from "prop-types";
 import React from "react";
 
@@ -75,35 +76,7 @@ export class Table extends DataManager {
     }
 
     renderPagination() {
-        const { start, end, pageCount, pageNumber, total } = super.preRenderPagination();
-        const firstPage = 0;
-        const lastPage = pageCount - 1;
-        return (
-            <div className="pagination">
-                <span className="pages section">
-                    {start}-{end} of {total}
-                </span>
-                <span className="links section">
-                    { this.state.page > firstPage
-                        ? <a aria-label="First page" className="first paginate" title="First page" onClick={this.movePage.bind(this, firstPage)}>⇤</a>
-                        : <span aria-label="First page" className="inactive first paginate" title="First page">⇤</span>
-                    }
-                    { this.state.page > 0
-                        ? <a aria-label="Previous page" className="prev paginate" title="Previous page" onClick={this.movePage.bind(this, this.state.page - 1)}>←</a>
-                        : <span aria-label="Previous page" className="inactive prev paginate" title="Previous page">←</span>
-                    }
-                    <span className="page-number">Page {pageNumber} of {pageCount}</span>
-                    { end < this.state.total
-                        ? <a aria-label="Next page" className="next paginate" title="Next page" onClick={this.movePage.bind(this, this.state.page + 1)}>→</a>
-                        : <span aria-label="Next page" className="inactive next paginate" title="Next page">→</span>
-                    }
-                    { this.state.page < lastPage
-                        ? <a aria-label="Last page" className="last paginate" title="Last page" onClick={this.movePage.bind(this, lastPage)}>⇥</a>
-                        : <span aria-label="Last page" className="inactive last paginate" title="Last page">⇥</span>
-                    }
-                </span>
-            </div>
-        );
+        return <Pagination {...super.preRenderPagination()} page={this.state.page} onPageChange={this.movePage.bind(this)}/>;
     }
 }
 

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -75,20 +75,31 @@ export class Table extends DataManager {
     }
 
     renderPagination() {
-        const { start, end, total } = super.preRenderPagination();
+        const { start, end, pageCount, pageNumber, total } = super.preRenderPagination();
+        const firstPage = 0;
+        const lastPage = pageCount - 1;
         return (
             <div className="pagination">
                 <span className="pages section">
                     {start}-{end} of {total}
                 </span>
                 <span className="links section">
-                    { this.state.page > 0
-                        ? <a className="prev paginate" onClick={this.movePage.bind(this, this.state.page - 1)}>←</a>
-                        : <span className="inactive prev paginate">←</span>
+                    { this.state.page > firstPage
+                        ? <a aria-label="First page" className="first paginate" title="First page" onClick={this.movePage.bind(this, firstPage)}>⇤</a>
+                        : <span aria-label="First page" className="inactive first paginate" title="First page">⇤</span>
                     }
+                    { this.state.page > 0
+                        ? <a aria-label="Previous page" className="prev paginate" title="Previous page" onClick={this.movePage.bind(this, this.state.page - 1)}>←</a>
+                        : <span aria-label="Previous page" className="inactive prev paginate" title="Previous page">←</span>
+                    }
+                    <span className="page-number">Page {pageNumber} of {pageCount}</span>
                     { end < this.state.total
-                        ? <a className="next paginate" onClick={this.movePage.bind(this, this.state.page + 1)}>→</a>
-                        : <span className="inactive next paginate">→</span>
+                        ? <a aria-label="Next page" className="next paginate" title="Next page" onClick={this.movePage.bind(this, this.state.page + 1)}>→</a>
+                        : <span aria-label="Next page" className="inactive next paginate" title="Next page">→</span>
+                    }
+                    { this.state.page < lastPage
+                        ? <a aria-label="Last page" className="last paginate" title="Last page" onClick={this.movePage.bind(this, lastPage)}>⇥</a>
+                        : <span aria-label="Last page" className="inactive last paginate" title="Last page">⇥</span>
                     }
                 </span>
             </div>


### PR DESCRIPTION
Fixes #6657

## Summary

- show the current page and total page count alongside the existing row range
- add first, previous, next, and last controls using consistent SVG icons and 44px targets
- use semantic, keyboard-accessible buttons with responsive wrapping
- share the pagination component between tables and grids

## Validation

- targeted browser test covering first/last jumps
- full decksite browser suite (11 passed)
- JavaScript lint
- focused Ruff and mypy
- production JavaScript build
- visual checks at desktop, 400px mobile, and a 240px narrow-layout audit

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/cc3d10a6-a138-4f72-840e-42561601b454)
