### PR TITLE
Lock decksite migrations across workers

### DIFF
--- a/decksite/database.py
+++ b/decksite/database.py
@@ -8,6 +8,8 @@ from shared.container import Container
 from shared.database import Database, get_database
 
 TEST_CONTEXT = Container()
+MIGRATION_LOCK = 'penny-dreadful-tools:decksite:migrations'
+MIGRATION_LOCK_TIMEOUT_SECONDS = 10 * 60
 
 def db() -> Database:
     ctx: Any = TEST_CONTEXT  # Fallback context for testing.
@@ -26,22 +28,27 @@ def setup_in_app_context() -> None:
         setup()
 
 def setup() -> None:
-    db().execute('CREATE TABLE IF NOT EXISTS db_version (version INTEGER UNIQUE NOT NULL)')
-    version = db_version()
-    patches = os.listdir('decksite/sql')
-    patches.sort(key=lambda n: int(n.split('.')[0]))
-    for fn in patches:
-        path = os.path.join('decksite/sql', fn)
-        n = int(fn.split('.')[0])
-        if version < n:
-            logger.warning(f'Patching database to v{n}')
-            fh = open(path)
-            sql = fh.read()
-            for stmt in sql.split(';'):
-                if stmt.strip() != '':
-                    db().execute(stmt)
-            fh.close()
-            db().execute(f'INSERT INTO db_version (version) VALUES ({n})')
+    migration_db = db()
+    migration_db.get_lock(MIGRATION_LOCK, MIGRATION_LOCK_TIMEOUT_SECONDS)
+    try:
+        migration_db.execute('CREATE TABLE IF NOT EXISTS db_version (version INTEGER UNIQUE NOT NULL)')
+        version = migration_db.value('SELECT version FROM db_version ORDER BY version DESC LIMIT 1', [], 0)
+        patches = os.listdir('decksite/sql')
+        patches.sort(key=lambda n: int(n.split('.')[0]))
+        for fn in patches:
+            path = os.path.join('decksite/sql', fn)
+            n = int(fn.split('.')[0])
+            if version < n:
+                logger.warning(f'Patching database to v{n}')
+                fh = open(path)
+                sql = fh.read()
+                for stmt in sql.split(';'):
+                    if stmt.strip() != '':
+                        migration_db.execute(stmt)
+                fh.close()
+                migration_db.execute(f'INSERT INTO db_version (version) VALUES ({n})')
+    finally:
+        migration_db.release_lock(MIGRATION_LOCK)
 
 def db_version() -> int:
     return db().value('SELECT version FROM db_version ORDER BY version DESC LIMIT 1', [], 0)

--- a/decksite/database_test.py
+++ b/decksite/database_test.py
@@ -1,0 +1,71 @@
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from decksite import database
+
+
+def test_setup_serializes_migrations_and_rechecks_the_version(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class ConcurrentDatabase:
+        def __init__(self) -> None:
+            self.version = 0
+            self.lock = threading.Lock()
+            self.migration_started = threading.Event()
+            self.finish_migration = threading.Event()
+            self.second_checked_version = threading.Event()
+            self.migration_calls: list[str] = []
+
+        def get_lock(self, lock_id: str, timeout: int) -> None:
+            assert lock_id == database.MIGRATION_LOCK
+            assert timeout == database.MIGRATION_LOCK_TIMEOUT_SECONDS
+            assert self.lock.acquire(timeout=timeout)
+
+        def release_lock(self, lock_id: str) -> None:
+            assert lock_id == database.MIGRATION_LOCK
+            self.lock.release()
+
+        def execute(self, sql: str, args: list[Any] | None = None) -> int:
+            if sql == 'APPLY PATCH':
+                self.migration_calls.append(threading.current_thread().name)
+                self.migration_started.set()
+                assert self.finish_migration.wait(timeout=5)
+            elif sql.startswith('INSERT INTO db_version'):
+                self.version = 1
+            return 0
+
+        def value(self, sql: str, args: list[Any], default: int) -> int:
+            if threading.current_thread().name == 'second':
+                self.second_checked_version.set()
+            return self.version
+
+    sql_dir = tmp_path / 'decksite' / 'sql'
+    sql_dir.mkdir(parents=True)
+    (sql_dir / '1.sql').write_text('APPLY PATCH;', encoding='utf-8')
+    monkeypatch.chdir(tmp_path)
+    fake_db = ConcurrentDatabase()
+    monkeypatch.setattr(database, 'db', lambda: fake_db)
+    errors: list[BaseException] = []
+
+    def run_setup() -> None:
+        try:
+            database.setup()
+        except BaseException as error:
+            errors.append(error)
+
+    first = threading.Thread(target=run_setup, name='first')
+    second = threading.Thread(target=run_setup, name='second')
+    first.start()
+    assert fake_db.migration_started.wait(timeout=5)
+    second.start()
+    second_checked_version_while_patch_was_running = fake_db.second_checked_version.wait(timeout=0.25)
+    fake_db.finish_migration.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert errors == []
+    assert not second_checked_version_while_patch_was_running
+    assert fake_db.migration_calls == ['first']


### PR DESCRIPTION
## Summary

- serialize decksite migrations across web workers with the existing MariaDB named-lock primitive
- make waiting workers re-read `db_version` after acquiring the lock, so each patch runs once and workers cannot continue startup against a migration still in progress
- release the lock on both success and failure, with a bounded 10-minute startup wait

Closes #6478.

## Why

The migration runner read the current schema version and applied every later SQL file without synchronization. Two workers starting together could therefore choose the same migration. The linked production report for #6478 shows both workers attempting the locale `ALTER TABLE`, with one failing on a duplicate column.

The existing `interprocess_locked()` helper uses the same underlying MariaDB lock for cards and maintenance work, but deliberately skips duplicate background jobs. Migrations instead need to wait and then re-check the schema; skipping would allow new code to start against the old schema.

## Validation

- fail-before: `uv run --frozen pytest decksite/database_test.py -q` ran the simulated migration twice and failed the new serialization assertion
- pass-after: `uv run --frozen pytest decksite/database_test.py -q` — 1 passed
- `uv run --frozen pytest decksite/database_test.py shared/database_test.py shared/decorators_test.py -q` — 14 passed
- `uv run --frozen ruff check decksite/database.py decksite/database_test.py`
- `uv run --frozen mypy decksite/database.py decksite/database_test.py`
- isolated real-MariaDB deployment probe: two independent Python processes ran the actual `decksite.database.setup()` path against a deliberately slow, non-idempotent migration; both exited 0, only one logged the patch, the schema object existed once, and `db_version` contained one row

## Post-deploy checks

- all decksite workers start and remain healthy
- `SELECT MAX(version), COUNT(*) FROM db_version` is unchanged by this code-only deploy
- `SELECT IS_FREE_LOCK('penny-dreadful-tools:decksite:migrations')` returns 1 after startup
- logs contain no lock timeout, `DatabaseException`, duplicate-schema error, or worker restart loop
- on the next genuine migration, exactly one worker logs `Patching database to vN` and exactly one version-N row is recorded

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b4dfbb98-9c19-4118-9beb-0f37ec2fd2d7)
