### PR TITLE
Fix typeahead menus in scrolling tables

### DIFF
--- a/.agents/skills/seeit/SKILL.md
+++ b/.agents/skills/seeit/SKILL.md
@@ -52,17 +52,20 @@ When it returns a port, use `RunLocalCommand` again to request
 `http://127.0.0.1:<local-port>/<path>`. Return that exact URL only after the Mac
 request succeeds.
 
-No row means forwarding is not enabled; it does not mean `RunLocalCommand` is
-unavailable. Confirm the state with this read-only query:
+No row can mean Conductor has detected the port but has not created its automatic
+forward yet. It does not mean `RunLocalCommand` is unavailable. Confirm the state
+with this read-only query:
 
 ```bash
 sqlite3 -readonly -header -column "$HOME/Library/Application Support/com.conductor.app/conductor.db" "SELECT auto_forward_enabled, port_forwarding_enabled FROM workspaces WHERE id = '<workspace-id>';"
 ```
 
-If `port_forwarding_enabled` is `0`, ask the user to enable detected port 5000
-in the workspace's Ports popover, then repeat the lookup and Mac HTTP check. If
-the Ports control is unavailable, follow the supervised SSH fallback in
+When automatic forwarding is enabled, poll the mapping query for up to 30 seconds
+before concluding that no native mapping is available. If no usable mapping
+appears, use RunLocalCommand to create the supervised SSH fallback in
 `.conductor/README.md`, record its URL in `.context/pd-preview.json`, and verify
-recovery as described there.
+initial connectivity and recovery as described there. Do this automatically; do
+not ask the user to enable a port. Ask the user only if RunLocalCommand is
+unavailable and there is no working native mapping or existing supervised tunnel.
 
 Never present the cloud VM's `127.0.0.1:5000` as the user's forwarded URL.

--- a/.conductor/README.md
+++ b/.conductor/README.md
@@ -16,10 +16,11 @@ restores a prepared database, and builds JavaScript. Use the **decksite_cloud** 
 script to start the app on port 5000 with Python auto-reload and no interactive
 debugger. After changing JavaScript, run `npm run build` (or `npm run watch`).
 
-**Enable port forwarding in the workspace's Ports panel.** Merely detecting port
-5000 in the VM does not enable forwarding on the Mac. Open the forwarded entry for
-5000; its Mac port can differ from 5000 and can change when reconnecting. A cloud
-`http://127.0.0.1:5000` health check verifies the VM only, not the Mac tunnel.
+Merely detecting port 5000 in the VM does not prove forwarding on the Mac.
+Conductor's automatic forwarding can appear shortly after detection, and its Mac
+port can differ from 5000 or change when reconnecting. Agents should poll briefly
+for that mapping and verify it from the Mac. A cloud `http://127.0.0.1:5000`
+health check verifies the VM only, not the Mac tunnel.
 
 An agent with RunLocalCommand can identify the actual mapping with this read-only
 query on the Mac (substitute the current `CONDUCTOR_WORKSPACE_ID`):
@@ -33,8 +34,11 @@ Then verify `http://127.0.0.1:<local_port>/` from the Mac before sharing that li
 This database is an implementation detail; if its schema changes, use the Ports UI.
 Leave the development server running after verification.
 
-If the Ports toggle is unavailable, use `.conductor/preview-tunnel.py` on the Mac
-to forward port 5000 through Conductor's existing SSH mapping for remote port 22.
+If no usable automatic mapping appears, use `.conductor/preview-tunnel.py` on the
+Mac to forward port 5000 through Conductor's existing SSH mapping for remote port
+22. Agents with RunLocalCommand should do this automatically instead of asking the
+user to change the Ports panel. Ask only when Mac access is unavailable and there
+is no working mapping or existing tunnel.
 A plain `ssh -f -N` tunnel is insufficient: VM restart/resume kills the database,
 web server, and SSH connection. The supervisor reconnects, and its restricted SSH
 command runs `.conductor/preview-ssh.sh` to restart MariaDB and decksite as needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@ Do not use the "merge when ready" label. It is a leftover from an old CI setup a
   port 5000. Port detection is separate from enabling forwarding in Conductor's
   Ports panel. Verify from the Mac with RunLocalCommand when available.
   Check `.context/pd-preview.json` for an existing temporary SSH preview tunnel.
