### PR TITLE
Replace archetype dropdowns with remote pickers

### DIFF
--- a/decksite/controllers/admin.py
+++ b/decksite/controllers/admin.py
@@ -140,7 +140,7 @@ def post_archetypes() -> wrappers.Response:
     else:
         raise InvalidArgumentException(f'Did not find any of the expected keys in POST to /admin/archetypes: {request.form}')
     if search_results:
-        view = ArchetypeSearch(archs.load_archetypes(order_by='a.name'), search_results, request.form.get('q', ''), request.form.get('notq', ''))
+        view = ArchetypeSearch(search_results, request.form.get('q', ''), request.form.get('notq', ''))
         return view.response()
     return edit_archetypes(request.form.get('q', ''), request.form.get('notq', ''))
 

--- a/decksite/controllers/admin_test.py
+++ b/decksite/controllers/admin_test.py
@@ -2,11 +2,15 @@ from typing import Any, cast
 
 import pytest
 
+from decksite import prepare
 from decksite.controllers import admin
-from decksite.data import deck
+from decksite.data import deck, rule
+from decksite.data.archetype import Archetype
 from decksite.league import EditMatchForm
 from decksite.main import APP
 from decksite.views import Ban, EditAliases, EditArchetypes, EditMatches, EditRules, PlayerNotes, Unlink
+from decksite.views.archetype_search import ArchetypeSearch
+from shared.container import Container
 from shared.pd_exception import InvalidDataException
 
 
