### PR TITLE
Show unique player counts in community stats (#1558)

### DIFF
--- a/decksite/data/match.py
+++ b/decksite/data/match.py
@@ -127,7 +127,8 @@ def setup_matches(show_active_deck_names: bool, matches: Sequence[Container]) ->
             m.opponent_deck_name = '(Active League Run)'
 
 def stats() -> dict[str, int]:
-    sql = """
+    season_start = dtutil.dt2ts(seasons.last_rotation())
+    matches_sql = """
         SELECT
             SUM(CASE WHEN FROM_UNIXTIME(`date`) >= NOW() - INTERVAL 1 DAY THEN 1 ELSE 0 END) AS num_matches_today,
             SUM(CASE WHEN FROM_UNIXTIME(`date`) >= NOW() - INTERVAL 7 DAY THEN 1 ELSE 0 END) AS num_matches_this_week,
@@ -137,7 +138,40 @@ def stats() -> dict[str, int]:
         FROM
             `match`
     """
-    return db().select(sql, [dtutil.dt2ts(seasons.last_rotation())])[0]
+    result = db().select(matches_sql, [season_start])[0]
+    players_sql = """
+        SELECT
+            COUNT(DISTINCT CASE WHEN m.`date` >= UNIX_TIMESTAMP(NOW() - INTERVAL 7 DAY) THEN d.person_id END) AS num_players_this_week,
+            COUNT(DISTINCT CASE WHEN m.`date` >= UNIX_TIMESTAMP(NOW() - INTERVAL 30 DAY) THEN d.person_id END) AS num_players_this_month,
+            COUNT(DISTINCT CASE WHEN m.`date` >= %s THEN d.person_id END) AS num_players_this_season,
+            (
+                SELECT
+                    COUNT(*)
+                FROM
+                    person AS all_time_person
+                WHERE
+                    EXISTS (
+                        SELECT
+                            1
+                        FROM
+                            deck AS all_time_deck
+                        INNER JOIN
+                            deck_match AS all_time_deck_match ON all_time_deck_match.deck_id = all_time_deck.id
+                        WHERE
+                            all_time_deck.person_id = all_time_person.id
+                    )
+            ) AS num_players_all_time
+        FROM
+            `match` AS m
+        INNER JOIN
+            deck_match AS dm ON dm.match_id = m.id
+        INNER JOIN
+            deck AS d ON d.id = dm.deck_id
+        WHERE
+            m.`date` >= LEAST(UNIX_TIMESTAMP(NOW() - INTERVAL 30 DAY), %s)
+    """
+    result.update(db().select(players_sql, [season_start, season_start])[0])
+    return result
 
 def update_match(match_id: int, left_id: int, left_games: int, right_id: int, right_games: int) -> None:
     db().begin('update_match')

--- a/decksite/data/match_test.py
+++ b/decksite/data/match_test.py
@@ -1,0 +1,18 @@
+from decksite.data import match
+from shared.container import Container
+
+
+def test_stats_counts_each_player_once_per_period(seeded_db: Container) -> None:
+    stats = match.stats()
+
+    assert {
+        'num_players_this_week': stats['num_players_this_week'],
+        'num_players_this_month': stats['num_players_this_month'],
+        'num_players_this_season': stats['num_players_this_season'],
+        'num_players_all_time': stats['num_players_all_time'],
+    } == {
+        'num_players_this_week': seeded_db.num_people,
+        'num_players_this_month': seeded_db.num_people,
+        'num_players_this_season': seeded_db.num_people,
+        'num_players_all_time': seeded_db.num_people,
+    }

--- a/decksite/views/home.py
+++ b/decksite/views/home.py
@@ -144,6 +144,23 @@ class Home(View):
                     },
                 ],
             },
+            {
+                'header': 'League and Tournament Players',
+                'stats': [
+                    {
+                        'text': f"{matches_stats_display['num_players_this_week']} players this week",
+                    },
+                    {
+                        'text': f"{matches_stats_display['num_players_this_month']} players this month",
+                    },
+                    {
+                        'text': f"{matches_stats_display['num_players_this_season']} players this season",
+                    },
+                    {
+                        'text': f"{matches_stats_display['num_players_all_time']} players all time",
+                    },
+                ],
+            },
         ]
 
 # movers_and_shakers arrives sorted by meta share change, most improved first. Show the biggest

--- a/decksite/views/home_test.py
+++ b/decksite/views/home_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from decksite.data.archetype import Archetype
-from decksite.views.home import biggest_movers
+from decksite.views.home import Home, biggest_movers
 
 
 def movers(*changes: float) -> list[Archetype]:
@@ -34,3 +34,28 @@ def test_biggest_movers_fills_the_table_from_whichever_direction_has_enough(chan
 
 def test_biggest_movers_is_empty_when_nothing_moved() -> None:
     assert biggest_movers([]) == []
+
+
+def test_setup_stats_shows_player_counts_for_each_requested_period() -> None:
+    view = Home.__new__(Home)
+    view.setup_stats({
+        'num_matches_today': 1,
+        'num_matches_this_week': 2,
+        'num_matches_this_month': 3,
+        'num_matches_this_season': 4,
+        'num_matches_all_time': 5,
+        'num_players_this_week': 6,
+        'num_players_this_month': 7,
+        'num_players_this_season': 8,
+        'num_players_all_time': 9000,
+    })
+
+    assert view.community_stats[1] == {
+        'header': 'League and Tournament Players',
+        'stats': [
+            {'text': '6 players this week'},
+            {'text': '7 players this month'},
+            {'text': '8 players this season'},
+            {'text': '9,000 players all time'},
+        ],
+    }


### PR DESCRIPTION
Closes #1558

## Summary
- count unique people with recorded league or tournament matches this week, month, season, and all time
- show those counts in the homepage Community Stats section
- cover unique counting and formatted presentation with focused regression tests

## Validation
- `uv run --frozen pytest decksite/data/match_test.py decksite/views/home_test.py -q`
- `uv run --frozen python dev.py mypy`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py jslint`
- `npm run build`
- `PD_BROWSER_BASE_URL=http://127.0.0.1:5000 PD_BROWSER_CHANNEL=chrome uv run --frozen pytest --no-cov -p no:cacheprovider decksite/browser_test.py -q`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/96bb2a91-57c0-44fe-bb4a-c31cc835e72f)
