### PR TITLE
Add exact timestamps to friendly web dates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Merging pull requests
 
 To merge a PR, comment `@mergifyio queue` on it (for example `gh pr comment <number> --body "@mergifyio queue"`).
-Mergify then merges it once the mypy, lint, test and jslint checks pass.
+Mergify then merges it once the mypy, lint, test, jslint and browser checks pass.
 
 Do not use the "merge when ready" label. It is a leftover from an old CI setup and Mergify ignores it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,14 @@ Do not use the "merge when ready" label. It is a leftover from an old CI setup a
   `.conductor/preview-tunnel.py` on the Mac and the restricted
   `.conductor/preview-ssh.sh` server entry point so it reconnects and restarts
   decksite. Verify recovery, not just the initial HTTP response.
+
+## Web dates
+
+- Keep `shared.dtutil.display_date` as a plain-text formatter for bots, errors,
+  and other non-HTML output.
+- For humanized dates in web views, use
+  `shared_web.friendly_time.friendly_date`, render it with the
+  `friendlytime.mustache` partial, or use the React `FriendlyTime` component.
+  This preserves the friendly label while providing an exact, localized
+  timestamp on hover. Do not render the compatibility `display_date` fields
+  directly in HTML.

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -33,7 +33,7 @@ if ENABLED:
     from playwright.sync_api import Browser, Locator, Page, Route, expect, sync_playwright
 
 # Fixed entry points. More pages are discovered from the links on these so the test needs no knowledge of what data the site has.
-PAGES = ['/', '/decks/', '/people/', '/cards/', '/metagame/', '/competitions/', '/tournaments/leaderboards/', '/resources/', '/about/']
+PAGES = ['/', '/decks/', '/people/', '/cards/', '/metagame/', '/competitions/', '/tournaments/leaderboards/', '/seasons/', '/rotation/', '/resources/', '/about/']
 # Links in tables may carry a /seasons/N/ prefix, so match anywhere in the href.
 DISCOVER = [('/decks/', '.decktable a[href*="/people/"]'), ('/decks/', '.decktable a[href*="/archetypes/"]'), ('/decks/', '.decktable a[href*="/competitions/"]'), ('/decks/', '.decktable a[href*="/decks/"]'), ('/cards/', '.cardtable a[href*="/cards/"]')]
 LIVE_TABLE_CLASSES = ['decktable', 'cardtable', 'persontable', 'matchtable', 'leaderboardtable', 'headtoheadtable']
