### PR TITLE
Handle decksite outages in resources command

### DIFF
--- a/discordbot/commands/network_io_test.py
+++ b/discordbot/commands/network_io_test.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 from contextlib import nullcontext
 from types import SimpleNamespace
@@ -87,6 +88,20 @@ async def test_resources_moves_sitemap_fetch_off_event_loop(monkeypatch: pytest.
     await resources.Resources.resources.callback(SimpleNamespace(), ctx, 'cards bolt')
 
     to_thread.assert_awaited_once_with(resources.site_resources, 'cards bolt')
+
+
+@pytest.mark.asyncio
+async def test_resources_reports_decksite_outage_to_user(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    ctx = SimpleNamespace(author=SimpleNamespace(mention='<@123>'), send=AsyncMock())
+    failure = resources.fetch_tools.FetchException('Server returned a 500')
+    monkeypatch.setattr(resources.asyncio, 'to_thread', AsyncMock(side_effect=failure))
+    monkeypatch.setattr(resources, 'resources_resources', Mock(return_value={}))
+
+    with caplog.at_level(logging.ERROR):
+        await resources.Resources.resources.callback(SimpleNamespace(), ctx, 'cards bolt')
+
+    ctx.send.assert_awaited_once_with('The Penny Dreadful website is currently unavailable. Please try again later.')
+    assert 'Could not retrieve the Penny Dreadful website sitemap' in caplog.text
 
 
 @pytest.mark.asyncio

--- a/discordbot/commands/resources.py
+++ b/discordbot/commands/resources.py
@@ -4,6 +4,7 @@ import re
 from interactions import Client, Extension
 from interactions.models.internal import OptionType, auto_defer, slash_command, slash_option
 
+from discordbot import error_handling
 from discordbot.command import MtgInteractionContext, roughly_matches
 from magic import fetcher
 from shared import fetch_tools
@@ -20,7 +21,12 @@ class Resources(Extension):
             resource = ''
         if len(resource) > 0:
             results.update(resources_resources(resource))
-            results.update(await asyncio.to_thread(site_resources, resource))
+            try:
+                results.update(await asyncio.to_thread(site_resources, resource))
+            except fetch_tools.FetchException as e:
+                error_handling.log_exception(e, 'Could not retrieve the Penny Dreadful website sitemap')
+                await ctx.send('The Penny Dreadful website is currently unavailable. Please try again later.')
+                return
         s = ''
         if len(results) == 0:
             s = "Sorry, I don't know about that.\nPD resources: <{url}>".format(url=fetcher.decksite_url('/resources/'))


### PR DESCRIPTION
Fixes #6315.

Catch decksite sitemap failures in the Discord resources command, retain structured error logging, and send users a clear outage message.

Tests:
- `uv run --frozen pytest discordbot/commands/network_io_test.py -q`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/c4663e69-96e5-44b0-85a8-f08812340c04)
