### PR TITLE
Add loading skeletons to live tables

### DIFF
--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -93,10 +93,12 @@ def wait_for_live_tables(page: 'Page') -> list[str]:
             root = page.locator(f'div.{css_class}').nth(i)
             rows = root.locator('.metagame-grid > *' if css_class == 'metagamegrid' else 'table tbody tr')
             try:
+                if css_class != 'metagamegrid':
+                    expect(root.locator('.table-skeleton')).to_have_count(0, timeout=LOAD_TIMEOUT)
                 expect(rows.first).to_be_attached(timeout=LOAD_TIMEOUT)
             except AssertionError:
                 error = root.locator('.message.error')
-                detail = error.first.text_content() if error.count() else ('still loading' if root.locator('.loading').count() else 'no rows')
+                detail = error.first.text_content() if error.count() else ('still loading' if root.locator('.loading, .table-skeleton').count() else 'no rows')
                 problems.append(f'{page.url}: {css_class} #{i} is empty ({detail})')
     return problems
 
@@ -155,6 +157,39 @@ def test_table_without_optional_class_name_omits_it(browser: 'Browser', site: Co
     expect(table_container).to_have_attribute('class', 'live')
     expect(table_container.locator('table')).to_have_attribute('class', 'live')
     expect(page.locator('.cardtable .undefined')).to_have_count(0)
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
+def test_live_table_reserves_space_with_skeleton_while_loading(browser: 'Browser', site: Container, monkeypatch: pytest.MonkeyPatch) -> None:
+    if BASE_URL:
+        pytest.skip('Cannot delay the API on a remote canary.')
+    from decksite.controllers import api
+
+    load_decks_with_total = api.deck.load_decks_with_total
+    release_request = threading.Event()
+
+    def delayed_load(*args: Any, **kwargs: Any) -> Any:
+        release_request.wait(timeout=LOAD_TIMEOUT / 1000)
+        return load_decks_with_total(*args, **kwargs)
+
+    monkeypatch.setattr(api.deck, 'load_decks_with_total', delayed_load)
+    page, collector = new_page(browser, site)
+    try:
+        page.goto('/decks/', wait_until='domcontentloaded')
+        skeleton = page.locator('.decktable .table-skeleton')
+        expect(skeleton).to_be_visible()
+        expect(skeleton).to_have_attribute('aria-busy', 'true')
+        expect(skeleton.locator('table')).to_have_attribute('aria-hidden', 'true')
+        expect(skeleton.locator('.table-loading')).to_have_text('Loading…')
+        expect(skeleton.locator('.skeleton-row')).to_have_count(20)
+        assert skeleton.locator('.skeleton-row').first.locator('td').count() == skeleton.locator('thead th').count()
+        box = skeleton.bounding_box()
+        assert box is not None
+        assert box['height'] > 500
+    finally:
+        release_request.set()
+    expect(page.locator('.decktable .table-skeleton')).to_have_count(0, timeout=LOAD_TIMEOUT)
+    expect(page.locator('.decktable div.live tbody tr').first).to_be_visible()
     assert not collector.problems, '\n'.join(collector.problems)
 
 

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -1290,6 +1290,81 @@ div.live {
     width: 10em;
 }
 
+.table-skeleton .table-header {
+    align-items: center;
+    min-height: 1.1rem;
+}
+
+.table-skeleton thead {
+    pointer-events: none;
+}
+
+.table-skeleton th {
+    cursor: default;
+}
+
+.table-loading {
+    line-height: 1.1rem;
+}
+
+.skeleton-cell {
+    animation: skeleton-pulse 1.2s ease-in-out infinite;
+    background-color: var(--light-gray);
+    border-radius: var(--button-rounded-corners);
+    display: block;
+    height: 0.6em;
+    margin: 0.2em 0;
+    width: 85%;
+}
+
+.skeleton-row {
+    height: 1.3rem;
+}
+
+.table-skeleton-season-icons .skeleton-row {
+    height: 1.35rem;
+}
+
+.skeleton-row:nth-child(3n+2) .skeleton-cell {
+    width: 65%;
+}
+
+.skeleton-row:nth-child(3n) .skeleton-cell {
+    width: 75%;
+}
+
+.skeleton-row td.c .skeleton-cell {
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.skeleton-row td.n .skeleton-cell {
+    margin-left: auto;
+}
+
+.skeleton-row td.marginalia .skeleton-cell {
+    visibility: hidden;
+}
+
+.skeleton-pagination {
+    min-height: 2.2rem;
+}
+
+@keyframes skeleton-pulse {
+    0%, 100% {
+        opacity: 0.45;
+    }
+    50% {
+        opacity: 0.8;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .skeleton-cell {
+        animation: none;
+    }
+}
+
 /* Highlight table rows on hover. */
 
 tr.clickable:hover td:not(.marginalia) {

--- a/shared_web/static/js/table.jsx
+++ b/shared_web/static/js/table.jsx
@@ -16,50 +16,54 @@ For properties see concrete uses in decktable, cardtable, etc.
 export class Table extends DataManager {
     render() {
         const { loading, objects, pageSizeChanged, queryChanged } = super.preRender();
-        if (loading) {
-            return <div className="loading"><span className="spinner"></span> <span className="text">Loading…</span></div>;
-        }
-
-        const rows = objects.map((o) => this.props.renderRow(this, o));
         const className = ("live " + (this.props.className ?? "")).trim();
+        const skeletonClassName = loading ? ` table-skeleton${this.props.showSeasonIcon ? " table-skeleton-season-icons" : ""}` : "";
+        const containerClassName = (className + skeletonClassName).trim();
+        const headerRow = this.props.renderHeaderRow(this);
+        const rows = loading ? this.renderSkeletonRows(headerRow) : objects.map((o) => this.props.renderRow(this, o));
 
         return (
-            <div ref={this.divRef} className={className}>
+            <div ref={this.divRef} aria-busy={loading} className={containerClassName}>
                 <div className="table-header">
-                    <span>
-                        { this.props.showSearch
-                            ? <form className="inline" onSubmit={(e) => { e.preventDefault(); }}>
-                                <input className="name" placeholder={this.props.searchPrompt} type="text" onChange={queryChanged.bind(this)} value={this.state.q}/>
-                            </form>
-                            : null
-                        }
-                    </span>
-                    { this.state.error
-                        ? <span className="message error" title={this.state.error}>{this.state.error}</span>
-                        : null
+                    { loading
+                        ? <span className="table-loading" role="status"><span className="spinner"></span> <span>Loading…</span></span>
+                        : <React.Fragment>
+                            <span>
+                                { this.props.showSearch
+                                    ? <form className="inline" onSubmit={(e) => { e.preventDefault(); }}>
+                                        <input className="name" placeholder={this.props.searchPrompt} type="text" onChange={queryChanged.bind(this)} value={this.state.q}/>
+                                    </form>
+                                    : null
+                                }
+                            </span>
+                            { this.state.error
+                                ? <span className="message error" title={this.state.error}>{this.state.error}</span>
+                                : null
+                            }
+                            { this.state.message
+                                ? <span className="message" title={this.state.message}>{this.state.message}</span>
+                                : null
+                            }
+                            <span>
+                                { this.state.total > 20
+                                    ? <form className="inline" onSubmit={(e) => { e.preventDefault(); }}>
+                                        <select className="page-size" value={this.state.pageSize} onChange={pageSizeChanged.bind(this)}>
+                                            <option value="20">20</option>
+                                            <option value="100">100</option>
+                                        </select>
+                                    </form>
+                                    : null
+                                }
+                            </span>
+                        </React.Fragment>
                     }
-                    { this.state.message
-                        ? <span className="message" title={this.state.message}>{this.state.message}</span>
-                        : null
-                    }
-                    <span>
-                        { this.state.total > 20
-                            ? <form className="inline" onSubmit={(e) => { e.preventDefault(); }}>
-                                <select className="page-size" value={this.state.pageSize} onChange={pageSizeChanged.bind(this)}>
-                                    <option value="20">20</option>
-                                    <option value="100">100</option>
-                                </select>
-                            </form>
-                            : null
-                        }
-                    </span>
                 </div>
-                <table className={className}>
+                <table aria-hidden={loading} className={className}>
                     <thead>
-                        {this.props.renderHeaderRow(this)}
+                        {headerRow}
                     </thead>
                     <tbody>
-                        { this.props.activeRunsText && this.state.page === 0
+                        { !loading && this.props.activeRunsText && this.state.page === 0
                             ? <tr>
                                 <td className="marginalia"><span className="active" title="Active in the current league">⊕</span></td>
                                 <td></td>
@@ -70,9 +74,26 @@ export class Table extends DataManager {
                         {rows}
                     </tbody>
                 </table>
-                {this.renderPagination()}
+                { loading
+                    ? <div aria-hidden="true" className="pagination skeleton-pagination"></div>
+                    : this.renderPagination()
+                }
             </div>
         );
+    }
+
+    renderSkeletonRows(headerRow) {
+        const cells = React.Children.toArray(headerRow.props.children);
+        const rowCount = this.state.pageSize + (this.props.activeRunsText ? 1 : 0);
+        return Array.from({ length: rowCount }, (_value, rowIndex) => (
+            <tr className="skeleton-row" key={rowIndex}>
+                {cells.map((cell, cellIndex) => (
+                    <td className={cell.props.className} key={cellIndex}>
+                        <span className="skeleton-cell"></span>
+                    </td>
+                ))}
+            </tr>
+        ));
     }
 
     renderPagination() {


### PR DESCRIPTION
## Summary

- render each live table's real headers and a page-sized skeleton during its initial API request
- reserve row and pagination space using the table's configured page size, conditional columns, and season-icon layout
- keep the loading state accessible and disable its animation for reduced-motion users
- make the browser-test helper wait for real rows instead of accepting skeleton rows, with a regression test that delays the decks API

## Verification

- `npm run build`
- `uv run --frozen python dev.py jslint`
- `uv run --frozen python dev.py lint`
- `uv run --frozen mypy decksite/browser_test.py`
- `git diff --check`
- manually delayed API responses in Chrome for `/decks/`, `/people/carmandor/`, and `/matchups/` at desktop and mobile widths
- verified the 20-row `/decks/` skeleton is within 0.5 px of the loaded table height and does not cause document-level horizontal overflow on mobile

The focused Playwright regression test cannot complete in this cloud workspace because the local MariaDB user cannot create the test database (`decksite_test_seeded`). Its setup reaches that existing infrastructure restriction before the test runs.

Closes #15266.
