### PR TITLE
Enforce auth decorator ordering

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -664,8 +664,8 @@ def card_api(card: str) -> Response:
 
 @APP.route('/api/archetype/reassign', methods=['POST'])
 @APP.route('/api/archetype/reassign/', methods=['POST'])
-@auth.demimod_required
 @fill_form('deck_id', 'archetype_id')
+@auth.demimod_required
 def post_reassign(deck_id: int, archetype_id: int) -> Response:
     archs.assign(deck_id, archetype_id, auth.person_id())
     return return_json({'success': True, 'deck_id': deck_id})

--- a/dev.py
+++ b/dev.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import ast
 import json
 import os
 import shutil
@@ -27,6 +28,7 @@ if ON_PROD:
     sys.exit(1)
 
 ON_WINDOWS = sys.platform == 'win32'
+AUTH_DECORATORS = {'admin_required', 'demimod_required'}
 
 
 @click.group()
@@ -60,6 +62,24 @@ def do_lint() -> None:
         python['-m', 'ruff', 'check', '.'] & FG
     except ProcessExecutionError as e:
         sys.exit(e.retcode)
+    errors = auth_decorator_order_errors(find_files(file_extension='py'))
+    if errors:
+        print('\n'.join(errors))
+        sys.exit(1)
+
+def auth_decorator_order_errors(paths: Iterable[str]) -> list[str]:
+    """Require permission checks to be applied before any route or helper wrapper."""
+    errors = []
+    for path in paths:
+        with open(path, encoding='utf-8') as f:
+            tree = ast.parse(f.read(), filename=path)
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for decorator in node.decorator_list[:-1]:
+                if isinstance(decorator, ast.Attribute) and isinstance(decorator.value, ast.Name) and decorator.value.id == 'auth' and decorator.attr in AUTH_DECORATORS:
+                    errors.append(f'{path}:{decorator.lineno}: PDA001 auth.{decorator.attr} must be the innermost decorator')
+    return errors
 
 @cli.command()
 def lint() -> None:

--- a/dev_test.py
+++ b/dev_test.py
@@ -1,5 +1,33 @@
+from pathlib import Path
+
 import dev
 
 
 def test_find_files() -> None:
     assert dev.find_files('dtutil', 'py') == ['shared/dtutil.py', 'shared/dtutil_test.py']
+
+
+def test_auth_decorators_must_be_innermost(tmp_path: Path) -> None:
+    path = tmp_path / 'controllers.py'
+    path.write_text("""\
+@APP.route('/good-admin')
+@auth.admin_required
+def good_admin():
+    pass
+
+@auth.admin_required
+@APP.route('/bad-admin')
+def bad_admin():
+    pass
+
+@APP.route('/bad-demimod')
+@auth.demimod_required
+@fill_form('deck_id')
+def bad_demimod():
+    pass
+""", encoding='utf-8')
+
+    assert dev.auth_decorator_order_errors([str(path)]) == [
+        f'{path}:6: PDA001 auth.admin_required must be the innermost decorator',
+        f'{path}:12: PDA001 auth.demimod_required must be the innermost decorator',
+    ]


### PR DESCRIPTION
## Summary
- add a Python AST lint check requiring admin and demimod permission decorators to be innermost
- correct the existing decorator-order violation on the archetype reassignment endpoint
- add focused regression coverage for accepted and rejected ordering

Fixes #7036

## Validation
- uv run --frozen pytest -q dev_test.py decksite/controllers/api_test.py -m 'not functional'
- uv run --frozen python dev.py lint
- uv run --frozen python dev.py mypy

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/4d1f1401-d132-4355-9962-2c7169bcba2f)