@@ -127,6 +127,9 @@ def test_pages_render_with_data_and_without_errors(browser: 'Browser', site: Con
             problems.append(f'{path}: HTTP {response.status}')
             continue
         problems.extend(wait_for_live_tables(page))
+        untitled_times = page.locator('time:not([title])')
+        if untitled_times.count():
+            problems.append(f'{path}: {untitled_times.count()} time elements lack exact timestamp titles')
         problems.extend(f'{path}: {p}' for p in collector.problems)
     if site.seed:
         assert any('/people/' in p and p != '/people/' for p in pages) and any('/cards/' in p and p != '/cards/' for p in pages), f'Discovery found no person/card pages in {pages}'
@@ -219,20 +222,18 @@ def test_friendly_deck_dates_have_exact_timestamp_titles(browser: 'Browser', sit
     assert not wait_for_live_tables(page)
 
     deck = response_info.value.json()['objects'][0]
+    api_friendly_date = deck['friendlyDate']
     friendly_date = page.locator('.decktable td.date time').first
-    exact_date = page.evaluate(
-        "timestamp => moment.unix(timestamp).tz(moment.tz.guess()).format('YYYY-MM-DD HH:mm:ss z')",
-        deck['activeDate'],
-    )
-    iso_date = page.evaluate('timestamp => new Date(timestamp * 1000).toISOString()', deck['activeDate'])
-    expect(friendly_date).to_have_text(deck['displayDate'])
-    expect(friendly_date).to_have_attribute('datetime', iso_date)
+    exact_date = page.evaluate('datetime => PD.formatExactTimestamp(datetime)', api_friendly_date['datetime'])
+    assert deck['displayDate'] == api_friendly_date['display']
+    expect(friendly_date).to_have_text(api_friendly_date['display'])
+    expect(friendly_date).to_have_attribute('datetime', api_friendly_date['datetime'])
     expect(friendly_date).to_have_attribute('title', exact_date)
 
     page.goto(deck['url'])
     deck_date = page.locator('.subtitle time').first
-    expect(deck_date).to_have_text(deck['displayDate'])
-    expect(deck_date).to_have_attribute('datetime', re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$'))
+    expect(deck_date).to_have_text(api_friendly_date['display'])
+    expect(deck_date).to_have_attribute('datetime', api_friendly_date['datetime'])
     expect(deck_date).to_have_attribute('title', exact_date)
     assert not collector.problems, '\n'.join(collector.problems)
 

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -212,6 +212,31 @@ def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: 
     assert not collector.problems, '\n'.join(collector.problems)
 
 
+def test_friendly_deck_dates_have_exact_timestamp_titles(browser: 'Browser', site: Container) -> None:
+    page, collector = new_page(browser, site)
+    with page.expect_response(lambda response: '/api/decks/?' in response.url) as response_info:
+        page.goto('/decks/')
+    assert not wait_for_live_tables(page)
+
+    deck = response_info.value.json()['objects'][0]
+    friendly_date = page.locator('.decktable td.date time').first
+    exact_date = page.evaluate(
+        "timestamp => moment.unix(timestamp).tz(moment.tz.guess()).format('YYYY-MM-DD HH:mm:ss z')",
+        deck['activeDate'],
+    )
+    iso_date = page.evaluate('timestamp => new Date(timestamp * 1000).toISOString()', deck['activeDate'])
+    expect(friendly_date).to_have_text(deck['displayDate'])
+    expect(friendly_date).to_have_attribute('datetime', iso_date)
+    expect(friendly_date).to_have_attribute('title', exact_date)
+
+    page.goto(deck['url'])
+    deck_date = page.locator('.subtitle time').first
+    expect(deck_date).to_have_text(deck['displayDate'])
+    expect(deck_date).to_have_attribute('datetime', re.compile(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$'))
+    expect(deck_date).to_have_attribute('title', exact_date)
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
 def test_card_stats_are_numbers_and_card_summaries_are_locale_formatted(browser: 'Browser', site: Container) -> None:
     page, collector = new_page(browser, site, locale='en-US')
     with page.expect_response(lambda response: '/api/cards2/' in response.url) as response_info:

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -216,7 +216,7 @@ def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: 
 
 
 def test_friendly_deck_dates_have_exact_timestamp_titles(browser: 'Browser', site: Container) -> None:
-    page, collector = new_page(browser, site, locale='en-US', timezone_id='America/Los_Angeles')
+    page, collector = new_page(browser, site, locale='en-GB', timezone_id='America/New_York')
     with page.expect_response(lambda response: '/api/decks/?' in response.url) as response_info:
         page.goto('/decks/')
     assert not wait_for_live_tables(page)
@@ -225,10 +225,10 @@ def test_friendly_deck_dates_have_exact_timestamp_titles(browser: 'Browser', sit
     api_friendly_date = deck['friendlyDate']
     friendly_date = page.locator('.decktable td.date time').first
     exact_date = page.evaluate(
-        "datetime => new Intl.DateTimeFormat('en-US', {dateStyle: 'full', timeStyle: 'long'}).format(new Date(datetime))",
+        "datetime => new Intl.DateTimeFormat('en-GB', {dateStyle: 'full', timeStyle: 'full'}).format(new Date(datetime))",
         api_friendly_date['datetime'],
     )
-    assert re.fullmatch(r'(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), .+ at \d{1,2}:\d{2}:\d{2} [AP]M P[SD]T', exact_date)
+    assert re.search(r' Eastern (Daylight|Standard) Time$', exact_date)
     assert deck['displayDate'] == api_friendly_date['display']
     expect(friendly_date).to_have_text(api_friendly_date['display'])
     expect(friendly_date).to_have_attribute('datetime', api_friendly_date['datetime'])

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -33,7 +33,7 @@ if ENABLED:
     from playwright.sync_api import Browser, Locator, Page, Route, expect, sync_playwright
 
 # Fixed entry points. More pages are discovered from the links on these so the test needs no knowledge of what data the site has.
-PAGES = ['/', '/decks/', '/people/', '/cards/', '/metagame/', '/competitions/', '/tournaments/leaderboards/', '/seasons/', '/rotation/', '/resources/', '/about/']
+PAGES = ['/', '/decks/', '/people/', '/cards/', '/metagame/', '/competitions/', '/tournaments/leaderboards/', '/resources/', '/about/']
 # Links in tables may carry a /seasons/N/ prefix, so match anywhere in the href.
 DISCOVER = [('/decks/', '.decktable a[href*="/people/"]'), ('/decks/', '.decktable a[href*="/archetypes/"]'), ('/decks/', '.decktable a[href*="/competitions/"]'), ('/decks/', '.decktable a[href*="/decks/"]'), ('/cards/', '.cardtable a[href*="/cards/"]')]
 LIVE_TABLE_CLASSES = ['decktable', 'cardtable', 'persontable', 'matchtable', 'leaderboardtable', 'headtoheadtable']

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -216,7 +216,7 @@ def test_help_cursor_does_not_hide_clickable_elements(browser: 'Browser', site: 
 
 
 def test_friendly_deck_dates_have_exact_timestamp_titles(browser: 'Browser', site: Container) -> None:
-    page, collector = new_page(browser, site)
+    page, collector = new_page(browser, site, locale='en-US', timezone_id='America/Los_Angeles')
     with page.expect_response(lambda response: '/api/decks/?' in response.url) as response_info:
         page.goto('/decks/')
     assert not wait_for_live_tables(page)
@@ -224,7 +224,11 @@ def test_friendly_deck_dates_have_exact_timestamp_titles(browser: 'Browser', sit
     deck = response_info.value.json()['objects'][0]
     api_friendly_date = deck['friendlyDate']
     friendly_date = page.locator('.decktable td.date time').first
-    exact_date = page.evaluate('datetime => PD.formatExactTimestamp(datetime)', api_friendly_date['datetime'])
+    exact_date = page.evaluate(
+        "datetime => new Intl.DateTimeFormat('en-US', {dateStyle: 'full', timeStyle: 'long'}).format(new Date(datetime))",
+        api_friendly_date['datetime'],
+    )
+    assert re.fullmatch(r'(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday), .+ at \d{1,2}:\d{2}:\d{2} [AP]M P[SD]T', exact_date)
     assert deck['displayDate'] == api_friendly_date['display']
     expect(friendly_date).to_have_text(api_friendly_date['display'])
     expect(friendly_date).to_have_attribute('datetime', api_friendly_date['datetime'])

--- a/decksite/data/news.py
+++ b/decksite/data/news.py
@@ -9,6 +9,7 @@ from magic.models import Deck
 from shared import dtutil, logger, repo
 from shared import redis_wrapper as redis
 from shared.container import Container
+from shared_web import friendly_time
 
 
 def all_news(ds: list[Deck], start_date: datetime.datetime | None = None, end_date: datetime.datetime | None = None, max_items: int = sys.maxsize) -> list[Container]:
@@ -28,7 +29,8 @@ def all_news(ds: list[Deck], start_date: datetime.datetime | None = None, end_da
             continue
         if item.date < start_date:
             break
-        item.display_date = dtutil.display_date(item.date)
+        item.friendly_date = friendly_time.friendly_date(item.date)
+        item.display_date = item.friendly_date.display  # API compatibility.
         results.append(item)
         if len(results) >= max_items:
             break

--- a/decksite/data/person.py
+++ b/decksite/data/person.py
@@ -8,6 +8,7 @@ from shared.container import Container
 from shared.database import sqlescape
 from shared.decorators import empty_page, retry_after_calling
 from shared.pd_exception import AlreadyExistsException, DatabaseException, DoesNotExistException
+from shared_web import friendly_time
 
 
 def load_person_by_id(person_id: int, season_id: int | None = None) -> Person:
@@ -332,7 +333,8 @@ def load_notes(person_id: int | None = None) -> list[Container]:
     notes = [Container(r) for r in db().select(sql)]
     for n in notes:
         n.created_date = dtutil.ts2dt(n.created_date)
-        n.display_date = dtutil.display_date(n.created_date)
+        n.friendly_date = friendly_time.friendly_date(n.created_date)
+        n.display_date = n.friendly_date.display  # API compatibility.
     return notes
 
 def add_note(creator_id: int, subject_id: int, note: str) -> None:

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -106,6 +106,7 @@ def prepare_deck(d: Deck) -> None:
     else:
         d.person_url = url_for('seasons.person', person_id=d.person_id, season_id=d.season_id)
     d.date_sort = dtutil.dt2ts(d.active_date)
+    d.date_iso = d.active_date.isoformat()
     d.display_date = dtutil.display_date(d.active_date)
     d.show_record = d.wins or d.losses or d.draws
     if d.competition_id:
@@ -168,6 +169,7 @@ def prepare_matches(ms: Sequence[Container], show_rounds: bool = False) -> None:
         if m.get('date'):
             m.display_date = dtutil.display_date(m.date)
             m.date_sort = dtutil.dt2ts(m.date)
+            m.date_iso = m.date.isoformat()
         if m.get('person'):
             m.person_url = url_for('person', mtgo_username=m.person)
         if m.get('deck_id'):

--- a/decksite/prepare.py
+++ b/decksite/prepare.py
@@ -14,6 +14,7 @@ from magic.models import Card, Deck
 from shared import dtutil
 from shared.container import Container
 from shared.pd_exception import InvalidDataException
+from shared_web import friendly_time
 
 # Take 'raw' items from the database and decorate them for use and display.
 
@@ -106,8 +107,8 @@ def prepare_deck(d: Deck) -> None:
     else:
         d.person_url = url_for('seasons.person', person_id=d.person_id, season_id=d.season_id)
     d.date_sort = dtutil.dt2ts(d.active_date)
-    d.date_iso = d.active_date.isoformat()
-    d.display_date = dtutil.display_date(d.active_date)
+    d.friendly_date = friendly_time.friendly_date(d.active_date)
+    d.display_date = d.friendly_date.display  # API compatibility.
     d.show_record = d.wins or d.losses or d.draws
     if d.competition_id:
         d.competition_url = f'/competitions/{d.competition_id}/'
@@ -167,9 +168,9 @@ def prepare_leaderboard(leaderboard: Sequence[Container]) -> None:
 def prepare_matches(ms: Sequence[Container], show_rounds: bool = False) -> None:
     for m in ms:
         if m.get('date'):
-            m.display_date = dtutil.display_date(m.date)
             m.date_sort = dtutil.dt2ts(m.date)
-            m.date_iso = m.date.isoformat()
+            m.friendly_date = friendly_time.friendly_date(m.date)
+            m.display_date = m.friendly_date.display  # API compatibility.
         if m.get('person'):
             m.person_url = url_for('person', mtgo_username=m.person)
         if m.get('deck_id'):

--- a/decksite/templates/competitions.mustache
+++ b/decksite/templates/competitions.mustache
@@ -13,7 +13,7 @@
                     <tr data-href="{{competition_url}}" class="clickable">
                         <td><a href="{{competition_url}}">{{{name}}}</a></td>
                         <td class="n" data-sortInitialOrder="desc"><a href="{{competition_url}}">{{{num_decks}}}</a></td>
-                        <td data-text="{{date_sort}}"><a href="{{competition_url}}">{{{display_date}}}</a></td>
+                        <td data-text="{{date_sort}}"><a href="{{competition_url}}">{{#friendly_date}}{{> friendlytime}}{{/friendly_date}}</a></td>
                     </tr>
                 {{/num_decks}}
             {{/competitions}}

--- a/decksite/templates/deckmatches.mustache
+++ b/decksite/templates/deckmatches.mustache
@@ -30,7 +30,7 @@
                     {{^opponent_url}}</span>{{/opponent_url}}
                     {{#opponent_url}}</a>{{/opponent_url}}</td>
                 {{^has_rounds}}
-                    <td data-text="{{date_sort}}"><time datetime="{{date_iso}}">{{display_date}}</time></td>
+                    <td data-text="{{date_sort}}">{{#friendly_date}}{{> friendlytime}}{{/friendly_date}}</td>
                 {{/has_rounds}}
             </tr>
         {{/matches}}

--- a/decksite/templates/deckmatches.mustache
+++ b/decksite/templates/deckmatches.mustache
@@ -30,7 +30,7 @@
                     {{^opponent_url}}</span>{{/opponent_url}}
                     {{#opponent_url}}</a>{{/opponent_url}}</td>
                 {{^has_rounds}}
-                    <td data-text="{{date_sort}}">{{display_date}}</td>
+                    <td data-text="{{date_sort}}"><time datetime="{{date_iso}}">{{display_date}}</time></td>
                 {{/has_rounds}}
             </tr>
         {{/matches}}

--- a/decksite/templates/deckrow.mustache
+++ b/decksite/templates/deckrow.mustache
@@ -32,7 +32,7 @@
     {{/hide_top8}}
     {{^hide_date}}
         <td data-text="{{date_sort}}">
-            <time datetime="{{date_iso}}">{{display_date}}</time>
+            {{#friendly_date}}{{> friendlytime}}{{/friendly_date}}
         </td>
     {{/hide_date}}
     {{#show_season_icon}}

--- a/decksite/templates/deckrow.mustache
+++ b/decksite/templates/deckrow.mustache
@@ -32,7 +32,7 @@
     {{/hide_top8}}
     {{^hide_date}}
         <td data-text="{{date_sort}}">
-            {{display_date}}
+            <time datetime="{{date_iso}}">{{display_date}}</time>
         </td>
     {{/hide_date}}
     {{#show_season_icon}}

--- a/decksite/templates/editmatches.mustache
+++ b/decksite/templates/editmatches.mustache
@@ -3,14 +3,14 @@
     <form method="post">
         <select {{#form.errors.left_id}}class="error" aria-describedby="left-id-error" {{/form.errors.left_id}}name="left_id">
             {{#decks}}
-                <option value="{{id}}" class="person">{{person}} ({{name}}, {{display_date}}, {{id}}{{#retired}}, Retired{{/retired}}, {{wins}}–{{losses}})</option>
+                <option value="{{id}}" class="person" data-friendly-datetime="{{friendly_date.datetime}}">{{person}} ({{name}}, {{friendly_date.display}}, {{id}}{{#retired}}, Retired{{/retired}}, {{wins}}–{{losses}})</option>
             {{/decks}}
         </select>
         <input {{#form.errors.left_games}}class="error" aria-describedby="left-games-error" {{/form.errors.left_games}}type="number" name="left_games" value="{{form.left_games}}">
         <input {{#form.errors.right_games}}class="error" aria-describedby="right-games-error" {{/form.errors.right_games}}type="number" name="right_games" value="{{form.right_games}}">
         <select {{#form.errors.right_id}}class="error" aria-describedby="right-id-error" {{/form.errors.right_id}}name="right_id">
             {{#decks}}
-                <option value="{{id}}" class="person">{{person}} ({{name}}, {{display_date}}, {{id}})</option>
+                <option value="{{id}}" class="person" data-friendly-datetime="{{friendly_date.datetime}}">{{person}} ({{name}}, {{friendly_date.display}}, {{id}})</option>
             {{/decks}}
         </select>
         <button type="submit" name="action" value="add">Add Match</button>

--- a/decksite/templates/home.mustache
+++ b/decksite/templates/home.mustache
@@ -1,6 +1,6 @@
 {{#deck_tables}}
     <section>
-        <h2>{{title}}{{#subtitle}} <span class="subtitle">{{subtitle}}</span>{{/subtitle}}</h2>
+        <h2>{{title}}{{#subtitle_friendly_date}} <span class="subtitle">{{> friendlytime}}</span>{{/subtitle_friendly_date}}{{^subtitle_friendly_date}}{{#subtitle}} <span class="subtitle">{{subtitle}}</span>{{/subtitle}}{{/subtitle_friendly_date}}</h2>
         {{> decktable}}
         <p><a href="{{url}}">{{link_text}}</a></p>
     </section>
@@ -68,7 +68,7 @@
 {{/has_news}}
 <section class="rotation">
     <h2>Season {{season_id}}</h2>
-    <p>Season {{season_id}} began {{season_start_display}} and ends {{season_end_display}}.</p>
+    <p>Season {{season_id}} began {{#season_start_friendly}}{{> friendlytime}}{{/season_start_friendly}} and ends {{#season_end_friendly}}{{> friendlytime}}{{/season_end_friendly}}.</p>
     <ul>
         <li><a href="{{scryfall_url}}">{{_ Legal cards (scryfall)}}</a></li>
         <li><a href="{{legal_cards_url}}">{{_ Legal cards (text)}}</a></li>

--- a/decksite/templates/news.mustache
+++ b/decksite/templates/news.mustache
@@ -2,7 +2,7 @@
     <h2>News</h2>
         <ul>
             {{#news}}
-                <li class="item {{type}}">{{#url}}<a href="{{url}}">{{/url}} <span class="story">{{title}}</span> <span class="date">{{display_date}}</span>{{#url}}</a>{{/url}}</li>
+                <li class="item {{type}}">{{#url}}<a href="{{url}}">{{/url}} <span class="story">{{title}}</span> <span class="date">{{#friendly_date}}{{> friendlytime}}{{/friendly_date}}</span>{{#url}}</a>{{/url}}</li>
             {{/news}}
         </ul>
 </section>

--- a/decksite/templates/personmatches.mustache
+++ b/decksite/templates/personmatches.mustache
@@ -26,7 +26,7 @@
                     </td>
                     <td class="n">{{game_wins}}–{{game_losses}}</td>
                     <td><a href="{{competition_url}}">{{competition_type_name}}</a></td>
-                    <td data-text="{{date_sort}}"><time datetime="{{date_iso}}">{{display_date}}</time></td>
+                    <td data-text="{{date_sort}}">{{#friendly_date}}{{> friendlytime}}{{/friendly_date}}</td>
                     <td>{{#mtgo_id}}<a href="{{log_url}}">{{mtgo_id}}</a>{{/mtgo_id}}</td>
                 </tr>
             {{/matches}}

--- a/decksite/templates/personmatches.mustache
+++ b/decksite/templates/personmatches.mustache
@@ -26,7 +26,7 @@
                     </td>
                     <td class="n">{{game_wins}}–{{game_losses}}</td>
                     <td><a href="{{competition_url}}">{{competition_type_name}}</a></td>
-                    <td data-text="{{date_sort}}">{{display_date}}</td>
+                    <td data-text="{{date_sort}}"><time datetime="{{date_iso}}">{{display_date}}</time></td>
                     <td>{{#mtgo_id}}<a href="{{log_url}}">{{mtgo_id}}</a>{{/mtgo_id}}</td>
                 </tr>
             {{/matches}}

--- a/decksite/templates/playernotes.mustache
+++ b/decksite/templates/playernotes.mustache
@@ -14,7 +14,7 @@
                     <td class="person"><a href="{{subject_url}}">{{subject}}</a></td>
                     <td class="person"><a href="{{creator_url}}">{{creator}}</a></td>
                     <td data-text="{{date_sort}}">
-                        {{display_date}}
+                        {{#friendly_date}}{{> friendlytime}}{{/friendly_date}}
                     </td>
                     <td class="wide">{{note}}</td>
                 </tr>

--- a/decksite/templates/rotation.mustache
+++ b/decksite/templates/rotation.mustache
@@ -1,5 +1,5 @@
 <section>
-    <p>{{rotation_msg}}</p>
+    <p>{{rotation_prefix}}{{#rotation_friendly_date}}{{> friendlytime}}{{/rotation_friendly_date}}</p>
     {{#runs}}
         {{#note}}
             <p>{{note}}</p>

--- a/decksite/templates/seasons.mustache
+++ b/decksite/templates/seasons.mustache
@@ -1,7 +1,7 @@
 {{#seasons}}
     <section class="stats">
         <h2>Season {{num}} ({{code}})</h2>
-        <p>{{start_date_display}}–{{end_date_display}} ({{length_in_days}})</p>
+        <p>{{#start_date_friendly}}{{> friendlytime}}{{/start_date_friendly}}–{{#end_date_friendly}}{{> friendlytime}}{{/end_date_friendly}}{{^end_date_friendly}}Now{{/end_date_friendly}} ({{length_in_days}})</p>
         <ul>
             <li><a href="{{decks_url}}">{{num_decks}} Decks</a></li>
             <li><a href="{{decks_url}}">{{decks_per_day}} Decks Per Day</a></li>

--- a/decksite/templates/sorters.mustache
+++ b/decksite/templates/sorters.mustache
@@ -15,7 +15,7 @@
                     <td class="person"><a href="{{url}}">{{name}}</a></td>
                     <td class="n">{{num_decks_sorted}}</td>
                     <td class="n">{{sorted_per_day}}</td>
-                    <td data-text="{{date_sort}}">{{display_last_sorted}}</td>
+                    <td data-text="{{date_sort}}">{{#last_sorted_friendly}}{{> friendlytime}}{{/last_sorted_friendly}}</td>
                 </tr>
             {{/people}}
         </tbody>

--- a/decksite/templates/subtitle.mustache
+++ b/decksite/templates/subtitle.mustache
@@ -11,18 +11,18 @@
     {{/competition_dates}}
 {{/competition_season_name}}
 {{^competition_dates}}
-    {{#competition_ends}}
+    {{#competition_ends_friendly}}
         <div class="subtitle">
-            Ends {{competition_ends}}
+            Ends {{> friendlytime}}
         </div>
-    {{/competition_ends}}
-    {{^competition_ends}}
+    {{/competition_ends_friendly}}
+    {{^competition_ends_friendly}}
         {{#date}}
             <div class="subtitle">
-                {{date}}
+                {{#friendly_date}}{{> friendlytime}}{{/friendly_date}}
             </div>
         {{/date}}
-    {{/competition_ends}}
+    {{/competition_ends_friendly}}
 {{/competition_dates}}
 {{#is_deck_page}}
     <div class="subtitle">
@@ -31,7 +31,7 @@
         by <a href="{{person_url}}" class="person">{{person}}</a>
     </div>
     <div class="subtitle">
-        <time datetime="{{date_iso}}">{{display_date}}</time>
+        {{#friendly_date}}{{> friendlytime}}{{/friendly_date}}
     </div>
     <div class="subtitle">
         <a href="{{#competition_url}}{{competition_url}}{{/competition_url}}{{^competition_url}}{{source_url}}{{/competition_url}}">

--- a/decksite/templates/subtitle.mustache
+++ b/decksite/templates/subtitle.mustache
@@ -31,7 +31,7 @@
         by <a href="{{person_url}}" class="person">{{person}}</a>
     </div>
     <div class="subtitle">
-        {{display_date}}
+        <time datetime="{{date_iso}}">{{display_date}}</time>
     </div>
     <div class="subtitle">
         <a href="{{#competition_url}}{{competition_url}}{{/competition_url}}{{^competition_url}}{{source_url}}{{/competition_url}}">

--- a/decksite/view.py
+++ b/decksite/view.py
@@ -15,7 +15,7 @@ from magic import card_price, legality, seasons, tournaments
 from magic.models import Deck
 from shared import dtutil, logger, text
 from shared.container import Container
-from shared_web import template
+from shared_web import friendly_time, template
 from shared_web.base_view import BaseView
 
 
@@ -240,8 +240,10 @@ class View(BaseView):
     def prepare_competitions(self) -> None:
         for c in getattr(self, 'competitions', []):
             c.competition_url = f'/competitions/{c.id}/'
-            c.display_date = dtutil.display_date(c.start_date)
-            c.competition_ends = '' if c.end_date < dtutil.now() else dtutil.display_date(c.end_date)
+            c.friendly_date = friendly_time.friendly_date(c.start_date)
+            c.display_date = c.friendly_date.display  # API compatibility.
+            c.competition_ends_friendly = None if c.end_date < dtutil.now() else friendly_time.friendly_date(c.end_date)
+            c.competition_ends = '' if c.competition_ends_friendly is None else c.competition_ends_friendly.display  # API compatibility.
             c.date_sort = dtutil.dt2ts(c.start_date)
             c.league = c.type == 'League'
 

--- a/decksite/views/competition.py
+++ b/decksite/views/competition.py
@@ -8,6 +8,7 @@ from decksite.view import View
 from magic import seasons, tournaments
 from magic.models import Competition as Comp
 from shared import dtutil
+from shared_web import friendly_time
 
 
 def _exact_date(date: datetime.datetime) -> str:
@@ -30,7 +31,8 @@ class Competition(View):
             self.hide_top8 = True
             self.has_leaderboard = True
             self.competition_dates = f'{self.competition_dates} – {_exact_date(competition.end_date)}'
-        self.date = dtutil.display_date(competition.start_date)
+        self.friendly_date = friendly_time.friendly_date(competition.start_date)
+        self.date = self.friendly_date.display
         if competition.season_id:
             self.competition_season_name = seasons.season_name(competition.season_id)
             self.competition_season_url = url_for('seasons.competitions', season_id=competition.season_id)

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -7,6 +7,7 @@ from magic import rotation, seasons, tournaments
 from magic.models import Card, Deck
 from shared import dtutil
 from shared.container import Container
+from shared_web import friendly_time
 
 
 class Home(View):
@@ -66,12 +67,14 @@ class Home(View):
                 },
             )
         if tournament_decks:
+            subtitle_friendly_date = friendly_time.friendly_date(tournament_decks[0].active_date)
             self.deck_tables.append(
                 {
                     'hide_source': True,
                     'hide_date': True,
                     'title': gettext('Latest Tournament Top 8'),
-                    'subtitle': dtutil.display_date(tournament_decks[0].active_date),
+                    'subtitle': subtitle_friendly_date.display,
+                    'subtitle_friendly_date': subtitle_friendly_date,
                     'url': url_for('competition', competition_id=tournament_id),
                     'link_text': gettext('View Tournament…'),
                     'decks': tournament_decks,
@@ -110,8 +113,10 @@ class Home(View):
         self.movers_and_shakers_window = gettext('Last %(days)d days', days=WINDOW_DAYS)
 
     def setup_rotation(self) -> None:
-        self.season_start_display = dtutil.display_date(seasons.last_rotation())
-        self.season_end_display = dtutil.display_date(seasons.next_rotation())
+        self.season_start_friendly = friendly_time.friendly_date(seasons.last_rotation())
+        self.season_end_friendly = friendly_time.friendly_date(seasons.next_rotation())
+        self.season_start_display = self.season_start_friendly.display
+        self.season_end_display = self.season_end_friendly.display
         self.scryfall_url = 'https://scryfall.com/search?q=f%3Apd'
         self.legal_cards_url = 'http://pdmtgo.com/legal_cards.txt'
         self.in_rotation = rotation.in_rotation()

--- a/decksite/views/player_notes.py
+++ b/decksite/views/player_notes.py
@@ -6,6 +6,7 @@ from decksite.data.person import Person
 from decksite.view import View
 from shared import dtutil
 from shared.container import Container
+from shared_web import friendly_time
 
 
 class PlayerNotes(View):
@@ -13,7 +14,8 @@ class PlayerNotes(View):
         super().__init__()
         for n in notes:
             n.date_sort = dtutil.dt2ts(n.created_date)
-            n.display_date = dtutil.display_date(n.created_date)
+            n.friendly_date = friendly_time.friendly_date(n.created_date)
+            n.display_date = n.friendly_date.display  # API compatibility.
             n.subject_url = url_for('person', person_id=n.subject_id)
             n.creator_url = url_for('person', person_id=n.creator_id)
         self.notes = notes

--- a/decksite/views/rotation.py
+++ b/decksite/views/rotation.py
@@ -1,6 +1,6 @@
 from decksite.view import View
 from magic import rotation, seasons
-from shared import dtutil
+from shared_web import friendly_time
 
 
 class Rotation(View):
@@ -11,9 +11,9 @@ class Rotation(View):
         self.total_runs = rotation.TOTAL_RUNS
         self.num_cards = num_cards
         self.has_cards = runs > 0
-        prefix = 'Rotation is in progress, ends ' if in_rotation else 'Rotation is '
-        display_date = dtutil.display_date(seasons.next_rotation(), 2)
-        self.rotation_msg = prefix + display_date
+        self.rotation_prefix = 'Rotation is in progress, ends ' if in_rotation else 'Rotation is '
+        self.rotation_friendly_date = friendly_time.friendly_date(seasons.next_rotation(), 2)
+        self.rotation_msg = self.rotation_prefix + self.rotation_friendly_date.display
         self.note = 'Data from the last rotation is shown' if runs and not in_rotation else ''
 
     def page_title(self) -> str:

--- a/decksite/views/seasons.py
+++ b/decksite/views/seasons.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 from decksite.view import View
 from magic import oracle
-from shared import dtutil
+from shared_web import friendly_time
 
 
 class Seasons(View):
@@ -33,11 +33,14 @@ class Seasons(View):
             for k, v in season.items():
                 if isinstance(v, int):
                     season[k] = f'{v:,}'  # Human-friendly number formatting like "29,000".
-            season['start_date_display'] = dtutil.display_date(season['start_date'])
+            season['start_date_friendly'] = friendly_time.friendly_date(season['start_date'])
+            season['start_date_display'] = season['start_date_friendly'].display
             season['length_in_days'] = season['length_in_days'] + ' day' + pluralize
             if season.get('end_date'):
-                season['end_date_display'] = dtutil.display_date(season['end_date'])
+                season['end_date_friendly'] = friendly_time.friendly_date(season['end_date'])
+                season['end_date_display'] = season['end_date_friendly'].display
             else:
+                season['end_date_friendly'] = None
                 season['end_date_display'] = 'Now'
                 season['length_in_days'] += ' so far'
             self.seasons.append(season)

--- a/decksite/views/sorters.py
+++ b/decksite/views/sorters.py
@@ -3,13 +3,15 @@ from collections.abc import Iterable
 from decksite.data.person import Person
 from decksite.view import View
 from shared import dtutil
+from shared_web import friendly_time
 
 
 class Sorters(View):
     def __init__(self, sorters: Iterable[Person]) -> None:
         super().__init__()
         for sorter in sorters:
-            sorter.display_last_sorted = dtutil.display_date(sorter.last_sorted)
+            sorter.last_sorted_friendly = friendly_time.friendly_date(sorter.last_sorted)
+            sorter.display_last_sorted = sorter.last_sorted_friendly.display
             sorter.date_sort = dtutil.dt2ts(sorter.last_sorted)
         self.people = sorters
 

--- a/logsite/data/match.py
+++ b/logsite/data/match.py
@@ -8,7 +8,9 @@ import sqlalchemy as sa
 from flask import url_for
 
 from shared import dtutil
+from shared.container import Container
 from shared.pd_exception import DoesNotExistException
+from shared_web import friendly_time
 
 from .. import db
 from ..db import DB as fsa
@@ -63,11 +65,11 @@ class Match(fsa.Model):
             return None
         return pytz.utc.localize(self.end_time)
 
-    def display_date(self) -> str:
+    def friendly_date(self) -> Container | None:
         start = self.start_time_aware()
         if start is None:
-            return ''
-        return dtutil.display_date(start)
+            return None
+        return friendly_time.friendly_date(start)
 
     def to_dict(self) -> dict:
         return {

--- a/logsite/templates/match.mustache
+++ b/logsite/templates/match.mustache
@@ -6,7 +6,7 @@
         <div class="title">
             <h1>{{{players_string_safe}}} ({{id}})</h1>
             <div class="subtitle">{{format_name}}: "{{comment}}"</div>
-            <div class="subtitle">{{display_date}}</div>
+            <div class="subtitle">{{#friendly_date}}{{> friendlytime}}{{/friendly_date}}</div>
         </div>
             <ul class="buttons">
                 <li class="button"><a title="" href="/export/{{id}}">Download</a></li>

--- a/logsite/templates/matchrow.mustache
+++ b/logsite/templates/matchrow.mustache
@@ -16,6 +16,6 @@
         <td>{{comment}}</td>
     {{/hide_comment}}
     <td data-text="{{date_sort}}">
-        {{display_date}}
+        {{#friendly_date}}{{> friendlytime}}{{/friendly_date}}
     </td>
 </tr>

--- a/logsite/views/match_view.py
+++ b/logsite/views/match_view.py
@@ -26,6 +26,7 @@ class Match(View):
         self.id = viewed_match.id
         self.comment = viewed_match.comment
         self.format_name = viewed_match.format_name()
+        self.friendly_date = viewed_match.friendly_date()
         self.players_string = ' vs '.join([p.name for p in viewed_match.players])
         self.players_string_safe = ' vs '.join([player_link(p.name) for p in viewed_match.players])
         self.module_string = ', '.join([m.name for m in viewed_match.modules])

--- a/shared_web/friendly_time.py
+++ b/shared_web/friendly_time.py
@@ -1,0 +1,12 @@
+import datetime
+
+from shared import dtutil
+from shared.container import Container
+
+
+def friendly_date(dt: datetime.datetime, granularity: int = 1) -> Container:
+    """Return the visible relative date and its exact machine-readable value for web views."""
+    return Container({
+        'datetime': dt.isoformat(),
+        'display': dtutil.display_date(dt, granularity),
+    })

--- a/shared_web/friendly_time_test.py
+++ b/shared_web/friendly_time_test.py
@@ -1,0 +1,47 @@
+import datetime
+import re
+from pathlib import Path
+
+import pytest
+
+from decksite.main import APP
+from shared import dtutil
+from shared_web import friendly_time, template
+
+
+def test_friendly_date_keeps_relative_text_and_exact_datetime(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime.datetime(2026, 9, 6, 12, tzinfo=datetime.UTC)
+    then = now - datetime.timedelta(days=3, hours=2)
+    monkeypatch.setattr(dtutil, 'now', lambda tz=None: now if tz is None else now.astimezone(tz))
+
+    date = friendly_time.friendly_date(then)
+
+    assert date.display == '3 days ago'
+    assert date.datetime == '2026-09-03T10:00:00+00:00'
+
+
+def test_friendly_time_partial_uses_semantic_time_markup() -> None:
+    with APP.test_request_context('/'):
+        html = template.render_name('friendlytime', {'display': '3 days ago', 'datetime': '2026-09-03T10:00:00+00:00'})
+
+    assert html.strip() == '<time datetime="2026-09-03T10:00:00+00:00">3 days ago</time>'
+
+
+def test_web_dates_use_shared_friendly_time_rendering() -> None:
+    direct_calls = []
+    for root in ('decksite', 'logsite'):
+        for path in Path(root).rglob('*.py'):
+            if path.name.endswith('_test.py') or path == Path('decksite/league.py'):
+                continue
+            for line_number, line in enumerate(path.read_text(encoding='utf-8').splitlines(), 1):
+                if 'dtutil.display_date(' in line:
+                    direct_calls.append(f'{path}:{line_number}')
+    assert direct_calls == [], f'Web dates must use shared_web.friendly_time, not dtutil.display_date directly: {direct_calls}'
+
+    legacy_fields = re.compile(r'{{{?\s*(display_date|display_last_sorted|season_(start|end)_display|start_date_display|end_date_display)\b')
+    raw_template_fields = []
+    for root in ('decksite/templates', 'logsite/templates'):
+        for path in Path(root).glob('*.mustache'):
+            if legacy_fields.search(path.read_text(encoding='utf-8')):
+                raw_template_fields.append(str(path))
+    assert raw_template_fields == [], f'Web dates must use the friendlytime partial: {raw_template_fields}'

--- a/shared_web/static/js/decktable.jsx
+++ b/shared_web/static/js/decktable.jsx
@@ -1,4 +1,4 @@
-import { Table, renderRecord } from "./table";
+import { Table, renderFriendlyDate, renderRecord } from "./table";
 import React from "react";
 import { createRoot } from "react-dom/client";
 
@@ -78,7 +78,7 @@ const renderRow = (table, deck) => (
             </td>
         }
         <td className="date">
-            {deck.displayDate}
+            {renderFriendlyDate(deck.displayDate, deck.activeDate)}
         </td>
         { table.props.showSeasonIcon
             ? <td dangerouslySetInnerHTML={{__html: deck.seasonIcon}}></td>

--- a/shared_web/static/js/decktable.jsx
+++ b/shared_web/static/js/decktable.jsx
@@ -1,4 +1,5 @@
-import { Table, renderFriendlyDate, renderRecord } from "./table";
+import { Table, renderRecord } from "./table";
+import { FriendlyTime } from "./friendlytime";
 import React from "react";
 import { createRoot } from "react-dom/client";
 
@@ -78,7 +79,7 @@ const renderRow = (table, deck) => (
             </td>
         }
         <td className="date">
-            {renderFriendlyDate(deck.displayDate, deck.activeDate)}
+            <FriendlyTime date={deck.friendlyDate}/>
         </td>
         { table.props.showSeasonIcon
             ? <td dangerouslySetInnerHTML={{__html: deck.seasonIcon}}></td>

--- a/shared_web/static/js/friendlytime.jsx
+++ b/shared_web/static/js/friendlytime.jsx
@@ -1,0 +1,18 @@
+/*global PD*/
+import PropTypes from "prop-types";
+import React from "react";
+
+
+export const FriendlyTime = ({date}) => {
+    if (!date || !date.datetime) {
+        return date?.display ?? "";
+    }
+    return <time dateTime={date.datetime} title={PD.formatExactTimestamp(date.datetime)}>{date.display}</time>;
+};
+
+FriendlyTime.propTypes = {
+    "date": PropTypes.shape({
+        "datetime": PropTypes.string.isRequired,
+        "display": PropTypes.string.isRequired,
+    }),
+};

--- a/shared_web/static/js/friendlytime.jsx
+++ b/shared_web/static/js/friendlytime.jsx
@@ -13,6 +13,6 @@ export const FriendlyTime = ({date}) => {
 FriendlyTime.propTypes = {
     "date": PropTypes.shape({
         "datetime": PropTypes.string.isRequired,
-        "display": PropTypes.string.isRequired,
-    }),
+        "display": PropTypes.string.isRequired
+    })
 };

--- a/shared_web/static/js/matchtable.jsx
+++ b/shared_web/static/js/matchtable.jsx
@@ -1,5 +1,5 @@
+import { Table, renderFriendlyDate } from "./table";
 import React from "react";
-import { Table } from "./table";
 import { createRoot } from "react-dom/client";
 
 const renderHeaderRow = (table) => (
@@ -27,7 +27,7 @@ const renderRow = (table, entry) => (
                 : "Manually Reported"
             }
         </td>
-        <td className="date">{entry.displayDate}</td>
+        <td className="date">{renderFriendlyDate(entry.displayDate, entry.date)}</td>
         <td>
             <form method="post" className="inline">
                 <input type="hidden" name="match_id" defaultValue={entry.id}/>

--- a/shared_web/static/js/matchtable.jsx
+++ b/shared_web/static/js/matchtable.jsx
@@ -1,5 +1,6 @@
-import { Table, renderFriendlyDate } from "./table";
+import { FriendlyTime } from "./friendlytime";
 import React from "react";
+import { Table } from "./table";
 import { createRoot } from "react-dom/client";
 
 const renderHeaderRow = (table) => (
@@ -27,7 +28,7 @@ const renderRow = (table, entry) => (
                 : "Manually Reported"
             }
         </td>
-        <td className="date">{renderFriendlyDate(entry.displayDate, entry.date)}</td>
+        <td className="date"><FriendlyTime date={entry.friendlyDate}/></td>
         <td>
             <form method="post" className="inline">
                 <input type="hidden" name="match_id" defaultValue={entry.id}/>

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -412,9 +412,9 @@ PD.initLinks = function() {
 };
 
 PD.localizeTimeElements = function() {
-    $("time").each(function() {
+    $("time, [data-friendly-datetime]").each(function() {
         var elem = $(this),
-            datetime = elem.attr("datetime"),
+            datetime = elem.attr("datetime") || elem.data("friendly-datetime"),
             t = moment(datetime),
             format = elem.data("format"),
             tz = moment.tz.guess(),
@@ -528,10 +528,11 @@ PD.initPersonNotes = function() {
             if (data.notes.length > 0) {
                 let s = "<article>";
                 for (i = 0; i < data.notes.length; i++) {
-                    s += '<p><span class="subtitle">' + data.notes[i].display_date + "</span> " + data.notes[i].note + "</p>";
+                    s += '<p><span class="subtitle"><time datetime="' + PD.htmlEscape(data.notes[i].friendly_date.datetime) + '">' + PD.htmlEscape(data.notes[i].friendly_date.display) + "</time></span> " + data.notes[i].note + "</p>";
                 }
                 s += "</article>";
                 $(".person-notes").html(s);
+                PD.localizeTimeElements();
             } else {
                 $(".person-notes").html("<p>None</p>");
             }

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -431,7 +431,7 @@ PD.localizeTimeElements = function() {
 PD.formatExactTimestamp = function(datetime) {
     return new Intl.DateTimeFormat(navigator.language, {
         dateStyle: "full",
-        timeStyle: "long"
+        timeStyle: "full"
     }).format(new Date(datetime));
 };
 

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -429,7 +429,10 @@ PD.localizeTimeElements = function() {
 };
 
 PD.formatExactTimestamp = function(datetime) {
-    return moment(datetime).tz(moment.tz.guess()).format("YYYY-MM-DD HH:mm:ss z");
+    return new Intl.DateTimeFormat(navigator.language, {
+        dateStyle: "full",
+        timeStyle: "long"
+    }).format(new Date(datetime));
 };
 
 PD.hideRepetitionInCalendar = function() {

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -413,12 +413,23 @@ PD.initLinks = function() {
 
 PD.localizeTimeElements = function() {
     $("time").each(function() {
-        var t = moment($(this).attr("datetime")),
-            format = $(this).data("format"),
+        var elem = $(this),
+            datetime = elem.attr("datetime"),
+            t = moment(datetime),
+            format = elem.data("format"),
             tz = moment.tz.guess(),
+            s;
+        elem.attr("title", PD.formatExactTimestamp(datetime));
+        if (format) {
             s = t.tz(tz).format(format);
-        $(this).html(s).show();
+            elem.html(s);
+        }
+        elem.show();
     });
+};
+
+PD.formatExactTimestamp = function(datetime) {
+    return moment(datetime).tz(moment.tz.guess()).format("YYYY-MM-DD HH:mm:ss z");
 };
 
 PD.hideRepetitionInCalendar = function() {

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -1,3 +1,4 @@
+/*global PD*/
 import { DataManager } from "./datamanager";
 import { Pagination } from "./pagination";
 import PropTypes from "prop-types";
@@ -92,6 +93,14 @@ export const renderWinPercent = (object) => {
         return object.winPercent.toLocaleString([], {minimumFractionDigits: 1, maximumFractionDigits: 1});
     }
     return "";
+};
+
+export const renderFriendlyDate = (displayDate, timestamp) => {
+    if (!Number.isFinite(timestamp)) {
+        return displayDate;
+    }
+    const isoDate = new Date(timestamp * 1000).toISOString();
+    return <time dateTime={isoDate} title={PD.formatExactTimestamp(isoDate)}>{displayDate}</time>;
 };
 
 export const renderCard = (card) => (

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -1,4 +1,3 @@
-/*global PD*/
 import { DataManager } from "./datamanager";
 import { Pagination } from "./pagination";
 import PropTypes from "prop-types";
@@ -93,14 +92,6 @@ export const renderWinPercent = (object) => {
         return object.winPercent.toLocaleString([], {minimumFractionDigits: 1, maximumFractionDigits: 1});
     }
     return "";
-};
-
-export const renderFriendlyDate = (displayDate, timestamp) => {
-    if (!Number.isFinite(timestamp)) {
-        return displayDate;
-    }
-    const isoDate = new Date(timestamp * 1000).toISOString();
-    return <time dateTime={isoDate} title={PD.formatExactTimestamp(isoDate)}>{displayDate}</time>;
 };
 
 export const renderCard = (card) => (

--- a/shared_web/templates/friendlytime.mustache
+++ b/shared_web/templates/friendlytime.mustache
@@ -1,0 +1,1 @@
+<time datetime="{{datetime}}">{{display}}</time>


### PR DESCRIPTION
Fixes #7063.

## Summary
- centralize web-facing friendly timestamp data and rendering
- show browser-localized exact timestamps with full timezone names on hover
- migrate existing decksite and logsite friendly dates to the shared path
- add browser and architecture regression coverage plus agent guidance

## Validation
- `uv run python dev.py lint`
- `uv run python dev.py mypy`
- `uv run python dev.py jslint`
- `npm run build`
- `uv run python -m pytest shared_web/friendly_time_test.py decksite/prepare_test.py decksite/views/home_test.py decksite/views/seasons_test.py decksite/view_test.py decksite/main_test.py -q`
- `PD_BROWSER_BASE_URL=http://127.0.0.1:5000 PD_BROWSER_CHANNEL=chrome uv run python -m pytest decksite/browser_test.py::test_pages_render_with_data_and_without_errors decksite/browser_test.py::test_friendly_deck_dates_have_exact_timestamp_titles -q`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e49cc232-89db-46cf-88ac-b191e0ab85de)
