### PR TITLE
Fix display time rounding across unit boundaries

### DIFF
--- a/shared/dtutil.py
+++ b/shared/dtutil.py
@@ -135,7 +135,14 @@ def round_up_preceding_unit(result: ResultsType) -> ResultsType:
     for i in range(1, len(result) + 1):
         prev_value, prev_unit = result[-i]
         result[-i] = (prev_value + 1, prev_unit)
-        if result[-i][0] < intervals[prev_unit][1]:
+        max_units = intervals[prev_unit][0]
+        if max_units is None or result[-i][0] < max_units:
             break
         result[-i] = (0, result[-i][1])
+    else:
+        # All entries overflowed, so prepend the next-largest unit if one exists.
+        units = list(intervals)
+        first_unit_index = units.index(result[0][1])
+        if first_unit_index > 0:
+            result.insert(0, (1, units[first_unit_index - 1]))
     return result

--- a/shared/dtutil_test.py
+++ b/shared/dtutil_test.py
@@ -93,6 +93,12 @@ def test_round_up_preceding_unit() -> None:
     results = [(1, 'hours'), (59, 'minutes'), (59, 'seconds')]
     dtutil.round_up_preceding_unit(results)
     assert results == [(2, 'hours'), (0, 'minutes'), (0, 'seconds')]
+    results = [(23, 'hours'), (59, 'minutes'), (59, 'seconds')]
+    dtutil.round_up_preceding_unit(results)
+    assert results == [(1, 'days'), (0, 'hours'), (0, 'minutes'), (0, 'seconds')]
+
+def test_display_time_boundary() -> None:
+    assert dtutil.display_time(60 * 60 - 1, granularity=1) == '1 hour'
 
 def test_display_time() -> None:
     assert dtutil.display_time(60 * 60 * 2 - 1 * 60) == '1 hour, 59 minutes'


### PR DESCRIPTION
Fixes #7206.

Use the maximum count for each time unit when carrying rounded values, and prepend the next-largest unit when every displayed unit overflows.

Adds regression coverage for 59:59 rounding to one hour and 23:59:59 carrying to one day.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7f50bb2d-5af9-4729-a8fb-f52f825be38a)
