### PR TITLE
Normalize bug report Discord mentions

### DIFF
--- a/discordbot/commands/bug.py
+++ b/discordbot/commands/bug.py
@@ -1,8 +1,34 @@
-from interactions import Client, Extension
+import re
+
+from interactions import Client, Extension, Guild
 from interactions.models import OptionType, slash_command, slash_option
 
 from discordbot.command import MtgContext
 from shared import repo
+
+
+def normalize_mentions(text: str, guild: Guild | None) -> str:
+    if guild is None:
+        return text
+
+    def replace_mention(match: re.Match[str]) -> str:
+        mention_type, snowflake = match.groups()
+        discord_id = int(snowflake)
+        if mention_type == '#':
+            channel = guild.get_channel(discord_id)
+            name = getattr(channel, 'name', None)
+            prefix = '#'
+        elif mention_type == '@&':
+            role = guild.get_role(discord_id)
+            name = role.name if role else None
+            prefix = '@'
+        else:
+            member = guild.get_member(discord_id)
+            name = member.display_name if member else None
+            prefix = '@'
+        return f'{prefix}{name}' if name else match.group(0)
+
+    return re.sub(r'<(@!?|@&|#)(\d+)>', replace_mention, text)
 
 
 class Bug(Extension):
@@ -14,6 +40,7 @@ class Bug(Extension):
         text = title
         if body:
             text += f'\n\n{body}'
+        text = normalize_mentions(text, ctx.guild)
         issue = repo.create_issue(text, str(ctx.author))
         if issue is None:
             msg = f'{ctx.author.mention}: Unable to create an issue. Please report at <https://github.com/PennyDreadfulMTG/Penny-Dreadful-Tools/issues/new>'
@@ -29,6 +56,7 @@ class Bug(Extension):
         text = title
         if body:
             text += f'\n\n{body}'
+        text = normalize_mentions(text, ctx.guild)
         issue = repo.create_issue(text, str(ctx.author), 'Discord', 'PennyDreadfulMTG/gatherling')
         if issue is None:
             await ctx.send('Report Gatherling issues at <https://github.com/PennyDreadfulMTG/gatherling/issues/new>')

--- a/discordbot/commands/bug_test.py
+++ b/discordbot/commands/bug_test.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from discordbot.commands import bug
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('callback', 'repository_args'),
+    [
+        (bug.Bug.bug.callback, ()),
+        (bug.Bug.gatherlingbug.callback, ('Discord', 'PennyDreadfulMTG/gatherling')),
+    ],
+)
+async def test_bug_commands_replace_discord_mentions_with_names(
+    monkeypatch: pytest.MonkeyPatch,
+    callback: object,
+    repository_args: tuple[str, ...],
+) -> None:
+    guild = SimpleNamespace(
+        get_channel=Mock(side_effect=lambda channel_id: SimpleNamespace(name='bot-dev') if channel_id == 123 else None),
+        get_member=Mock(side_effect=lambda member_id: SimpleNamespace(display_name='Silas') if member_id == 456 else None),
+        get_role=Mock(side_effect=lambda role_id: SimpleNamespace(name='Developers') if role_id == 789 else None),
+    )
+    author = Mock(mention='<@456>')
+    ctx = SimpleNamespace(guild=guild, author=author, send=AsyncMock())
+    issue = SimpleNamespace(html_url='https://example.com/issues/1')
+    create_issue = Mock(return_value=issue)
+    monkeypatch.setattr(bug.repo, 'create_issue', create_issue)
+
+    await callback(  # type: ignore[operator]
+        SimpleNamespace(),
+        ctx,
+        'Failure in <#123> reported by <@456>',
+        'Nickname <@!456>, role <@&789>, unknown <@999>.',
+    )
+
+    create_issue.assert_called_once_with(
+        'Failure in #bot-dev reported by @Silas\n\nNickname @Silas, role @Developers, unknown <@999>.',
+        str(author),
+        *repository_args,
+    )
+    ctx.send.assert_awaited_once_with('Issue has been reported at <https://example.com/issues/1>')


### PR DESCRIPTION
## Summary
- resolve Discord channel mentions to `#channel` names before creating bug reports
- resolve user and role mentions to readable `@name` values
- preserve unknown mentions unchanged
- apply normalization to both `/bug` and `/gbug`

Closes #5503

## Testing
- `uv run pytest discordbot -q` (87 passed, 1 skipped)
- connected the cloud test bot to the test guild and verified a live `<@...>` argument was logged as `@bakert`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/93ae7269-92e8-4348-ab5e-eea0e3ce02ab)
