### PR TITLE
Flag invalid modo-bugs issue metadata (#4212)

### DIFF
--- a/modo_bugs/update.py
+++ b/modo_bugs/update.py
@@ -30,6 +30,11 @@ ALL_BUGS: list[BugData] = []
 
 VERIFICATION_BY_ISSUE: dict[int, str] = {}
 
+MAX_TITLE_LENGTH = 120
+ALLOWED_MULTIPLE_CATEGORIES = {
+    frozenset({'Advantageous', 'Non-Functional ability'}),
+}
+
 if sys.stdout.encoding != 'utf-8':
     sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer)
 
@@ -91,6 +96,7 @@ def process_issue(issue: Issue) -> None:
     if age < 5:
         fix_user_errors(issue)
         apply_screenshot_labels(issue)
+    check_for_invalid_metadata(issue)
     labels = [c.name for c in issue.labels]
     see_also = strings.get_body_field(issue.body, 'See Also')
     feedback_link = strings.get_body_field(issue.body, 'Forum Post')
@@ -239,6 +245,20 @@ def check_for_invalid_card_names(issue: Issue, cards: list[str]) -> None:
         issue.add_to_labels('Invalid Card Name')
     elif not fail and 'Invalid Card Name' in labels:
         issue.remove_from_labels('Invalid Card Name')
+
+def check_for_invalid_metadata(issue: Issue) -> None:
+    labels = [label.name for label in issue.labels]
+    categories = frozenset(label for label in labels if label in CATEGORIES)
+    has_invalid_categories = len(categories) > 1 and categories not in ALLOWED_MULTIPLE_CATEGORIES
+
+    update_validation_label(issue, labels, 'Invalid Title', len(issue.title) > MAX_TITLE_LENGTH)
+    update_validation_label(issue, labels, 'Multiple Categories', has_invalid_categories)
+
+def update_validation_label(issue: Issue, labels: list[str], label: str, should_apply: bool) -> None:
+    if should_apply and label not in labels:
+        issue.add_to_labels(label)
+    elif not should_apply and label in labels:
+        issue.remove_from_labels(label)
 
 def get_affects(issue: Issue) -> list[str]:
     affects = strings.get_body_field(issue.body, 'Affects')

--- a/modo_bugs/update_test.py
+++ b/modo_bugs/update_test.py
@@ -1,10 +1,62 @@
 import datetime
 from types import SimpleNamespace
 
+import pytest
+
 from modo_bugs import update
+
+
+class FakeIssue:
+    def __init__(self, title: str, labels: list[str]) -> None:
+        self.title = title
+        self.labels = [SimpleNamespace(name=label) for label in labels]
+        self.body = ''
+        self.updated_at = datetime.datetime.now(datetime.UTC)
+        self.comments = [object()]
+        self.number = 1
+        self.actions: list[tuple[str, object]] = []
+
+    def add_to_labels(self, label: str) -> None:
+        self.actions.append(('add', label))
+
+    def remove_from_labels(self, label: str) -> None:
+        self.actions.append(('remove', label))
+
+    def edit(self, **kwargs: object) -> None:
+        self.actions.append(('edit', kwargs))
+
+    def create_comment(self, body: str) -> None:
+        self.actions.append(('comment', body))
 
 
 def test_age_in_days_handles_pygithub_aware_datetimes() -> None:
     """PyGithub 2.x returns tz-aware datetimes. A naive now() minus one of those is a TypeError, which took down every issue in update.main()."""
     issue = SimpleNamespace(updated_at=datetime.datetime.now(datetime.UTC) - datetime.timedelta(days=7, hours=1))
     assert update.age_in_days(issue) == 7  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ('title', 'labels', 'expected_actions'),
+    [
+        ('x' * 121, ['Advantageous'], [('add', 'Invalid Title')]),
+        ('x' * 120, ['Advantageous', 'Invalid Title'], [('remove', 'Invalid Title')]),
+        ('A concise title', ['Advantageous', 'Graphical'], [('add', 'Multiple Categories')]),
+        ('A concise title', ['Advantageous', 'Non-Functional ability', 'Multiple Categories'], [('remove', 'Multiple Categories')]),
+    ],
+)
+def test_check_for_invalid_metadata(title: str, labels: list[str], expected_actions: list[tuple[str, str]]) -> None:
+    issue = FakeIssue(title, labels)
+
+    update.check_for_invalid_metadata(issue)  # type: ignore[arg-type]
+
+    assert issue.actions == expected_actions
+
+
+def test_process_issue_checks_old_issues(monkeypatch: pytest.MonkeyPatch) -> None:
+    issue = FakeIssue('x' * 121, ['Advantageous'])
+    issue.updated_at -= datetime.timedelta(days=365)
+    monkeypatch.setattr(update, 'pd_legal_cards', lambda: [])
+
+    update.process_issue(issue)  # type: ignore[arg-type]
+
+    assert ('add', 'Invalid Title') in issue.actions


### PR DESCRIPTION
## Summary

- flag titles longer than 120 characters with `Invalid Title`
- flag issues with multiple category-taxonomy labels using `Multiple Categories`
- allow the intentional `Advantageous` plus `Non-Functional ability` combination
- validate the full open backlog and remove either validation label after correction

Ordinary non-category labels remain unrestricted. The updater continues generating bug data; these labels provide the requested human triage queue.

## Backlog impact

A read-only evaluation of the current 269 open issues found 63 titles over 120 characters and 10 disallowed category combinations. Some issues may belong to both groups.

## Deployment prerequisite

Create the `Invalid Title` and `Multiple Categories` labels in `PennyDreadfulMTG/modo-bugs` before deploying this change. GitHub rejects attempts to add labels that do not exist.

## Tests

- `uv run pytest --noconftest modo_bugs/update_test.py -q` (6 passed)
- `uv run python dev.py lint`
- `uv run python dev.py mypy` (375 source files)

Fixes #4212

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/dfa2fb04-f1f8-4d37-9298-183d5337d618)