+- Do not ask the user to enable cloud preview forwarding. Conductor's automatic
+  forwarding can appear shortly after port detection, so poll for the Mac mapping.
+  If no usable mapping appears and RunLocalCommand is available, create the
+  supervised SSH fallback described in `.conductor/README.md`. Ask the user only
+  when neither Mac access nor an existing preview tunnel is available.
 - Cloud VM restart/resume stops background services. An SSH fallback must use
   `.conductor/preview-tunnel.py` on the Mac and the restricted
   `.conductor/preview-ssh.sh` server entry point so it reconnects and restarts

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -174,6 +174,41 @@ def test_header_search_ranks_aliases_and_navigates_live_results(browser: 'Browse
     assert not collector.problems, '\n'.join(collector.problems)
 
 
+def test_table_typeahead_suggestions_escape_scroll_container(browser: 'Browser', site: Container) -> None:
+    if BASE_URL:
+        pytest.skip('Cannot create a demimod session on a remote canary.')
+    from decksite.main import APP
+
+    serializer = APP.session_interface.get_signing_serializer(APP)
+    assert serializer is not None
+    page, collector = new_page(browser, site, viewport=(800, 800))
+    page.context.add_cookies([{
+        'name': APP.config.get('SESSION_COOKIE_NAME', 'session'),
+        'value': serializer.dumps({'demimod': True}),
+        'url': site.base_url,
+    }])
+    page.goto('/admin/archetypes/')
+    table = page.locator('main table').first
+    table.evaluate('(element) => { element.scrollLeft = element.scrollWidth; }')
+    picker = table.locator('input.tt-input').first
+    expect(picker).to_be_visible()
+    picker.fill('rakdos')
+    menu = picker.locator('xpath=following-sibling::*[contains(@class, "tt-menu")]')
+    suggestion = menu.locator('.tt-suggestion').first
+    expect(suggestion).to_be_visible()
+
+    picker_box = picker.bounding_box()
+    menu_box = menu.bounding_box()
+    assert picker_box is not None and menu_box is not None
+    assert min(abs(menu_box['y'] - (picker_box['y'] + picker_box['height'])), abs(menu_box['y'] + menu_box['height'] - picker_box['y'])) < 1
+    assert 0 <= menu_box['x'] <= picker_box['x']
+    assert menu_box['x'] + menu_box['width'] >= picker_box['x'] + picker_box['width']
+    assert menu_box['x'] + menu_box['width'] <= 800
+    assert table.evaluate('(element) => element.scrollHeight === element.clientHeight')
+    assert suggestion.evaluate('(element) => element.contains(document.elementFromPoint(element.getBoundingClientRect().left + 2, element.getBoundingClientRect().top + 2))')
+    assert not collector.problems, '\n'.join(collector.problems)
+
+
 def test_live_table_reserves_space_with_skeleton_while_loading(browser: 'Browser', site: Container, monkeypatch: pytest.MonkeyPatch) -> None:
     if BASE_URL:
         pytest.skip('Cannot delay the API on a remote canary.')

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -193,6 +193,7 @@ def test_table_typeahead_suggestions_escape_scroll_container(browser: 'Browser',
     table = page.locator('main table').first
     table.evaluate('(element) => { element.scrollLeft = element.scrollWidth; }')
     picker = table.locator('input.tt-input').first
+    picker.scroll_into_view_if_needed()
     expect(picker).to_be_visible()
     picker.fill('rakdos')
     menu = picker.locator('xpath=following-sibling::*[contains(@class, "tt-menu")]')

--- a/decksite/browser_test.py
+++ b/decksite/browser_test.py
@@ -174,11 +174,13 @@ def test_header_search_ranks_aliases_and_navigates_live_results(browser: 'Browse
     assert not collector.problems, '\n'.join(collector.problems)
 
 
-def test_table_typeahead_suggestions_escape_scroll_container(browser: 'Browser', site: Container) -> None:
+def test_table_typeahead_suggestions_escape_scroll_container(browser: 'Browser', site: Container, monkeypatch: pytest.MonkeyPatch) -> None:
     if BASE_URL:
         pytest.skip('Cannot create a demimod session on a remote canary.')
     from decksite.main import APP
 
+    # CI deliberately has no OAuth secret, which production normally reuses as Flask's session signing key.
+    monkeypatch.setitem(APP.config, 'SECRET_KEY', 'browser-test-secret')
     serializer = APP.session_interface.get_signing_serializer(APP)
     assert serializer is not None
     page, collector = new_page(browser, site, viewport=(800, 800))

--- a/shared_web/static/css/pd.css
+++ b/shared_web/static/css/pd.css
@@ -2286,6 +2286,17 @@ main td.archetype-picker-cell {
     overflow: visible;
 }
 
+/* Tables scroll horizontally on narrow screens. Keep their typeahead menus out of that scroll container so they are not clipped or given a vertical scrollbar. */
+main table .tt-menu {
+    left: var(--table-typeahead-left) !important; /* csslint allow: important */
+    max-width: 20rem;
+    position: fixed !important; /* csslint allow: important */
+    right: auto !important; /* csslint allow: important */
+    top: var(--table-typeahead-top) !important; /* csslint allow: important */
+    width: min(20rem, max(12rem, var(--table-typeahead-input-width)), calc(100vw - 2rem));
+    z-index: 4;
+}
+
 .inline input, .inline select, .inline textarea, .inline label, .inline button {
     height: 1.1rem; /* Nonstandard height because of the padding the browser adds. */
     font-size: var(--table-font-size);

--- a/shared_web/static/js/pd.js
+++ b/shared_web/static/js/pd.js
@@ -16,6 +16,7 @@ PD.init = function() {
     PD.initMatchupCalculator();
     PD.initPersonPickers();
     PD.initArchetypePickers();
+    PD.initTableTypeaheadMenus();
     PD.initSearchShortcut();
     PD.initUseGuess();
     PD.initReassign();
@@ -346,6 +347,31 @@ PD.initArchetypePickers = function() {
         });
     });
 };
+PD.initTableTypeaheadMenus = function() {
+    var inputs = $("main table input.tt-input");
+    if (!inputs.length) {
+        return;
+    }
+    var positionOpenMenu = function() {
+        var input = $(this),
+            menu = input.siblings(".tt-menu"),
+            bounds = input[0].getBoundingClientRect(),
+            menuBounds = menu[0].getBoundingClientRect(),
+            left = Math.max(0, Math.min(bounds.left, window.innerWidth - menuBounds.width)),
+            top = bounds.bottom + menuBounds.height > window.innerHeight && bounds.top >= menuBounds.height ? bounds.top - menuBounds.height : bounds.bottom;
+        menu[0].style.setProperty("--table-typeahead-left", left + "px");
+        menu[0].style.setProperty("--table-typeahead-top", top + "px");
+        menu[0].style.setProperty("--table-typeahead-input-width", bounds.width + "px");
+    };
+    inputs.each(positionOpenMenu);
+    inputs.on("typeahead:open typeahead:render", positionOpenMenu);
+    inputs.closest("table").on("scroll", function() {
+        $(this).find("input.tt-input").each(positionOpenMenu);
+    });
+    $(window).on("resize scroll", function() {
+        inputs.each(positionOpenMenu);
+    });
+};
 
 PD.initSearchShortcut = function() {
     $(document).keypress(function(e) {
@@ -618,7 +644,6 @@ PD.htmlEscape = function(s) {
 $(document).ready(function() {
     PD.init();
 });
-
 
 // Shift-click checkboxes behavior.
 // Inlining https://raw.githubusercontent.com/rmariuzzo/checkboxes.js/master/src/jquery.checkboxes.js because it's not very big and there's no CDN version.


### PR DESCRIPTION
## Summary
- render table typeahead menus as viewport overlays so horizontal table scrolling does not trap them behind a vertical scrollbar
- keep suggestion menus readable, within the viewport, and above or below the input according to available space
- add browser regression coverage and make cloud preview instructions require automatic forwarding/fallback handling

## Verification
- npm run build
- uv run --frozen python dev.py jslint
- uv run --frozen python dev.py lint
- uv run --frozen mypy decksite/browser_test.py
- uv run --frozen pytest decksite/controllers/admin_test.py
- PD_BROWSER_TESTS=1 PD_BROWSER_CHANNEL=chrome uv run --frozen pytest decksite/browser_test.py -k table_typeahead_suggestions_escape_scroll_container
- live 800px browser verification against the cloud development database

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/44c23806-5426-4cef-adad-f798101a2dc9)
