### PR TITLE
Speed up matchup chooser loading

### DIFF
--- a/decksite/controllers/api.py
+++ b/decksite/controllers/api.py
@@ -11,6 +11,7 @@ from decksite import APP, auth, league
 from decksite.data import archetype as archs
 from decksite.data import card, clauses, deck, match, playability, query
 from decksite.data import competition as comp
+from decksite.data import matchup as mus
 from decksite.data import person as ps
 from decksite.data import rotation as rot
 from decksite.data import rule as rs
@@ -817,6 +818,12 @@ def search() -> Response:
         elif q in name:
             fuzzy_matches.append(item)
     return return_json(exact_matches + fuzzy_matches)
+
+
+@APP.route('/api/matchup-options/<any(archetypes,people,cards):option_type>')
+@APP.route('/api/matchup-options/<any(archetypes,people,cards):option_type>/')
+def matchup_options(option_type: mus.MatchupOptionType) -> Response:
+    return return_json(mus.search_options(option_type, request.args.get('q', '')))
 
 def init_search_cache() -> None:
     if len(SEARCH_CACHE) > 0:

--- a/decksite/controllers/api_test.py
+++ b/decksite/controllers/api_test.py
@@ -68,6 +68,16 @@ def test_card_api_returns_not_found_for_unknown_card() -> None:
     assert response.get_json()['code'] == 'NOTFOUND'
 
 
