### PR TITLE
Add show chat explanation

### DIFF
--- a/discordbot/commands/explain.py
+++ b/discordbot/commands/explain.py
@@ -173,6 +173,10 @@ explanations: dict[str, tuple[str, dict[str, str]]] = {
             'Tournament Rules': fetcher.decksite_url('/tournaments/'),
         },
     ),
+    'showchat': (
+        'If game chat is hidden on Magic Online, click the chat icon in the bottom-left corner of the game window, then select `Show Chat`.',
+        {},
+    ),
     'spectating': (
         """
         Spectating tournament and league matches is allowed and encouraged.

--- a/discordbot/commands/explain_test.py
+++ b/discordbot/commands/explain_test.py
@@ -1,0 +1,17 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from discordbot.commands.explain import ExplainCog
+
+
+@pytest.mark.asyncio
+async def test_explain_showchat() -> None:
+    ctx = Mock()
+    ctx.send = AsyncMock()
+
+    await ExplainCog.explain.callback(None, ctx, 'showchat')
+
+    ctx.send.assert_awaited_once_with(
+        'If game chat is hidden on Magic Online, click the chat icon in the bottom-left corner of the game window, then select `Show Chat`.',
+    )


### PR DESCRIPTION
Closes #5876

Adds a `showchat` topic to `/explain` with instructions for revealing hidden Magic Online game chat. Includes a targeted behavioral regression test.

Validation:
- `uv run pytest discordbot/commands/explain_test.py discordbot/command_test.py -q`
- `uv run ruff check discordbot/commands/explain.py discordbot/commands/explain_test.py`
- `uv run mypy discordbot/commands/explain.py discordbot/commands/explain_test.py`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/a3a1b051-a376-46a4-a7a3-000c48546c62)
