### PR TITLE
Add Discord previews for matchup links

### DIFF
--- a/decksite/views/matchups.py
+++ b/decksite/views/matchups.py
@@ -36,19 +36,19 @@ class Matchups(View):
     def show_season_icon(self) -> bool:
         return not self.search_season_id
 
-    def og_title(self) -> str | None:
+    def og_title(self) -> str:
         if self.results is None:
-            return None
+            return super().og_title()
         return f'{self.hero_summary} versus {self.enemy_summary}'
 
-    def og_url(self) -> str | None:
+    def og_url(self) -> str:
         if self.results is None:
-            return None
+            return super().og_url()
         return request.url
 
-    def og_description(self) -> str | None:
+    def og_description(self) -> str:
         if self.results is None:
-            return None
+            return super().og_description()
         record = f'{self.results.wins}–{self.results.losses}'
         if self.results.draws:
             record += f'–{self.results.draws}'

--- a/decksite/views/matchups.py
+++ b/decksite/views/matchups.py
@@ -1,5 +1,7 @@
 from collections.abc import Mapping
 
+from flask import request
+
 from decksite.data.archetype import Archetype
 from decksite.data.matchup import MatchupResults
 from decksite.data.person import Person
@@ -33,6 +35,26 @@ class Matchups(View):
 
     def show_season_icon(self) -> bool:
         return not self.search_season_id
+
+    def og_title(self) -> str | None:
+        if self.results is None:
+            return None
+        return f'{self.hero_summary} versus {self.enemy_summary}'
+
+    def og_url(self) -> str | None:
+        if self.results is None:
+            return None
+        return request.url
+
+    def og_description(self) -> str | None:
+        if self.results is None:
+            return None
+        record = f'{self.results.wins}–{self.results.losses}'
+        if self.results.draws:
+            record += f'–{self.results.draws}'
+        if self.results.win_percent is not None:
+            record += f' ({self.results.win_percent}% win rate)'
+        return f'{record} · {self.season_summary}'
 
     def page_title(self) -> str:
         return 'Matchups Calculator'

--- a/decksite/views/matchups.py
+++ b/decksite/views/matchups.py
@@ -54,7 +54,7 @@ class Matchups(View):
             record += f'–{self.results.draws}'
         if self.results.win_percent is not None:
             record += f' ({self.results.win_percent}% win rate)'
-        return f'{record} · {self.season_summary}'
+        return f'{self.hero_summary} versus {self.enemy_summary} is {record} · {self.season_summary}'
 
     def page_title(self) -> str:
         return 'Matchups Calculator'

--- a/decksite/views/matchups_test.py
+++ b/decksite/views/matchups_test.py
@@ -38,7 +38,7 @@ def test_matchup_search_has_open_graph_summary(monkeypatch: pytest.MonkeyPatch) 
         )
 
         assert view.og_title() == 'Aggro, SmokeTester versus Control'
-        assert view.og_description() == '2–1–1 (66.7% win rate) · Season 7'
+        assert view.og_description() == 'Aggro, SmokeTester versus Control is 2–1–1 (66.7% win rate) · Season 7'
         assert view.og_url() == f'http://localhost{path}'
 
 