@@ -195,12 +199,67 @@ def test_edit_archetypes_add_form_includes_rule_fields(monkeypatch: pytest.Monke
     assert '<section id="add-archetype">' in html
     assert '<form method="post" action="#add-archetype">' in html
     assert '<input type="hidden" name="create_archetype" value="1">' in html
-    assert '<select name="parent" id="parent" required>' in html
+    assert '<input id="parent_name" class="archetype-option" data-option-type="archetypes" type="text" autocomplete="off" placeholder="Search archetypes" value="" required>' in html
+    assert '<input id="parent" name="parent" type="hidden" value="">' in html
     assert '<input type="text" name="name" id="name" value="" required>' in html
     assert '<label for="include">Must include</label>' in html
     assert '<textarea name="include" id="include"></textarea>' in html
     assert '<label for="exclude">Must not include</label>' in html
     assert '<textarea name="exclude" id="exclude"></textarea>' in html
+    assert html.count('class="archetype-option"') == 5
+    assert '<select name="archetype_id"' not in html
+    assert '<select name="parent"' not in html
+
+
+def test_edit_archetypes_queue_uses_remote_picker_and_keeps_rule_guess(monkeypatch: pytest.MonkeyPatch) -> None:
+    queued_deck = Container({
+        'id': 123,
+        'archetype_id': 67,
+        'archetype_name': 'Burn',
+        'rule_archetype_id': 44,
+        'rule_archetype_name': 'Burning Vengeance',
+        'similarity': '75%',
+    })
+    archetypes = [
+        Archetype({'id': 44, 'name': 'Burning Vengeance', 'description': 'Rule match'}),
+        Archetype({'id': 67, 'name': 'Burn', 'description': 'Current guess'}),
+    ]
+    monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: [queued_deck])
+    monkeypatch.setattr(deck, 'load_queue_similarity', lambda decks: None)
+    monkeypatch.setattr(rule, 'apply_rules_to_decks', lambda decks: None)
+    monkeypatch.setattr(prepare, 'prepare_deck', lambda d: None)
+
+    with APP.test_request_context('/admin/archetypes/'):
+        html = EditArchetypes(archetypes, '', '').render_content()
+
+    assert html.count('class="archetype-option"') == 6
+    assert 'value="Burning Vengeance"' in html
+    assert '<input name="archetype_id" type="hidden" value="44">' in html
+    assert 'data-archetype_id="67" data-archetype_name="Burn"' in html
+    assert '<option' not in html
+
+
+def test_edit_archetypes_preserves_selected_parent_after_add_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    parent = Archetype({'id': 67, 'name': 'Burn', 'description': ''})
+    monkeypatch.setattr(deck, 'load_decks', lambda *args, **kwargs: [])
+    monkeypatch.setattr(deck, 'load_queue_similarity', lambda decks: None)
+
+    with APP.test_request_context('/admin/archetypes/'):
+        html = EditArchetypes([parent], '', '', add_errors=['Invalid rule'], add_values={'parent': '67'}).render_content()
+
+    assert '<input id="parent_name" class="archetype-option" data-option-type="archetypes" type="text" autocomplete="off" placeholder="Search archetypes" value="Burn" required>' in html
+    assert '<input id="parent" name="parent" type="hidden" value="67">' in html
+
+
+def test_archetype_search_results_use_remote_picker(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(prepare, 'prepare_deck', lambda d: None)
+
+    with APP.test_request_context('/admin/archetypes/'):
+        html = ArchetypeSearch([Container({'id': 123})], 'Bolt', '').render_content()
+
+    assert 'class="archetype-option"' in html
+    assert '<input name="archetype_id" type="hidden" value="">' in html
+    assert '<select name="archetype_id"' not in html
 
 
 def test_admin_menu_hides_admin_only_items_from_demimod() -> None:

--- a/decksite/templates/archetypepicker.mustache
+++ b/decksite/templates/archetypepicker.mustache
@@ -1,0 +1,2 @@
+<input class="archetype-option" data-option-type="archetypes" type="text" autocomplete="off" placeholder="Search archetypes" value="{{selected_archetype_name}}"{{#archetype_required}} required{{/archetype_required}}>
+<input name="{{prefix}}archetype_id" type="hidden" value="{{selected_archetype_id}}">

--- a/decksite/templates/archetypesearch.mustache
+++ b/decksite/templates/archetypesearch.mustache
@@ -55,7 +55,7 @@
                     {{/search_results}}
                 </tbody>
             </table>
-            {{> archetypedropdown }}
+            {{> archetypepicker }}
             <button type="submit">Reassign</button>
         </form>
     {{/has_search_results}}

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -20,7 +20,7 @@
                         <td><a href="{{source_url}}">{{source_name}}</a></td>
                         <td>
                             <a href="{{archetype_url}}" title="{{archetype_description}}">{{archetype_name}}</a>
-                            {{#archetype_id}}<a class="use-guess" title="Assign this deck to {{archetype_name}}" data-archetype_id="{{archetype_id}}">[✓]</a>{{/archetype_id}}
+                            {{#archetype_id}}<a class="use-guess" title="Assign this deck to {{archetype_name}}" data-archetype_id="{{archetype_id}}" data-archetype_name="{{archetype_name}}">[✓]</a>{{/archetype_id}}
                         </td>
                         <td class="n">
                             {{similarity}}
@@ -31,7 +31,7 @@
                         <td><a href="{{rule_archetype_url}}" title="{{rule_archetype_description}}">{{rule_archetype_name}}</a></td>
                         <td>
                             <input type="hidden" name="deck_id" value="{{id}}">
-                            {{> archetypedropdown}}
+                            {{> archetypepicker}}
                         </td>
                     </tr>
                 {{/queue}}
@@ -45,11 +45,11 @@
     <form method="post">
         <div>
             <label>Move</label>
-            {{> archetypedropdown}}
+            {{> archetypepicker}}
         </div>
         <div>
             <label>New Parent</label>
-            {{> archetypedropdown}}
+            {{> archetypepicker}}
         </div>
         <button type="submit">Move</button>
     </form>
@@ -59,7 +59,7 @@
     <form method="post">
         <div>
             <label for="archetype_id">Rename</label>
-            {{> archetypedropdown}}
+            {{> archetypepicker}}
         </div>
         <div>
             <label for="rename_to">To</label>
@@ -73,7 +73,7 @@
     <form method="post">
         <div>
             <label>Update</label>
-            {{> archetypedropdown}}
+            {{> archetypepicker}}
         </div>
         <div>
             <label>New description</label>
@@ -136,13 +136,9 @@
     <form method="post" action="#add-archetype">
         <input type="hidden" name="create_archetype" value="1">
         <div>
-            <label for="parent">Parent</label>
-            <select name="parent" id="parent" required>
-                <option value="">[Select]</option>
-                {{#add_archetypes}}
-                    <option value="{{id}}"{{#selected}} selected{{/selected}}>{{name}}</option>
-                {{/add_archetypes}}
-            </select>
+            <label for="parent_name">Parent</label>
+            <input id="parent_name" class="archetype-option" data-option-type="archetypes" type="text" autocomplete="off" placeholder="Search archetypes" value="{{add_parent_name}}" required>
+            <input id="parent" name="parent" type="hidden" value="{{add_parent_id}}">
         </div>
         <div>
             <label for="name">Name</label>

--- a/decksite/templates/editarchetypes.mustache
+++ b/decksite/templates/editarchetypes.mustache
@@ -29,7 +29,7 @@
                             {{/show_add_rule_prompt}}
                         </td>
                         <td><a href="{{rule_archetype_url}}" title="{{rule_archetype_description}}">{{rule_archetype_name}}</a></td>
-                        <td>
+                        <td class="archetype-picker-cell">
                             <input type="hidden" name="deck_id" value="{{id}}">
                             {{> archetypepicker}}
                         </td>

--- a/decksite/views/archetype_search.py
+++ b/decksite/views/archetype_search.py
@@ -1,16 +1,11 @@
 from decksite import prepare
-from decksite.data import archetype
-from decksite.data.archetype import Archetype
 from decksite.view import View
 from magic.models import Deck
 
 
 class ArchetypeSearch(View):
-    def __init__(self, archetypes: list[Archetype], search_results: list[Deck], q: str, notq: str) -> None:
+    def __init__(self, search_results: list[Deck], q: str, notq: str) -> None:
         super().__init__()
-        self.archetypes = archetypes
-        self.archetypes_preordered = archetype.preorder(archetypes)
-
         self.has_search_results = len(search_results) > 0
         self.search_results = search_results
         for d in self.search_results:

--- a/decksite/views/edit_archetypes.py
+++ b/decksite/views/edit_archetypes.py
@@ -22,15 +22,13 @@ class EditArchetypes(View):
             prepare.prepare_deck(d)
             d.archetype_url = url_for('.archetype', archetype_id=d.archetype_name)
             d.archetype_description = archetype_descriptions.get(d.get('archetype_id'), '')
+            d.selected_archetype_id = ''
+            d.selected_archetype_name = ''
             if d.get('rule_archetype_id'):
                 d.rule_archetype_url = url_for('.archetype', archetype_id=d.rule_archetype_name)
                 d.rule_archetype_description = archetype_descriptions.get(d.rule_archetype_id, '')
-                d.archetypes = []
-                for a in self.archetypes:
-                    if a.id == d.rule_archetype_id:
-                        d.archetypes.append({'id': a.id, 'name': a.name, 'selected': True})
-                    else:
-                        d.archetypes.append(a)
+                d.selected_archetype_id = d.rule_archetype_id
+                d.selected_archetype_name = d.rule_archetype_name
             if d.get('rule_archetype_id') == 0:
                 d.rule_archetype_url = url_for('edit_rules')
             d.show_add_rule_prompt = d.similarity == '100%' and not d.get('rule_archetype_name')
@@ -44,7 +42,9 @@ class EditArchetypes(View):
         self.add_errors = add_errors or []
         self.has_add_errors = bool(self.add_errors)
         values = add_values or {}
-        self.add_archetypes = [{'id': a.id, 'name': a.name, 'selected': str(a.id) == values.get('parent')} for a in archetypes]
+        selected_parent = next((a for a in archetypes if str(a.id) == values.get('parent')), None)
+        self.add_parent_id = selected_parent.id if selected_parent else ''
+        self.add_parent_name = selected_parent.name if selected_parent else ''
         self.add_name = values.get('name', '')
         self.add_description = values.get('description', '')
         self.add_include = values.get('include', '')

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2420,6 +2420,12 @@ Search
 
 }
 
+main form .tt-suggestion {
+    font-size: inherit;
+    line-height: 1.333;
+    padding: 0.1em 0.4rem;
+}
+
 .tt-highlight {
     background-color: var(--highlight);
 }

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2148,6 +2148,12 @@ main form .twitter-typeahead input {
     width: 100%;
 }
 
+/* Value pickers should look like ordinary form inputs, not header search. */
+main form .tt-input {
+    background-color: var(--light-gray) !important;
+    box-shadow: none;
+}
+
 main form .tt-hint, main form .tt-menu {
     left: 0 !important;
     right: auto !important;
@@ -2193,6 +2199,16 @@ form.inline, .inline input, .inline select, .inline textarea, .inline label, .in
     float: none;
     margin: 0;
     max-width: 100%;
+}
+
+main form.inline .twitter-typeahead {
+    margin: 0;
+    max-width: 100%;
+    width: 100%;
+}
+
+main td.archetype-picker-cell {
+    overflow: visible;
 }
 
 .inline input, .inline select, .inline textarea, .inline label, .inline button {

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2201,7 +2201,7 @@ form.inline, .inline input, .inline select, .inline textarea, .inline label, .in
     max-width: 100%;
 }
 
-main form.inline .twitter-typeahead {
+main td.archetype-picker-cell .twitter-typeahead {
     margin: 0;
     max-width: 100%;
     width: 100%;

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -15,6 +15,7 @@ PD.init = function() {
     PD.initTypeahead();
     PD.initMatchupCalculator();
     PD.initPersonPickers();
+    PD.initArchetypePickers();
     PD.initSearchShortcut();
     PD.initUseGuess();
     PD.initReassign();
@@ -268,6 +269,31 @@ PD.initRemoteTypeahead = function(input, config) {
     }
 };
 
+PD.initValueTypeahead = function(input, config) {
+    var valueInput = input.siblings("input[type=hidden]");
+    PD.initRemoteTypeahead(input, {
+        "display": config.display,
+        "hint": config.hint,
+        "url": config.url,
+        "onInput": function() {
+            valueInput.val("");
+            input[0].setCustomValidity("");
+        },
+        "selectEvents": "typeahead:autocomplete typeahead:select",
+        "onSelect": function(_event, suggestion) {
+            valueInput.val(suggestion.value);
+            input[0].setCustomValidity("");
+        }
+    });
+    input.closest("form").on("submit", function(event) {
+        if (input.val() && !valueInput.val()) {
+            input[0].setCustomValidity(config.selectionError);
+            input[0].reportValidity();
+            event.preventDefault();
+        }
+    });
+};
+
 PD.initTypeahead = function() {
     $(".typeahead").each(function() {
         PD.initRemoteTypeahead($(this), {
@@ -300,28 +326,22 @@ PD.initMatchupCalculator = function() {
 
 PD.initPersonPickers = function() {
     $(".person-option").each(function() {
-        var input = $(this),
-            valueInput = input.siblings("input[type=hidden]");
-        PD.initRemoteTypeahead(input, {
+        var input = $(this);
+        PD.initValueTypeahead(input, {
             "display": "label",
             "hint": false,
             "url": "/api/matchup-options/people/?personFilter=" + encodeURIComponent(input.data("person-filter")) + "&q={q}",
-            "onInput": function() {
-                valueInput.val("");
-                input[0].setCustomValidity("");
-            },
-            "selectEvents": "typeahead:autocomplete typeahead:select",
-            "onSelect": function(_event, suggestion) {
-                valueInput.val(suggestion.value);
-                input[0].setCustomValidity("");
-            }
+            "selectionError": "Select a person from the suggestions."
         });
-        input.closest("form").on("submit", function(event) {
-            if (!valueInput.val()) {
-                input[0].setCustomValidity("Select a person from the suggestions.");
-                input[0].reportValidity();
-                event.preventDefault();
-            }
+    });
+};
+
+PD.initArchetypePickers = function() {
+    $(".archetype-option").each(function() {
+        PD.initValueTypeahead($(this), {
+            "display": "name",
+            "url": "/api/matchup-options/archetypes/?q={q}",
+            "selectionError": "Select an archetype from the suggestions."
         });
     });
 };
@@ -338,7 +358,10 @@ PD.initSearchShortcut = function() {
 
 PD.initUseGuess = function() {
     $(".use-guess").click(function() {
-        $(this).closest("tr").find("select[name$='archetype_id']").val($(this).data("archetype_id"));
+        var row = $(this).closest("tr"),
+            input = row.find(".archetype-option.tt-input");
+        input.typeahead("val", $(this).data("archetype_name"));
+        row.find("input[type=hidden][name$='archetype_id']").val($(this).data("archetype_id"));
         return false;
     });
 };

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -340,6 +340,7 @@ PD.initArchetypePickers = function() {
     $(".archetype-option").each(function() {
         PD.initValueTypeahead($(this), {
             "display": "name",
+            "hint": false,
             "url": "/api/matchup-options/archetypes/?q={q}",
             "selectionError": "Select an archetype from the suggestions."
         });


### PR DESCRIPTION
## Summary

- Replace every archetype dropdown on Edit Archetypes with the shared remote Typeahead UI.
- Reuse `/api/matchup-options/archetypes/`; no endpoint or POST contract changes.
- Preserve queue rule guesses, the `[✓]` use-guess shortcut, one-to-many and per-deck assignments, Move, Rename, Update Description, Add Parent, and card-search reassignment.
- Share hidden-value selection and free-text validation behavior between person and archetype pickers.
- Avoid loading the full archetype list again when rendering card-search results.

## Performance

Against the cloud development snapshot, `/admin/archetypes/` changed from 10,674 `<option>` elements, 18 `<select>` elements, and 1,072,561 bytes of HTML to zero options/selects and 261,289 bytes of HTML: a 76% reduction. Search responses remain capped at ten results through the existing endpoint.

## Verification

- `npm run build`
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy decksite/controllers/admin_test.py decksite/controllers/admin.py decksite/views/edit_archetypes.py decksite/views/archetype_search.py`
- `uv run --frozen python dev.py jslint`
- 45 focused Python tests passed.
- One broader API test could not set up because the cloud database user cannot create `decksite_test_seeded`; this is the existing cloud snapshot limitation.
- Real Chrome verified all 18 pickers, queue deck/archetype pairing, remote selection, rule-guess defaults, `[✓]` use guess, invalid free-text prevention, parent selection, person-picker regression coverage, desktop layout, and no console errors.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b17272a5-139b-4e61-8801-740724382c96)