+def test_matchup_options_api_returns_small_search_results(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected = [{'name': 'Lightning Bolt', 'value': 'Lightning Bolt'}]
+    monkeypatch.setattr(api.mus, 'search_options', lambda option_type, search: expected if option_type == 'cards' and search == 'bolt' else [])
+
+    response = APP.test_client().get('/api/matchup-options/cards/?q=bolt')
+
+    assert response.status_code == 200
+    assert response.get_json() == expected
+
+
 @pytest.mark.functional
 def test_aggregate_apis_serialize_integer_stats_as_numbers(seeded_db: Container) -> None:
     season_id = db().value('SELECT season_id FROM deck_cache LIMIT 1')

--- a/decksite/controllers/metagame.py
+++ b/decksite/controllers/metagame.py
@@ -10,7 +10,6 @@ from decksite.data import card as cs
 from decksite.data import deck as ds
 from decksite.data import match
 from decksite.data import matchup as mus
-from decksite.data import person as ps
 from decksite.data import season as ss
 from decksite.deck_type import DeckType
 from decksite.views import Archetype, Archetypes, Card, Cards, Deck, Decks, Matchups, Metagame, Seasons
@@ -138,25 +137,12 @@ def archetype(archetype_id: str, deck_type: str | None = None) -> str:
 
 @APP.route('/matchups/')
 def matchups() -> str:
-    hero: dict[str, str] = {}
-    enemy: dict[str, str] = {}
-    for k, v in request.args.items():
-        if k.startswith('hero_'):
-            k = k.replace('hero_', '')
-            hero[k] = v
-        else:
-            k = k.replace('enemy_', '')
-            enemy[k] = v
+    hero = mus.resolve_choices({k.removeprefix('hero_'): v for k, v in request.args.items() if k.startswith('hero_')})
+    enemy = mus.resolve_choices({k.removeprefix('enemy_'): v for k, v in request.args.items() if k.startswith('enemy_')})
     season_str = request.args.get('season_id')
     season_id = int(season_str) if season_str else None
     results = mus.matchup(hero, enemy, season_id=season_id) if 'hero_person_id' in request.args else None
-    matchup_archetypes = archs.load_archetypes()
-    matchup_archetypes.sort(key=lambda a: a.name)
-    matchup_people = ps.load_people(where='p.mtgo_username IS NOT NULL')
-    matchup_people.sort(key=lambda p: p.name)
-    matchup_cards = cs.load_cards()
-    matchup_cards.sort(key=lambda c: c.name)
-    view = Matchups(hero, enemy, season_id, matchup_archetypes, matchup_people, matchup_cards, results)
+    view = Matchups(hero, enemy, season_id, results)
     return view.page()
 
 

--- a/decksite/controllers/metagame_test.py
+++ b/decksite/controllers/metagame_test.py
@@ -115,6 +115,32 @@ def test_split_cards_do_not_redirect_when_the_proxy_has_merged_the_slashes(monke
     assert response == 'split card page'
 
 
+def test_matchups_only_resolves_selected_criteria(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolved: list[dict[str, str]] = []
+
+    def resolve_choices(choices: dict[str, str]) -> dict[str, str]:
+        resolved.append(choices)
+        return choices
+
+    class FakeMatchups:
+        def __init__(self, hero: dict[str, str], enemy: dict[str, str], season_id: int | None, results: object | None) -> None:
+            assert hero == {'archetype_id': '16'}
+            assert enemy == {'card': 'Counterspell'}
+            assert season_id == 43
+            assert results is None
+
+        def page(self) -> str:
+            return 'fast matchup page'
+
+    monkeypatch.setattr(metagame.mus, 'resolve_choices', resolve_choices)
+    monkeypatch.setattr(metagame, 'Matchups', FakeMatchups)
+    with APP.test_request_context('/matchups/?season_id=43&hero_archetype_id=16&enemy_card=Counterspell'):
+        response = metagame.matchups()
+
+    assert response == 'fast matchup page'
+    assert resolved == [{'archetype_id': '16'}, {'card': 'Counterspell'}]
+
+
 @pytest.mark.parametrize(
     ('submitted', 'canonical', 'expected'),
     [

--- a/decksite/data/matchup.py
+++ b/decksite/data/matchup.py
@@ -1,10 +1,14 @@
 from dataclasses import dataclass
+from typing import Literal
 
 from decksite.data import deck, match, query
 from decksite.database import db
 from magic.models import Deck
 from shared import guarantee
 from shared.container import Container
+from shared.pd_exception import DoesNotExistException
+
+MatchupOptionType = Literal['archetypes', 'people', 'cards']
 
 
 @dataclass
@@ -25,6 +29,90 @@ class MatchupResults:
     @property
     def win_percent(self) -> float | None:
         return round((self.wins / (self.wins + self.losses)) * 100, 1) if (self.wins + self.losses) > 0 else None
+
+
+def search_options(option_type: MatchupOptionType, search: str, limit: int = 10) -> list[dict[str, str]]:
+    """Return the small amount of data the matchup typeaheads actually use."""
+    search = search.strip()
+    if not search:
+        return []
+    contains = f'%{search}%'
+    starts_with = f'{search}%'
+    if option_type == 'archetypes':
+        sql = """
+            SELECT CAST(id AS CHAR) AS value, name
+            FROM archetype
+            WHERE name LIKE %s
+            ORDER BY CASE WHEN name LIKE %s THEN 0 ELSE 1 END, name
+            LIMIT %s
+        """
+    elif option_type == 'people':
+        sql = """
+            SELECT CAST(id AS CHAR) AS value, LOWER(mtgo_username) AS name
+            FROM person
+            WHERE mtgo_username IS NOT NULL AND mtgo_username LIKE %s
+            ORDER BY CASE WHEN mtgo_username LIKE %s THEN 0 ELSE 1 END, mtgo_username
+            LIMIT %s
+        """
+    else:
+        # Match the old chooser's contents exactly: cards represented in the all-time
+        # card statistics, rather than every card in the Oracle database.
+        sql = """
+            SELECT name AS value, name
+            FROM (SELECT DISTINCT name FROM _card_stats) AS cards
+            WHERE name LIKE %s
+            ORDER BY CASE WHEN name LIKE %s THEN 0 ELSE 1 END, name
+            LIMIT %s
+        """
+    return [{'value': str(r['value']), 'name': r['name']} for r in db().select(sql, [contains, starts_with, limit])]
+
+
+def resolve_choices(choices: dict[str, str]) -> dict[str, str]:
+    """Resolve submitted IDs (and typed-name fallbacks) into display-ready criteria."""
+    resolved: dict[str, str] = {}
+    archetype = _resolve_archetype(choices.get('archetype_id'), choices.get('archetype_name'))
+    if archetype:
+        resolved['archetype_id'] = str(archetype['id'])
+        resolved['archetype_name'] = str(archetype['name'])
+    person = _resolve_person(choices.get('person_id'), choices.get('person_name'))
+    if person:
+        resolved['person_id'] = str(person['id'])
+        resolved['person_name'] = str(person['name'])
+        resolved['person_label'] = str(person['label'])
+    card_name = choices.get('card') or choices.get('card_name')
+    if card_name:
+        card = db().value('SELECT name FROM _card_stats WHERE name = %s LIMIT 1', [card_name])
+        if card is None:
+            raise DoesNotExistException(f'Did not find a played card with name of `{card_name}`')
+        resolved['card'] = card
+    return resolved
+
+
+def _resolve_archetype(archetype_id: str | None, name: str | None) -> dict[str, str | int] | None:
+    if archetype_id:
+        rows = db().select('SELECT id, name FROM archetype WHERE id = %s', [archetype_id])
+    elif name:
+        rows = db().select('SELECT id, name FROM archetype WHERE name = %s', [name])
+    else:
+        return None
+    if not rows:
+        value = archetype_id or name
+        raise DoesNotExistException(f'Did not find archetype `{value}`')
+    return rows[0]
+
+
+def _resolve_person(person_id: str | None, name: str | None) -> dict[str, str | int] | None:
+    person_name = query.person_query()
+    if person_id:
+        rows = db().select(f'SELECT id, {person_name} AS name, LOWER(mtgo_username) AS label FROM person AS p WHERE id = %s AND mtgo_username IS NOT NULL', [person_id])
+    elif name:
+        rows = db().select(f'SELECT id, {person_name} AS name, LOWER(mtgo_username) AS label FROM person AS p WHERE mtgo_username = %s', [name])
+    else:
+        return None
+    if not rows:
+        value = person_id or name
+        raise DoesNotExistException(f'Did not find MTGO player `{value}`')
+    return rows[0]
 
 def matchup(hero: dict[str, str], enemy: dict[str, str], season_id: int | None = None) -> MatchupResults:
     where = 'TRUE'

--- a/decksite/data/matchup_test.py
+++ b/decksite/data/matchup_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from decksite.data import matchup
 from decksite.data.matchup import MatchupResults
 
 
@@ -24,3 +25,63 @@ def test_win_percent_is_float_or_none(wins: int, losses: int, expected: float | 
 
     assert results.win_percent == expected
     assert results.win_percent is None or isinstance(results.win_percent, float)
+
+
+@pytest.mark.parametrize(
+    ('option_type', 'expected_table'),
+    [
+        ('archetypes', 'FROM archetype'),
+        ('people', 'FROM person'),
+        ('cards', 'FROM _card_stats'),
+    ],
+)
+def test_search_options_returns_lightweight_matches(option_type: matchup.MatchupOptionType, expected_table: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeDatabase:
+        def select(self, sql: str, args: list[str | int]) -> list[dict[str, str]]:
+            assert expected_table in sql
+            assert args == ['%Bolt%', 'Bolt%', 10]
+            return [{'value': '123', 'name': 'Lightning Bolt'}]
+
+    monkeypatch.setattr(matchup, 'db', FakeDatabase)
+
+    options = matchup.search_options(option_type, 'Bolt')
+
+    assert options == [{'value': '123', 'name': 'Lightning Bolt'}]
+
+
+def test_search_options_ignores_an_empty_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(matchup, 'db', lambda: pytest.fail('An empty search should not query the database'))
+
+    assert matchup.search_options('cards', ' ') == []
+
+
+def test_resolve_choices_supports_typed_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeDatabase:
+        def select(self, sql: str, args: list[str]) -> list[dict[str, str | int]]:
+            if 'FROM archetype' in sql:
+                assert args == ['Aggro']
+                return [{'id': 16, 'name': 'Aggro'}]
+            assert 'FROM person' in sql
+            assert args == ['SmokeTester']
+            return [{'id': 42, 'name': 'smoketester', 'label': 'smoketester'}]
+
+        def value(self, sql: str, args: list[str]) -> str:
+            assert 'FROM _card_stats' in sql
+            assert args == ['Lightning Bolt']
+            return 'Lightning Bolt'
+
+    monkeypatch.setattr(matchup, 'db', FakeDatabase)
+    choices = matchup.resolve_choices({
+        'archetype_name': 'Aggro',
+        'person_name': 'SmokeTester',
+        'card_name': 'Lightning Bolt',
+    })
+
+    assert choices == {
+        'archetype_id': '16',
+        'archetype_name': 'Aggro',
+        'person_id': '42',
+        'person_name': 'smoketester',
+        'person_label': 'smoketester',
+        'card': 'Lightning Bolt',
+    }

--- a/decksite/templates/chooser.mustache
+++ b/decksite/templates/chooser.mustache
@@ -1,22 +1,15 @@
 <div>
-    <label for="{{prefix}}archetype">{{_ Archetype}}</label>
-    {{> archetypedropdown}}
+    <label for="{{prefix}}archetype_name">{{_ Archetype}}</label>
+    <input id="{{prefix}}archetype_name" name="{{prefix}}archetype_name" class="matchup-option" data-option-type="archetypes" type="text" autocomplete="off" placeholder="Search archetypes" value="{{archetype_name}}">
+    <input name="{{prefix}}archetype_id" type="hidden" value="{{archetype_id}}">
 </div>
 <div>
-    <label for="{{prefix}}person_id">{{_ Person}}</label>
-    <select name="{{prefix}}person_id">
-        <option value="">[Select]</option>
-        {{#people}}
-            <option value="{{id}}" {{#selected}}selected="selected"{{/selected}}>{{mtgo_username}}</option>
-        {{/people}}
-    </select>
+    <label for="{{prefix}}person_name">{{_ Person}}</label>
+    <input id="{{prefix}}person_name" name="{{prefix}}person_name" class="matchup-option" data-option-type="people" type="text" autocomplete="off" placeholder="Search people" value="{{person_label}}">
+    <input name="{{prefix}}person_id" type="hidden" value="{{person_id}}">
 </div>
 <div>
-    <label for="{{prefix}}card">{{_ Card}}</label>
-    <select name="{{prefix}}card">
-        <option value="">[Select]</option>
-        {{#cards}}
-            <option {{#selected}}selected="selected"{{/selected}}>{{name}}</option>
-        {{/cards}}
-    </select>
+    <label for="{{prefix}}card_name">{{_ Card}}</label>
+    <input id="{{prefix}}card_name" name="{{prefix}}card_name" class="matchup-option" data-option-type="cards" type="text" autocomplete="off" placeholder="Search cards" value="{{card}}">
+    <input name="{{prefix}}card" type="hidden" value="{{card}}">
 </div>

--- a/decksite/views/matchups.py
+++ b/decksite/views/matchups.py
@@ -1,32 +1,24 @@
 from collections.abc import Mapping
 
-from decksite.data.archetype import Archetype
 from decksite.data.matchup import MatchupResults
-from decksite.data.person import Person
 from decksite.view import View
-from magic.models import Card
 
 
 class Matchups(View):
-    def __init__(self, hero: Mapping[str, str | int], enemy: Mapping[str, str | int], season_id: int | None, archetypes: list[Archetype], people: list[Person], cards: list[Card], results: MatchupResults | None) -> None:
+    def __init__(self, hero: Mapping[str, str | int], enemy: Mapping[str, str | int], season_id: int | None, results: MatchupResults | None) -> None:
         super().__init__()
         self.results = results
         self.criteria = [
-            {'name': 'Decks Matching…', 'prefix': 'hero_', 'choices': hero},
-            {'name': '… versus …', 'prefix': 'enemy_', 'choices': enemy},
+            criterion('Decks Matching…', 'hero_', hero),
+            criterion('… versus …', 'enemy_', enemy),
         ]
-        # Set up options for dropdowns, marking the right ones as selected.
-        for c in self.criteria:
-            c['archetypes'] = [{'name': a.name, 'id': a.id, 'selected': str(c['choices'].get('archetype_id')) == str(a.id)} for a in archetypes]  # type: ignore
-            c['people'] = [{'mtgo_username': p.mtgo_username.lower(), 'id': p.id, 'selected': str(c['choices'].get('person_id')) == str(p.id)} for p in people]  # type: ignore
-            c['cards'] = [{'name': card.name, 'selected': c['choices'].get('card') == card.name} for card in cards]  # type: ignore
         self.seasons = [{'season_id': s['num'] or '', 'name': s['name'], 'selected': str(season_id) == str(s['num'])} for s in self.all_seasons()]
         self.decks = results.hero_decks if results and results.hero_decks else []
         self.show_decks = len(self.decks) > 0
         self.matches = results.matches if results and results.matches else []
         self.show_matches = len(self.matches) > 0
-        self.hero_summary = summary_text(hero, archetypes, people)
-        self.enemy_summary = summary_text(enemy, archetypes, people)
+        self.hero_summary = summary_text(hero)
+        self.enemy_summary = summary_text(enemy)
         self.season_summary = f'Season {season_id}' if season_id else 'All Time'
         self.show_hero = True  # We should show both players in the list of matches, not just "opponent".
         self.search_season_id = season_id
@@ -38,15 +30,18 @@ class Matchups(View):
         return 'Matchups Calculator'
 
 
-def summary_text(choices: Mapping[str, str | int], archetypes: list[Archetype], people: list[Person]) -> str:
-    s = ''
-    if choices.get('archetype_id'):
-        s += next(a.name for a in archetypes if a.id == int(choices['archetype_id'])) + ', '
-    if choices.get('person_id'):
-        s += next(p.name for p in people if p.id == int(choices['person_id'])) + ', '
-    if choices.get('card'):
-        s += str(choices['card']) + ', '
-    s = s.strip(', ')
-    if not s:
-        s = 'All Decks'
-    return s
+def summary_text(choices: Mapping[str, str | int]) -> str:
+    parts = [str(choices[k]) for k in ('archetype_name', 'person_name', 'card') if choices.get(k)]
+    return ', '.join(parts) or 'All Decks'
+
+
+def criterion(name: str, prefix: str, choices: Mapping[str, str | int]) -> dict[str, object]:
+    return {
+        'name': name,
+        'prefix': prefix,
+        'archetype_id': choices.get('archetype_id') or '',
+        'archetype_name': choices.get('archetype_name') or '',
+        'person_id': choices.get('person_id') or '',
+        'person_label': choices.get('person_label') or '',
+        'card': choices.get('card') or '',
+    }

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -521,6 +521,29 @@ div:not(.table-header):after, header:after, nav:after, main:after, footer:after,
     margin-top: 2rem;
 }
 
+.matchup-calculator .twitter-typeahead {
+    margin-left: var(--form-element-margin);
+    width: 20rem;
+}
+
+.matchup-calculator .twitter-typeahead input {
+    margin-left: 0;
+    max-width: 100%;
+    width: 100%;
+}
+
+.matchup-calculator .tt-hint, .matchup-calculator .tt-menu {
+    left: 0 !important;
+    right: auto !important;
+}
+
+@media only screen and (max-width: 800px) {
+    .matchup-calculator .twitter-typeahead {
+        margin-left: 0;
+        max-width: 80%;
+    }
+}
+
 /*
 
 Spacing

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -15,6 +15,7 @@ PD.init = function() {
     PD.initDarkModeToggle();
     PD.initTooltips();
     PD.initTypeahead();
+    PD.initMatchupCalculator();
     PD.initSearchShortcut();
     PD.initUseGuess();
     PD.initReassign();
@@ -279,6 +280,41 @@ PD.initTypeahead = function() {
     $(".typeahead").typeahead(options, dataSource);
     $(".typeahead").bind("typeahead:select", function(event, suggestion) {
         window.location.href = suggestion.url;
+    });
+};
+
+PD.initMatchupCalculator = function() {
+    $(".matchup-option").each(function() {
+        var input = $(this),
+            valueInput = input.siblings("input[type=hidden]"),
+            optionType = input.data("option-type"),
+            corpus = new Bloodhound({
+                datumTokenizer: Bloodhound.tokenizers.obj.whitespace("name"),
+                queryTokenizer: Bloodhound.tokenizers.whitespace,
+                remote: {
+                    "url": "/api/matchup-options/" + optionType + "/?q={q}",
+                    "wildcard": "{q}"
+                }
+            }),
+            options = {
+                "autoselect": true,
+                "highlight": true,
+                "hint": true,
+                "minLength": 1
+            },
+            dataSource = {
+                "display": "name",
+                "limit": 10,
+                "source": corpus,
+                "templates": {
+                    "empty": function() { return '<div class="tt-suggestion">No results found</div>'; }
+                }
+            };
+        input.typeahead(options, dataSource);
+        input.on("input", function() { valueInput.val(""); });
+        input.bind("typeahead:autocomplete typeahead:select", function(_event, suggestion) {
+            valueInput.val(suggestion.value);
+        });
     });
 };
 


### PR DESCRIPTION
## Summary

- Replace the enormous matchup chooser dropdown payload with remote typeaheads.
- Resolve submitted IDs and exact typed values server-side while preserving old saved URLs.
- Keep the selectable archetype, MTGO player, and played-card sets unchanged.

## Performance

- Empty matchup chooser: roughly 3.0s / 3.88 MB to 25–74ms / 32 KB.
- Representative selected-player result: roughly 3.1s / 4.06 MB to 118ms / 217 KB.

## Verification

- `uv run pytest decksite/controllers/api_test.py decksite/controllers/metagame_test.py decksite/data/matchup_test.py -m 'not functional'`
- Ruff and mypy on the changed Python files.
- `uv run --frozen python dev.py jslint`
- `npm run build`
- Browser-checked chooser suggestions, form submission, saved-query compatibility, and unchanged result summaries.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b17272a5-139b-4e61-8801-740724382c96)