@@ -49,7 +49,7 @@ def test_matchup_search_without_matches_still_has_open_graph_summary(monkeypatch
         view = Matchups({'card': 'Black Lotus'}, {}, None, [], [], [], matchup_results(wins=0, losses=0, draws=0))
 
         assert view.og_title() == 'Black Lotus versus All Decks'
-        assert view.og_description() == '0–0 · All Time'
+        assert view.og_description() == 'Black Lotus versus All Decks is 0–0 · All Time'
 
 
 def test_matchup_calculator_without_search_has_no_open_graph_summary(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/decksite/views/matchups_test.py
+++ b/decksite/views/matchups_test.py
@@ -1,0 +1,63 @@
+import pytest
+
+from decksite.data.archetype import Archetype
+from decksite.data.matchup import MatchupResults
+from decksite.data.person import Person
+from decksite.main import APP
+from decksite.views.matchups import Matchups
+
+
+def matchup_results(wins: int = 2, losses: int = 1, draws: int = 1) -> MatchupResults:
+    return MatchupResults(
+        hero_deck_ids=[1, 2],
+        enemy_deck_ids=[3],
+        match_ids=[1, 2, 3, 4],
+        wins=wins,
+        draws=draws,
+        losses=losses,
+        hero_decks=[],
+        matches=[],
+    )
+
+
+def test_matchup_search_has_open_graph_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Matchups, 'all_seasons', lambda _self: [])
+    archetypes = [Archetype({'id': 2, 'name': 'Aggro'}), Archetype({'id': 3, 'name': 'Control'})]
+    people = [Person({'id': 1, 'name': 'SmokeTester', 'mtgo_username': 'SmokeTester'})]
+    path = '/matchups/?hero_person_id=1&hero_archetype_id=2&enemy_archetype_id=3&season_id=7'
+
+    with APP.test_request_context(path):
+        view = Matchups(
+            {'person_id': '1', 'archetype_id': '2'},
+            {'archetype_id': '3'},
+            7,
+            archetypes,
+            people,
+            [],
+            matchup_results(),
+        )
+
+        assert view.og_title() == 'Aggro, SmokeTester versus Control'
+        assert view.og_description() == '2–1–1 (66.7% win rate) · Season 7'
+        assert view.og_url() == f'http://localhost{path}'
+
+
+def test_matchup_search_without_matches_still_has_open_graph_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Matchups, 'all_seasons', lambda _self: [])
+
+    with APP.test_request_context('/matchups/?hero_person_id=&hero_card=Black+Lotus'):
+        view = Matchups({'card': 'Black Lotus'}, {}, None, [], [], [], matchup_results(wins=0, losses=0, draws=0))
+
+        assert view.og_title() == 'Black Lotus versus All Decks'
+        assert view.og_description() == '0–0 · All Time'
+
+
+def test_matchup_calculator_without_search_has_no_open_graph_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(Matchups, 'all_seasons', lambda _self: [])
+
+    with APP.test_request_context('/matchups/'):
+        view = Matchups({}, {}, None, [], [], [], None)
+
+        assert view.og_title() is None
+        assert view.og_description() is None
+        assert view.og_url() is None

--- a/decksite/views/matchups_test.py
+++ b/decksite/views/matchups_test.py
@@ -52,12 +52,12 @@ def test_matchup_search_without_matches_still_has_open_graph_summary(monkeypatch
         assert view.og_description() == 'Black Lotus versus All Decks is 0–0 · All Time'
 
 
-def test_matchup_calculator_without_search_has_no_open_graph_summary(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_matchup_calculator_without_search_has_default_open_graph_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(Matchups, 'all_seasons', lambda _self: [])
 
     with APP.test_request_context('/matchups/'):
         view = Matchups({}, {}, None, [], [], [], None)
 
-        assert view.og_title() is None
-        assert view.og_description() is None
-        assert view.og_url() is None
+        assert view.og_title() == 'Matchups Calculator'
+        assert view.og_description() == 'Penny Dreadful is an ultra-budget Magic Online format with thousands of legal cards, free weekly tournaments, a free league, and quarterly rotations.'
+        assert view.og_url() == 'http://localhost/matchups/'


### PR DESCRIPTION
Fixes #6212

- add Open Graph metadata to submitted matchup searches
- summarize both criteria and the calculated record in a self-contained description
- omit matchup-specific metadata from the blank calculator
- cover populated, zero-match, and blank searches

Validation:
- uv run --frozen pytest -q decksite/views/matchups_test.py
- uv run --frozen python dev.py lint
- uv run --frozen python dev.py mypy
- npm run build
- Chromium verification of rendered Open Graph tags

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/5f394de5-a529-4fb4-8bd1-e93d715baa7e)
