### PR TITLE
Add backlog sweep orchestration skill

### DIFF
--- a/.agents/skills/backlog-sweep/SKILL.md
+++ b/.agents/skills/backlog-sweep/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: backlog-sweep
+description: Orchestrate the Penny Dreadful GitHub backlog sweep by verifying stale candidates, closing proven completed or obsolete issues, and implementing narrowly scoped fixes. Use when asked to start, resume, or continue backlog cleanup.
+---
+
+# Backlog Sweep
+
+Read [references/state.md](references/state.md) before selecting work. Treat it
+as a dated handoff, not as proof that an issue is currently resolved.
+
+## Work as the master
+
+- Work from `origin/master` and read the repository `AGENTS.md` first.
+- Delegate bounded, independent issue investigations when parallel work is
+  useful. Keep GitHub mutations and final judgments in the master workspace.
+- Use `origin/sweep-state` as an evidence index. Its snapshot, reports, journal,
+  and classifications can be stale and are never sufficient grounds to close
+  an issue.
+- Prefer genuinely low-effort completed, obsolete, or narrowly fixable open
+  issues. Avoid turning the sweep into speculative redesign work.
+
+## Verify before acting
+
+For each candidate, read the original issue and later discussion, trace the
+current end-to-end behavior, inspect relevant code and tests, and check for
+later regressions. For behavior owned by another repository, inspect that
+repository rather than inferring from this one.
+
+Classify the result as one of:
+
+- verified complete;
+- obsolete, with a concrete reason;
+- narrow fix worth implementing now;
+- still open or insufficiently proven.
+
+Do not close an issue because a related component exists, a workaround exists,
+or an old sweep classification says it is complete.
+
+## GitHub access
+
+Before relying on Cloud GitHub writes, verify them with a reversible operation
+that is already part of the selected issue workflow. Do not change live issue
+state solely as an authentication test. Never print credentials.
+
+If Cloud writes return `Resource not accessible by integration`, use
+Conductor's `RunLocalCommand` with the Mac's working `gh` authentication for
+comments, closures, PR creation, and Mergify queueing. Continue read-only
+investigation in Cloud.
+
+For a verified closure, leave a concise evidence-based comment explaining the
+current behavior and why closure is appropriate, then close the issue. For a
+narrow code fix, test it proportionally, open a PR against `master`, and follow
+the repository's merge instructions.
+
+## Maintain the handoff
+
+Before ending a substantial sweep, update `references/state.md` with the date,
+new durable conclusions, merged fixes, unresolved regressions, and promising
+next candidates. Remove conclusions that have become stale or were disproved.

--- a/.agents/skills/backlog-sweep/references/state.md
+++ b/.agents/skills/backlog-sweep/references/state.md
@@ -1,0 +1,52 @@
+# Backlog sweep handoff
+
+Last updated: 2026-09-09.
+
+## Evidence source
+
+`origin/sweep-state` contains a snapshot, reports, a journal, and supporting
+evidence. Its 2026-09-06 snapshot produced false positives. Recheck the
+original request, current behavior, and later regressions before acting on any
+classification.
+
+## Must remain open
+
+- #6976: admin retirement was implemented but regressed in #14052; admins now
+  see only unassociated runs.
+- #7164: the request likely concerns guesses at or above 90% archetype
+  similarity. Existing rule-based preselection is not equivalent.
+- #7524: a permission-change workaround exists, but the requested DB-backed
+  session design and admin UI do not.
+- #11685: correct storage and handling of multiword subtypes such as `Time Lord`
+  has not been proven.
+- #15273: show whether a searched card was actually played in each matchup
+  result.
+
+## Verified outcomes
+
+- #6651 was closed as obsolete rather than literally implemented.
+- #7133, #7496, #7716, #7828, #8056, #8285, #8627, #8727, #11193,
+  #11220, #11223, and #11229 were verified, commented on, and closed.
+- #8727 was verified in `PennyDreadfulMTG/PDBot`; `TestWeirdCards.cs`
+  explicitly tests both Erayo's Essence spellings.
+- #5039, #7738, #11291, #11721, #12244, and #12421 were reviewed but were
+  not safe to close.
+- #11747, #11307, and #12463 may merit fuller investigation.
+
+## Merged fixes
+
+- PR #15275, `Use GeoNames for local time lookups`, was corrected after review
+  and merged.
+- Issue #7206 was fixed by PR #15287, `Fix display time rounding across unit
+  boundaries`, merged on 2026-09-08.
+
+## GitHub authentication
+
+As of 2026-09-09, Conductor Cloud GitHub mutations returned
+`Resource not accessible by integration` for both an approved fine-grained PAT
+and the exact classic `repo`-scoped PAT that succeeded from the Mac. The Cloud
+secret value and token type were verified by hashes without printing them.
+PennyDreadfulMTG is on the Free plan and has no organization IP allow-list
+control. Use `RunLocalCommand` for GitHub mutations unless a fresh Cloud test
+demonstrates that the restriction is gone. Do not repeat token rotations or
+Cloud Computer rebuilds without new evidence.


### PR DESCRIPTION
Adds a repo-local `backlog-sweep` skill so future workspaces can resume the backlog sweep with a short invocation.

The skill preserves the evidence-first workflow, records the current dated handoff separately, and documents the Cloud GitHub write fallback.

Validation: skill-creator quick validator; git diff --check.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/7f50bb2d-5af9-4729-a8fb-f52f825be38a)
