### PR TITLE
Fix Discord card update locking

### DIFF
--- a/shared/decorators.py
+++ b/shared/decorators.py
@@ -112,7 +112,9 @@ class _SystemwideLock:
     def __call__[**P](self, f: Callable[P, None]) -> Callable[P, None]:
         @functools.wraps(f)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> None:
-            lock_db = get_database(configuration.get_str('decksite_database'))
+            # Every process that uses these locks has a cards database, while non-web
+            # processes such as discordbot may not have a valid decksite database.
+            lock_db = get_database(configuration.get_str('magic_database'))
             acquired = False
             try:
                 try:

--- a/shared/decorators_test.py
+++ b/shared/decorators_test.py
@@ -85,13 +85,17 @@ def test_schedule_reprime_cache_detaches_once_per_cooldown(monkeypatch: pytest.M
 
 def test_interprocess_locked_uses_a_nonblocking_systemwide_database_lock(monkeypatch: pytest.MonkeyPatch) -> None:
     lock_db = mock.Mock()
-    monkeypatch.setattr(decorators, 'get_database', mock.Mock(return_value=lock_db))
+    get_database_mock = mock.Mock(return_value=lock_db)
+    monkeypatch.setattr(decorators, 'get_database', get_database_mock)
+    monkeypatch.setitem(configuration.CONFIG, 'magic_database', 'discordbot')
+    monkeypatch.setitem(configuration.CONFIG, 'decksite_database', './decksite.sqlite')
     work = mock.Mock(return_value=None)
     work.__name__ = 'work'
 
     wrapped = decorators.interprocess_locked('.task.lock')(work)
 
     assert wrapped() is None
+    get_database_mock.assert_called_once_with('discordbot')
     work.assert_called_once_with()
     lock_db.get_lock.assert_called_once_with('penny-dreadful-tools:.task.lock', 0)
     lock_db.release_lock.assert_called_once_with('penny-dreadful-tools:.task.lock')
@@ -117,7 +121,7 @@ def test_interprocess_locked_does_not_queue_another_run(monkeypatch: pytest.Monk
 def test_interprocess_locked_contends_across_real_database_connections() -> None:
     path = f'.test-{uuid4()}.lock'
     lock_key = f'penny-dreadful-tools:{path}'
-    holder = get_database(configuration.get_str('decksite_database'))
+    holder = get_database(configuration.get_str('magic_database'))
     calls: list[bool] = []
 
     @decorators.interprocess_locked(path)


### PR DESCRIPTION
## Summary

- acquire system-wide task locks through the configured magic database
- allow Discord card refreshes when the bot has no valid decksite database
- cover the production-style configuration with a regression test

## Testing

- `uv run --frozen pytest shared/decorators_test.py discordbot/background_test.py run_test.py` (23 passed)
- `uv run --frozen python dev.py lint`
- `uv run --frozen python dev.py mypy`
- full test run reached 162 passed before the cloud database user lacked permission to create `decksite_test_seeded`

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/e5d8fa54-ef3a-4c22-a407-4926800ab324)
